### PR TITLE
Get avy forecasts happy again

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -36,11 +36,9 @@ const queryClient: QueryClient = new QueryClient();
 const Tab = createBottomTabNavigator<TabNavigatorParamList>();
 const HomeStack = createNativeStackNavigator<HomeStackParamList>();
 
-// TODO(brian): do we need this? I'm guessing this kept things working while
-// developing in the offseason. Also TBD whether this should be part of the
-// route; are there use cases for supporting forecasts from different dates than
-// "today"?
-const defaultDate = formatISO(new Date('2022-03-01'));
+// For now, we are implicitly interested in today's forecast.
+// If you want to investigate an issue on a different day, you can change this value.
+const defaultDate = formatISO(Date.now());
 
 // TODO(brian): commented out stuff needs to be moved/restored, keeping it here for now
 
@@ -200,7 +198,7 @@ const App = () => {
     console.log('Location permission status', locationStatus);
 
     // Using NAC staging may trigger errors, but we'll try it for now
-    const [contextValue, setContextValue] = useState(stagingClientProps);
+    const [contextValue, setContextValue] = useState(productionClientProps);
 
     useEffect(() => {
       // Add toggle commands to the React Native debug menu

--- a/hooks/useAvalancheForecast.ts
+++ b/hooks/useAvalancheForecast.ts
@@ -6,7 +6,7 @@ import {useQuery} from 'react-query';
 import * as Sentry from 'sentry-expo';
 
 import {ClientContext, ClientProps} from '../clientContext';
-import {Product, productSchema} from '../types/nationalAvalancheCenter';
+import {Product, productSchema, numberToProblemSize} from '../types/nationalAvalancheCenter';
 import {useAvalancheForecastFragment} from './useAvalancheForecastFragment';
 
 export const useAvalancheForecast = (center_id: string, forecast_zone_id: number, date: Date) => {
@@ -22,12 +22,14 @@ export const useAvalancheForecast = (center_id: string, forecast_zone_id: number
 
       // Fix up data issues before parsing
       // 1) NWAC (and probably others) return strings for avalanche problem size, not numbers
+      // 2) NWAC (and probably others) use values outside our enums 1-4
       data.forecast_avalanche_problems?.forEach(problem => {
         if (problem.size.find(s => typeof s === 'string')) {
           // this is pretty noisy
           console.log('converting size string to number', problem.size);
           problem.size = problem.size.map(s => Number(s));
         }
+        problem.size = problem.size.map(numberToProblemSize);
       });
 
       const parseResult = productSchema.safeParse(data);

--- a/types/nationalAvalancheCenter/enums.ts
+++ b/types/nationalAvalancheCenter/enums.ts
@@ -87,6 +87,9 @@ export enum AvalancheProblemSize {
   Historic,
 }
 
+// Round the number up, then clamp it to the bounds 1-4
+export const numberToProblemSize = (size: number): AvalancheProblemSize => Math.max(AvalancheProblemSize.Small, Math.min(AvalancheProblemSize.Historic, Math.round(size)));
+
 export enum ForecastPeriod {
   Current = 'current',
   Tomorrow = 'tomorrow',


### PR DESCRIPTION
- use today's date
- clamp fractional problem sizes before parsing
- use production NAC server instead of staging

map | forecast
--- | ---
<img width="311" alt="image" src="https://user-images.githubusercontent.com/101196/208184538-caefcf71-bd45-4cea-a7f3-e016f07e782d.png"> | <img width="311" alt="image" src="https://user-images.githubusercontent.com/101196/208184642-349a206d-37b0-4ae9-8e58-f0aad14ee4fb.png">


