### PR TITLE
Fix safe area issues

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -44,7 +44,7 @@ const SelectorStack = createNativeStackNavigator<StackParamList>();
 const AvalancheCenterSelectionScreen = () => {
   // TODO(skuznets) not showing the header here means iOS has no way to get back to this screen once they choose a center, but showing it means we double-up on headers ... ?
   return (
-    <SelectorStack.Navigator initialRouteName="avalancheCenterSelection" screenOptions={{headerShown: false}}>
+    <SelectorStack.Navigator initialRouteName="avalancheCenterSelection" screenOptions={{headerStatusBarHeight: 0}}>
       <SelectorStack.Screen name="avalancheCenterSelection" component={AvalancheCenterSelectorScreen} options={{title: 'Select an Avalanche Center'}} />
       <SelectorStack.Screen name="avalancheCenterHome" component={AvalancheCenterTabScreen} options={({route}) => ({title: route.params.center_id})} />
     </SelectorStack.Navigator>


### PR DESCRIPTION
better:
<img width="344" alt="image" src="https://user-images.githubusercontent.com/101196/208169068-0d960374-39e7-4f52-a912-d21cefbcd03f.png">
still might be doubling up on headers but we'll fix that shortly
<img width="319" alt="image" src="https://user-images.githubusercontent.com/101196/208169223-76c65270-0fea-4098-87dc-395240c554a2.png">
