### PR TITLE
Update react-native to 0.69.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "expo-status-bar": "~1.4.0",
     "polylabel": "^1.1.0",
     "react": "18.0.0",
-    "react-native": "0.69.6",
+    "react-native": "0.69.7",
     "react-native-gesture-handler": "~2.5.0",
     "react-native-maps": "0.31.1",
     "react-native-render-html": "^6.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6784,10 +6784,10 @@ react-native-svg@12.3.0:
     css-select "^4.2.1"
     css-tree "^1.0.0-alpha.39"
 
-react-native@0.69.6:
-  version "0.69.6"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.69.6.tgz#cdd1a5757d902b91b165c28fdda4e518ed6f683a"
-  integrity sha512-wwXpqM+12kdEYdBZCJUb5SBu95CzgejrwFeYJ78RzHZV/Sj6DBRekbsHGrDDsY4R25QXALQxy4DQYQCObVvWjA==
+react-native@0.69.7:
+  version "0.69.7"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.69.7.tgz#891ba4ed7722f1ab570099ce097c355bef8ceb05"
+  integrity sha512-T3z2utgRcE/+mMML3Wg4vvpnFoGWJcqWskq+8vdFS4ASM1zYg5Hab5vPlKZp9uncD8weYiGsYwkWXzrvZrsayQ==
   dependencies:
     "@jest/create-cache-key-function" "^27.0.1"
     "@react-native-community/cli" "^8.0.4"


### PR DESCRIPTION
Non-interactive builds on main branch were failing with `Task :expo:compileReleaseKotlin FAILED` ([example](https://github.com/stevekuznetsov/avalanche-forecast/actions/runs/3651725362/jobs/6169292326))

According to https://github.com/facebook/react-native/issues/35210, this should be fixed by bouncing the react-native version. 