### PR TITLE
Home

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,5 +4,16 @@
   "plugins": ["@typescript-eslint"],
   "root": true,
   "ignorePatterns": ["babel.config.js"],
-  "reportUnusedDisableDirectives": true
+  "reportUnusedDisableDirectives": true,
+  "rules": {
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        // Don't produce unused arg errors if identifier starts with an underscore:
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_",
+        "caughtErrorsIgnorePattern": "^_"
+      }
+    ]
+  }
 }

--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 
-import {AppStateStatus, DevSettings, Platform, StyleSheet, Text} from 'react-native';
+import {AppStateStatus, DevSettings, Platform, StyleSheet, Text, View} from 'react-native';
 import {NavigationContainer} from '@react-navigation/native';
 import {createNativeStackNavigator, NativeStackScreenProps} from '@react-navigation/native-stack';
 import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
@@ -90,9 +90,9 @@ type AvalancheCenterProps = NativeStackScreenProps<HomeStackParamList, 'avalanch
 const MapScreen = ({route}: AvalancheCenterProps) => {
   const {center_id, date} = route.params;
   return (
-    <SafeAreaView style={styles.container}>
+    <View style={{...styles.container}}>
       <AvalancheForecastZoneMap centers={[center_id]} date={date} />
-    </SafeAreaView>
+    </View>
   );
 };
 
@@ -100,9 +100,9 @@ type ForecastScreenProps = NativeStackScreenProps<HomeStackParamList, 'forecast'
 const ForecastScreen = ({route}: ForecastScreenProps) => {
   const {center_id, forecast_zone_id, date} = route.params;
   return (
-    <SafeAreaView style={styles.container}>
+    <View style={styles.container}>
       <AvalancheForecast center_id={center_id} forecast_zone_id={forecast_zone_id} date={date} />
-    </SafeAreaView>
+    </View>
   );
 };
 
@@ -130,9 +130,9 @@ const ForecastScreen = ({route}: ForecastScreenProps) => {
 // const TelemetryScreen = ({route}: AvalancheCenterProps) => {
 //   const {center_id} = route.params;
 //   return (
-//     <SafeAreaView style={styles.container}>
+//     <View style={styles.container}>
 //       <TelemetryStationMap center_id={center_id} />
-//     </SafeAreaView>
+//     </View>
 //   );
 // };
 
@@ -140,9 +140,9 @@ const ForecastScreen = ({route}: ForecastScreenProps) => {
 // const TelemetryStationScreen = ({route}: TelemetryStationProps) => {
 //   const {center_id, source, station_id} = route.params;
 //   return (
-//     <SafeAreaView style={styles.container}>
+//     <View style={styles.container}>
 //       <TelemetryStationData center_id={center_id} source={source} station_id={station_id} />
-//     </SafeAreaView>
+//     </View>
 //   );
 // };
 
@@ -155,9 +155,11 @@ const onAppStateChange = (status: AppStateStatus) => {
 
 function PlaceholderScreen(label: string) {
   return (
-    <SafeAreaView style={styles.container}>
-      <Text>{label}</Text>
-    </SafeAreaView>
+    <View style={{...styles.container, flex: 1, justifyContent: 'space-between', alignItems: 'center'}}>
+      <Text>This is top text.</Text>
+      <Text style={{fontSize: 24, fontWeight: 'bold'}}>View name: {label}</Text>
+      <Text>This is bottom text.</Text>
+    </View>
   );
 }
 
@@ -169,7 +171,7 @@ function HomeScreen({route}) {
         name="avalancheCenter"
         component={MapScreen}
         initialParams={{center_id: center_id, date: defaultDate}}
-        options={({route}) => ({title: route.params.center_id, headerBarStatusHeight: 0})}
+        options={({route}) => ({title: route.params.center_id, headerShown: false})}
       />
       <HomeStack.Screen
         name="forecast"
@@ -218,29 +220,31 @@ const App = () => {
         <QueryClientProvider client={queryClient}>
           <SafeAreaProvider>
             <NavigationContainer>
-              <Tab.Navigator initialRouteName="Home" screenOptions={{headerBarStatusHeight: 0}}>
-                <Tab.Screen name="Home" initialParams={{center_id: defaultCenterId}}>
-                  {args => HomeScreen(args)}
-                </Tab.Screen>
-                <Tab.Screen name="Observations" initialParams={{center_id: defaultCenterId}}>
-                  {() => PlaceholderScreen('Observations')}
-                </Tab.Screen>
-                <Tab.Screen name="WeatherData" initialParams={{center_id: defaultCenterId}}>
-                  {() => PlaceholderScreen('Weather data')}
-                </Tab.Screen>
-                <Tab.Screen name="Menu" initialParams={{center_id: defaultCenterId}}>
-                  {() => PlaceholderScreen('Menu')}
-                </Tab.Screen>
-                {__DEV__ && (
-                  <Tab.Screen name="Debug" initialParams={{center_id: defaultCenterId}}>
-                    {() => (
-                      <SafeAreaView style={styles.container}>
-                        <AvalancheCenterSelector />
-                      </SafeAreaView>
-                    )}
+              <SafeAreaView style={styles.container}>
+                <Tab.Navigator initialRouteName="Home" screenOptions={{headerShown: false}}>
+                  <Tab.Screen name="Home" initialParams={{center_id: defaultCenterId}}>
+                    {args => HomeScreen(args)}
                   </Tab.Screen>
-                )}
-              </Tab.Navigator>
+                  <Tab.Screen name="Observations" initialParams={{center_id: defaultCenterId}}>
+                    {() => PlaceholderScreen('Observations')}
+                  </Tab.Screen>
+                  <Tab.Screen name="WeatherData" initialParams={{center_id: defaultCenterId}}>
+                    {() => PlaceholderScreen('Weather data')}
+                  </Tab.Screen>
+                  <Tab.Screen name="Menu" initialParams={{center_id: defaultCenterId}}>
+                    {() => PlaceholderScreen('Menu')}
+                  </Tab.Screen>
+                  {__DEV__ && (
+                    <Tab.Screen name="Debug" initialParams={{center_id: defaultCenterId}}>
+                      {() => (
+                        <View style={styles.container}>
+                          <AvalancheCenterSelector />
+                        </View>
+                      )}
+                    </Tab.Screen>
+                  )}
+                </Tab.Navigator>
+              </SafeAreaView>
             </NavigationContainer>
           </SafeAreaProvider>
         </QueryClientProvider>

--- a/App.tsx
+++ b/App.tsx
@@ -169,7 +169,7 @@ function HomeScreen({route}) {
         name="avalancheCenter"
         component={MapScreen}
         initialParams={{center_id: center_id, date: defaultDate}}
-        options={({route}) => ({title: route.params.center_id, headerShown: false})}
+        options={({route}) => ({title: route.params.center_id, headerBarStatusHeight: 0})}
       />
       <HomeStack.Screen
         name="forecast"
@@ -218,7 +218,7 @@ const App = () => {
         <QueryClientProvider client={queryClient}>
           <SafeAreaProvider>
             <NavigationContainer>
-              <Tab.Navigator initialRouteName="Home" screenOptions={{headerShown: false}}>
+              <Tab.Navigator initialRouteName="Home" screenOptions={{headerBarStatusHeight: 0}}>
                 <Tab.Screen name="Home" initialParams={{center_id: defaultCenterId}}>
                   {args => HomeScreen(args)}
                 </Tab.Screen>

--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 
-import {AppStateStatus, DevSettings, Platform, StyleSheet} from 'react-native';
+import {AppStateStatus, DevSettings, Platform, StyleSheet, Text} from 'react-native';
 import {NavigationContainer} from '@react-navigation/native';
 import {createNativeStackNavigator, NativeStackScreenProps} from '@react-navigation/native-stack';
 import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
@@ -19,8 +19,9 @@ import {AvalancheCenterSelector} from './components/AvalancheCenterSelector';
 import {useAppState} from './hooks/useAppState';
 import {useLocation} from './hooks/useLocation';
 import {useOnlineManager} from './hooks/useOnlineManager';
-import {TelemetryStationMap} from './components/TelemetryStationMap';
-import {TelemetryStationData} from './components/TelemetryStationData';
+// import {TelemetryStationMap} from './components/TelemetryStationMap';
+// import {TelemetryStationData} from './components/TelemetryStationData';
+import {TabNavigatorParamList, HomeStackParamList} from './routes';
 
 Sentry.init({
   // we're overwriting a field that was previously defined in app.json, so we know it's non-null:
@@ -32,67 +33,59 @@ Sentry.init({
 
 const queryClient: QueryClient = new QueryClient();
 
-const AvalancheCenterSelectorScreen = () => {
-  return (
-    <SafeAreaView style={styles.container}>
-      <AvalancheCenterSelector date={formatISO(new Date('2022-03-01'))} />
-    </SafeAreaView>
-  );
-};
+const Tab = createBottomTabNavigator<TabNavigatorParamList>();
+const HomeStack = createNativeStackNavigator<HomeStackParamList>();
 
-const SelectorStack = createNativeStackNavigator<StackParamList>();
-const AvalancheCenterSelectionScreen = () => {
-  // TODO(skuznets) not showing the header here means iOS has no way to get back to this screen once they choose a center, but showing it means we double-up on headers ... ?
-  return (
-    <SelectorStack.Navigator initialRouteName="avalancheCenterSelection" screenOptions={{headerShown: false}}>
-      <SelectorStack.Screen name="avalancheCenterSelection" component={AvalancheCenterSelectorScreen} options={{title: 'Select an Avalanche Center'}} />
-      <SelectorStack.Screen name="avalancheCenterHome" component={AvalancheCenterTabScreen} options={({route}) => ({title: route.params.center_id})} />
-    </SelectorStack.Navigator>
-  );
-};
+// TODO(brian): do we need this? I'm guessing this kept things working while
+// developing in the offseason. Also TBD whether this should be part of the
+// route; are there use cases for supporting forecasts from different dates than
+// "today"?
+const defaultDate = formatISO(new Date('2022-03-01'));
 
-type AvalancheCenterProps = NativeStackScreenProps<StackParamList, 'avalancheCenter'>;
-const AvalancheCenterTab = createBottomTabNavigator<StackParamList>();
-const AvalancheCenterTabScreen = ({route}: AvalancheCenterProps) => {
-  const {center_id, date} = route.params;
-  return (
-    <AvalancheCenterTab.Navigator screenOptions={{headerShown: false}}>
-      <AvalancheCenterTab.Screen
-        name={'avalancheCenterStack'}
-        component={AvalancheCenterStackScreen}
-        initialParams={{center_id: center_id, date: date}}
-        options={() => ({title: center_id})}
-      />
-      <AvalancheCenterTab.Screen
-        name={'avalancheCenterTelemetryStack'}
-        component={AvalancheCenterTelemetryStackScreen}
-        initialParams={{center_id: center_id}}
-        options={({route}) => ({title: `${route.params.center_id} Telemetry Stations`})}
-      />
-    </AvalancheCenterTab.Navigator>
-  );
-};
+// TODO(brian): commented out stuff needs to be moved/restored, keeping it here for now
 
-const AvalancheCenterStack = createNativeStackNavigator<StackParamList>();
-const AvalancheCenterStackScreen = ({route}: AvalancheCenterProps) => {
-  const {center_id, date} = route.params;
-  return (
-    <AvalancheCenterStack.Navigator initialRouteName="avalancheCenter">
-      <AvalancheCenterStack.Screen
-        name="avalancheCenter"
-        component={MapScreen}
-        initialParams={{center_id: center_id, date: date}}
-        options={({route}) => ({title: route.params.center_id})}
-      />
-      <AvalancheCenterStack.Screen
-        name="forecast"
-        component={ForecastScreen}
-        initialParams={{center_id: center_id, date: date}}
-        options={({route}) => ({title: String(route.params.forecast_zone_id)})}
-      />
-    </AvalancheCenterStack.Navigator>
-  );
-};
+type AvalancheCenterProps = NativeStackScreenProps<HomeStackParamList, 'avalancheCenter'>;
+// const AvalancheCenterTab = createBottomTabNavigator<HomeStackParamList>();
+// const AvalancheCenterTabScreen = ({route}: AvalancheCenterProps) => {
+//   const {center_id, date} = route.params;
+//   return (
+//     <AvalancheCenterTab.Navigator screenOptions={{headerShown: false}}>
+//       <AvalancheCenterTab.Screen
+//         name={'avalancheCenterStack'}
+//         component={AvalancheCenterStackScreen}
+//         initialParams={{center_id: center_id, date: date}}
+//         options={() => ({title: center_id})}
+//       />
+//       <AvalancheCenterTab.Screen
+//         name={'avalancheCenterTelemetryStack'}
+//         component={AvalancheCenterTelemetryStackScreen}
+//         initialParams={{center_id: center_id}}
+//         options={({route}) => ({title: `${route.params.center_id} Telemetry Stations`})}
+//       />
+//     </AvalancheCenterTab.Navigator>
+//   );
+// };
+
+// const AvalancheCenterStack = createNativeStackNavigator<HomeStackParamList>();
+// const AvalancheCenterStackScreen = ({route}: AvalancheCenterProps) => {
+//   const {center_id, date} = route.params;
+//   return (
+//     <AvalancheCenterStack.Navigator initialRouteName="avalancheCenter">
+//       <AvalancheCenterStack.Screen
+//         name="avalancheCenter"
+//         component={MapScreen}
+//         initialParams={{center_id: center_id, date: date}}
+//         options={({route}) => ({title: route.params.center_id})}
+//       />
+//       <AvalancheCenterStack.Screen
+//         name="forecast"
+//         component={ForecastScreen}
+//         initialParams={{center_id: center_id, date: date}}
+//         options={({route}) => ({title: String(route.params.forecast_zone_id)})}
+//       />
+//     </AvalancheCenterStack.Navigator>
+//   );
+// };
 
 const MapScreen = ({route}: AvalancheCenterProps) => {
   const {center_id, date} = route.params;
@@ -103,7 +96,7 @@ const MapScreen = ({route}: AvalancheCenterProps) => {
   );
 };
 
-type ForecastScreenProps = NativeStackScreenProps<StackParamList, 'forecast'>;
+type ForecastScreenProps = NativeStackScreenProps<HomeStackParamList, 'forecast'>;
 const ForecastScreen = ({route}: ForecastScreenProps) => {
   const {center_id, forecast_zone_id, date} = route.params;
   return (
@@ -113,88 +106,45 @@ const ForecastScreen = ({route}: ForecastScreenProps) => {
   );
 };
 
-const AvalancheCenterTelemetryStack = createNativeStackNavigator<StackParamList>();
-const AvalancheCenterTelemetryStackScreen = ({route}: AvalancheCenterProps) => {
-  const {center_id} = route.params;
-  return (
-    <AvalancheCenterTelemetryStack.Navigator initialRouteName="telemetryStations">
-      <AvalancheCenterTelemetryStack.Screen
-        name="telemetryStations"
-        component={TelemetryScreen}
-        initialParams={{center_id: center_id}}
-        options={({route}) => ({title: `${route.params.center_id} Telemetry Stations`})}
-      />
-      <AvalancheCenterTelemetryStack.Screen
-        name="telemetryStation"
-        component={TelemetryStationScreen}
-        initialParams={{center_id: center_id}}
-        options={({route}) => ({title: String(route.params.name)})}
-      />
-    </AvalancheCenterTelemetryStack.Navigator>
-  );
-};
+// const AvalancheCenterTelemetryStack = createNativeStackNavigator<HomeStackParamList>();
+// const AvalancheCenterTelemetryStackScreen = ({route}: AvalancheCenterProps) => {
+//   const {center_id} = route.params;
+//   return (
+//     <AvalancheCenterTelemetryStack.Navigator initialRouteName="telemetryStations">
+//       <AvalancheCenterTelemetryStack.Screen
+//         name="telemetryStations"
+//         component={TelemetryScreen}
+//         initialParams={{center_id: center_id}}
+//         options={({route}) => ({title: `${route.params.center_id} Telemetry Stations`})}
+//       />
+//       <AvalancheCenterTelemetryStack.Screen
+//         name="telemetryStation"
+//         component={TelemetryStationScreen}
+//         initialParams={{center_id: center_id}}
+//         options={({route}) => ({title: String(route.params.name)})}
+//       />
+//     </AvalancheCenterTelemetryStack.Navigator>
+//   );
+// };
 
-const TelemetryScreen = ({route}: AvalancheCenterProps) => {
-  const {center_id} = route.params;
-  return (
-    <SafeAreaView style={styles.container}>
-      <TelemetryStationMap center_id={center_id} />
-    </SafeAreaView>
-  );
-};
+// const TelemetryScreen = ({route}: AvalancheCenterProps) => {
+//   const {center_id} = route.params;
+//   return (
+//     <SafeAreaView style={styles.container}>
+//       <TelemetryStationMap center_id={center_id} />
+//     </SafeAreaView>
+//   );
+// };
 
-type TelemetryStationProps = NativeStackScreenProps<StackParamList, 'telemetryStation'>;
-const TelemetryStationScreen = ({route}: TelemetryStationProps) => {
-  const {center_id, source, station_id} = route.params;
-  return (
-    <SafeAreaView style={styles.container}>
-      <TelemetryStationData center_id={center_id} source={source} station_id={station_id} />
-    </SafeAreaView>
-  );
-};
-
-type StackParamList = {
-  avalancheCenterSelection: undefined;
-  avalancheCenterHome: {
-    center_id: string;
-    date: string;
-  };
-  avalancheCenterStack: {
-    center_id: string;
-    date: string;
-  };
-  avalancheCenter: {
-    center_id: string;
-    date: string;
-  };
-  forecast: {
-    center_id: string;
-    forecast_zone_id: number;
-    date: string;
-  };
-  avalancheCenterTelemetryStack: {
-    center_id: string;
-  };
-  telemetryStations: {
-    center_id: string;
-  };
-  telemetryStation: {
-    center_id: string;
-    source: string;
-    station_id: number;
-    name: string;
-  };
-};
-
-// TODO(brian): dig into this. This is somehow suppressing typescript errors in
-// other files - if you comment it out, compilation fails.
-declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace ReactNavigation {
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface RootParamList extends StackParamList {}
-  }
-}
+// type TelemetryStationProps = NativeStackScreenProps<HomeStackParamList, 'telemetryStation'>;
+// const TelemetryStationScreen = ({route}: TelemetryStationProps) => {
+//   const {center_id, source, station_id} = route.params;
+//   return (
+//     <SafeAreaView style={styles.container}>
+//       <TelemetryStationData center_id={center_id} source={source} station_id={station_id} />
+//     </SafeAreaView>
+//   );
+// };
 
 const onAppStateChange = (status: AppStateStatus) => {
   // React Query already supports in web browser refetch on window focus by default
@@ -203,6 +153,37 @@ const onAppStateChange = (status: AppStateStatus) => {
   }
 };
 
+function PlaceholderScreen(label: string) {
+  return (
+    <SafeAreaView style={styles.container}>
+      <Text>{label}</Text>
+    </SafeAreaView>
+  );
+}
+
+function HomeScreen({route}) {
+  const {center_id} = route.params;
+  return (
+    <HomeStack.Navigator initialRouteName="avalancheCenter">
+      <HomeStack.Screen
+        name="avalancheCenter"
+        component={MapScreen}
+        initialParams={{center_id: center_id, date: defaultDate}}
+        options={({route}) => ({title: route.params.center_id, headerShown: false})}
+      />
+      <HomeStack.Screen
+        name="forecast"
+        component={ForecastScreen}
+        initialParams={{center_id: center_id, date: defaultDate}}
+        options={({route}) => ({title: String(route.params.forecast_zone_id)})}
+      />
+    </HomeStack.Navigator>
+  );
+}
+
+// TODO(brian): move this into app config
+export const defaultCenterId = 'NWAC';
+
 const App = () => {
   try {
     // your code
@@ -210,8 +191,9 @@ const App = () => {
 
     useAppState(onAppStateChange);
 
-    const locationStatus = useLocation(location => {
-      console.log('Location update', location);
+    const locationStatus = useLocation(_location => {
+      // console.log('Location update', location);
+      undefined;
     });
     console.log('Location permission status', locationStatus);
 
@@ -236,7 +218,29 @@ const App = () => {
         <QueryClientProvider client={queryClient}>
           <SafeAreaProvider>
             <NavigationContainer>
-              <AvalancheCenterSelectionScreen />
+              <Tab.Navigator initialRouteName="Home" screenOptions={{headerShown: false}}>
+                <Tab.Screen name="Home" initialParams={{center_id: defaultCenterId}}>
+                  {args => HomeScreen(args)}
+                </Tab.Screen>
+                <Tab.Screen name="Observations" initialParams={{center_id: defaultCenterId}}>
+                  {() => PlaceholderScreen('Observations')}
+                </Tab.Screen>
+                <Tab.Screen name="WeatherData" initialParams={{center_id: defaultCenterId}}>
+                  {() => PlaceholderScreen('Weather data')}
+                </Tab.Screen>
+                <Tab.Screen name="Menu" initialParams={{center_id: defaultCenterId}}>
+                  {() => PlaceholderScreen('Menu')}
+                </Tab.Screen>
+                {__DEV__ && (
+                  <Tab.Screen name="Debug" initialParams={{center_id: defaultCenterId}}>
+                    {() => (
+                      <SafeAreaView style={styles.container}>
+                        <AvalancheCenterSelector />
+                      </SafeAreaView>
+                    )}
+                  </Tab.Screen>
+                )}
+              </Tab.Navigator>
             </NavigationContainer>
           </SafeAreaProvider>
         </QueryClientProvider>

--- a/components/AvalancheCenterSelector.tsx
+++ b/components/AvalancheCenterSelector.tsx
@@ -5,6 +5,7 @@ import {useNavigation} from '@react-navigation/native';
 
 import {AvalancheCenterLogo} from './AvalancheCenterLogo';
 import {useAvalancheCenterMetadata} from '../hooks/useAvalancheCenterMetadata';
+import {TabNavigationProps} from '../routes';
 
 const center_idsByType: SectionListData<string>[] = [
   {
@@ -43,11 +44,10 @@ const center_idsByType: SectionListData<string>[] = [
 
 interface AvalancheCenterCardProps {
   center_id: string;
-  date: string;
 }
 
-const AvalancheCenterCard: React.FunctionComponent<AvalancheCenterCardProps> = ({center_id, date}: AvalancheCenterCardProps) => {
-  const navigation = useNavigation();
+const AvalancheCenterCard: React.FunctionComponent<AvalancheCenterCardProps> = ({center_id}: AvalancheCenterCardProps) => {
+  const navigation = useNavigation<TabNavigationProps>();
   const {isLoading, isError, data: avalancheCenter, error} = useAvalancheCenterMetadata(center_id);
   if (isLoading) {
     return <ActivityIndicator style={styles.item} />;
@@ -68,24 +68,29 @@ const AvalancheCenterCard: React.FunctionComponent<AvalancheCenterCardProps> = (
   }
 
   return (
-    <TouchableOpacity style={styles.item} onPress={() => navigation.navigate('avalancheCenterHome', {center_id: center_id, date: date})}>
+    <TouchableOpacity
+      style={styles.item}
+      onPress={() => {
+        // We need to clear navigation state to force all screens from the
+        // previous avalanche center selection to unmount
+        navigation.reset({
+          index: 0,
+          routes: [{name: 'Home', params: {center_id}}],
+        });
+      }}>
       <AvalancheCenterLogo style={styles.logo} center_id={center_id} />
       <Text style={{textAlignVertical: 'center'}}>{avalancheCenter.name}</Text>
     </TouchableOpacity>
   );
 };
 
-export interface AvalancheCenterSelectorProps {
-  date: string;
-}
-
-export const AvalancheCenterSelector: React.FunctionComponent<AvalancheCenterSelectorProps> = ({date}: AvalancheCenterSelectorProps) => {
+export const AvalancheCenterSelector = () => {
   return (
     <SectionList
       style={styles.container}
       sections={center_idsByType}
       keyExtractor={item => item}
-      renderItem={({item}) => <AvalancheCenterCard center_id={item} date={date} />}
+      renderItem={({item}) => <AvalancheCenterCard center_id={item} />}
       renderSectionHeader={({section: {title}}) => <Text style={styles.title}>{title + ' Centers'}</Text>}
     />
   );

--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -15,6 +15,7 @@ import {AvalancheDangerIcon} from './AvalancheDangerIcon';
 import {dangerText} from './helpers/dangerText';
 import {useMapLayer} from '../hooks/useMapLayer';
 import {useAvalancheForecastFragment} from '../hooks/useAvalancheForecastFragment';
+import {HomeStackNavigationProps} from '../routes';
 
 export const defaultRegion: Region = {
   // TODO(skuznets): add a sane default for the US?
@@ -192,7 +193,7 @@ export const AvalancheForecastZoneCard: React.FunctionComponent<{
 }> = ({feature, date, style}) => {
   const forecastDate: Date = parseISO(date);
   const {width} = useWindowDimensions();
-  const navigation = useNavigation();
+  const navigation = useNavigation<HomeStackNavigationProps>();
   const {isLoading, isError, data: forecast, error} = useAvalancheForecastFragment(feature.properties.center_id, feature.id, forecastDate);
   if (isLoading) {
     return (

--- a/components/AvalancheForecastZonePolygon.tsx
+++ b/components/AvalancheForecastZonePolygon.tsx
@@ -9,6 +9,7 @@ import polylabel from 'polylabel';
 import {AvalancheDangerForecast, DangerLevel, Feature, FeatureComponent, ForecastPeriod} from '../types/nationalAvalancheCenter';
 import {useAvalancheForecastFragment} from '../hooks/useAvalancheForecastFragment';
 import {colorFor} from './AvalancheDangerPyramid';
+import {HomeStackNavigationProps} from '../routes';
 
 const coordinateList = (geometry: FeatureComponent): number[][] => {
   let items: number[][] = [];
@@ -96,7 +97,7 @@ export const AvalancheForecastZonePolygon: React.FunctionComponent<AvalancheFore
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const forecastDate: Date = parseISO(date);
-  const navigation = useNavigation();
+  const navigation = useNavigation<HomeStackNavigationProps>();
   const {isLoading, isError, data: forecast, error} = useAvalancheForecastFragment(feature.properties.center_id, feature.id, forecastDate);
   if (isLoading) {
     return (

--- a/components/TelemetryStationMap.tsx
+++ b/components/TelemetryStationMap.tsx
@@ -9,6 +9,7 @@ import {StyleSheet, ActivityIndicator, FlatList, TouchableOpacity, View, ViewSty
 import {CARD_MARGIN, CARD_SPACING, CARD_WIDTH, defaultRegion} from './AvalancheForecastZoneMap';
 import {updateRegionToContain} from './AvalancheForecastZonePolygon';
 import {useNavigation} from '@react-navigation/native';
+import {HomeStackNavigationProps} from '../routes';
 
 export const TelemetryStationMap: React.FunctionComponent<{
   center_id: string;
@@ -138,7 +139,7 @@ export const TelemetryStationCard: React.FunctionComponent<{
   style: ViewStyle;
 }> = ({center_id, station, style}) => {
   const {width} = useWindowDimensions();
-  const navigation = useNavigation();
+  const navigation = useNavigation<HomeStackNavigationProps>();
   return (
     <TouchableOpacity
       onPress={() => {

--- a/routes.ts
+++ b/routes.ts
@@ -1,0 +1,45 @@
+import {BottomTabNavigationProp} from '@react-navigation/bottom-tabs';
+import {NativeStackNavigationProp} from '@react-navigation/native-stack';
+
+export type TabNavigatorParamList = {
+  Home: {center_id: string};
+  WeatherData: {center_id: string};
+  Observations: {center_id: string};
+  Menu: {center_id: string};
+  Debug: {center_id: string};
+};
+export type TabNavigationProps = BottomTabNavigationProp<TabNavigatorParamList>;
+
+export type HomeStackParamList = {
+  avalancheCenterSelection: undefined;
+  avalancheCenterHome: {
+    center_id: string;
+    date: string;
+  };
+  avalancheCenterStack: {
+    center_id: string;
+    date: string;
+  };
+  avalancheCenter: {
+    center_id: string;
+    date: string;
+  };
+  forecast: {
+    center_id: string;
+    forecast_zone_id: number;
+    date: string;
+  };
+  avalancheCenterTelemetryStack: {
+    center_id: string;
+  };
+  telemetryStations: {
+    center_id: string;
+  };
+  telemetryStation: {
+    center_id: string;
+    source: string;
+    station_id: number;
+    name: string;
+  };
+};
+export type HomeStackNavigationProps = NativeStackNavigationProp<HomeStackParamList>;


### PR DESCRIPTION
- stub in a new home view
- avalanche center picker is still alive, in a `__DEV__`-only tab called "Debug"
- forecast viewing is *broken* - I'll be fast-following with that
- there seems to be some extra padding at the bottom of the tab navigator...will debug that later as well 🤔 

<img width="321" alt="image" src="https://user-images.githubusercontent.com/101196/208175273-3cba14cd-27dc-4cee-acc8-6a56b96a0510.png">
