### PR TITLE
Make useLocation hook, prompt for location permissions

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -16,8 +16,9 @@ import {ClientContext, productionClientProps, stagingClientProps} from './client
 import {AvalancheForecastZoneMap} from './components/AvalancheForecastZoneMap';
 import {AvalancheForecast} from './components/AvalancheForecast';
 import {AvalancheCenterSelector} from './components/AvalancheCenterSelector';
-import {useOnlineManager} from './hooks/useOnlineManager';
 import {useAppState} from './hooks/useAppState';
+import {useLocation} from './hooks/useLocation';
+import {useOnlineManager} from './hooks/useOnlineManager';
 import {TelemetryStationMap} from './components/TelemetryStationMap';
 import {TelemetryStationData} from './components/TelemetryStationData';
 
@@ -209,6 +210,11 @@ const App = () => {
 
     useAppState(onAppStateChange);
 
+    const locationStatus = useLocation(location => {
+      console.log('Location update', location);
+    });
+    console.log('Location permission status', locationStatus);
+
     // Using NAC staging may trigger errors, but we'll try it for now
     const [contextValue, setContextValue] = useState(stagingClientProps);
 
@@ -223,7 +229,7 @@ const App = () => {
         console.log('Switch to production API');
         setContextValue(productionClientProps);
       });
-    });
+    }, []); // this effect should only run once
 
     return (
       <ClientContext.Provider value={contextValue}>

--- a/app.json
+++ b/app.json
@@ -32,7 +32,8 @@
       },
       "config": {
         "googleMaps": {"apiKey": "LOADED_FROM_ENVIRONMENT"}
-      }
+      },
+      "permissions": ["ACCESS_FINE_LOCATION", "ACCESS_COARSE_LOCATION", "FOREGROUND_SERVICE"]
     },
     "hooks": {
       "postPublish": [

--- a/hooks/useLocation.ts
+++ b/hooks/useLocation.ts
@@ -1,0 +1,51 @@
+import {useEffect} from 'react';
+
+import * as Location from 'expo-location';
+
+export type LocationResponse = {
+  status: Location.LocationPermissionResponse;
+  location: Location.LocationObject | null;
+};
+
+export const useLocation = (callback: (location: Location.LocationObject) => void): Location.LocationPermissionResponse | null => {
+  const [status, requestPermission] = Location.useForegroundPermissions();
+
+  useEffect(() => {
+    const granted = status?.granted;
+    const canAskAgain = status?.canAskAgain;
+
+    if (!granted && canAskAgain) {
+      (async () => {
+        await requestPermission();
+      })();
+    }
+
+    let unmounted = false;
+    let subscriptionCancel = null;
+
+    if (granted) {
+      (async () => {
+        const subscription = await Location.watchPositionAsync(
+          {
+            accuracy: Location.Accuracy.High,
+          },
+          (location: Location.LocationObject) => {
+            callback(location);
+          },
+        );
+        if (unmounted) {
+          subscription.remove();
+        } else {
+          subscriptionCancel = subscription.remove;
+        }
+      })();
+    }
+
+    return () => {
+      unmounted = true;
+      subscriptionCancel?.();
+    };
+  }, [status, requestPermission, callback]);
+
+  return status;
+};

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "expo-constants": "~13.2.4",
     "expo-dev-client": "~1.3.1",
     "expo-device": "~4.3.0",
+    "expo-location": "~14.3.0",
     "expo-status-bar": "~1.4.0",
     "expo-updates": "~0.14.7",
     "polylabel": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4618,6 +4618,13 @@ expo-keep-awake@~10.2.0:
   resolved "https://registry.yarnpkg.com/expo-keep-awake/-/expo-keep-awake-10.2.0.tgz#46f04740bccd321732bbbed93491e2076d5dbbd7"
   integrity sha512-kIRtO4Hmrvxh4E45IPWG/NiUZsuRe1AQwBT09pq+kx8nm6tUS4B9TeL6+1NFy+qVBLbGKDqoQD5Ez7XYTFtBeQ==
 
+expo-location@~14.3.0:
+  version "14.3.0"
+  resolved "https://registry.yarnpkg.com/expo-location/-/expo-location-14.3.0.tgz#f613147e36afad974732ddc1b4e142d7e1b8bba2"
+  integrity sha512-CKU6bW1rB6521LruyUsZm6dQXXBix9E64ZZmOpVgom1DQ3Bfd23IBvXXeUQeIhy+NbOzF1itFrPTLzspgl6wPg==
+  dependencies:
+    "@expo/config-plugins" "~5.0.0"
+
 expo-manifests@~0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/expo-manifests/-/expo-manifests-0.3.1.tgz#52c3ef41d3b1958039be0434363e6499c773aaf6"


### PR DESCRIPTION
This was an experiment to see what was involved in getting `expo-location` working.

Not sure all of the requesting permission bits are set up correctly for the real app, but it is working in Expo Go at least:

ios | android
--- | ---
![image](https://user-images.githubusercontent.com/101196/207740817-b9d8d8ef-d4e2-418b-a43a-a1a95a8a7df9.png) | ![Screenshot_20221214-155916_Permission controller](https://user-images.githubusercontent.com/101196/207741385-e2ea425e-62a6-4975-a901-a4ad7a12926d.jpg)
