### PR TITLE
Fix safe area views; remove debug tab

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -126,11 +126,11 @@ const onAppStateChange = (status: AppStateStatus) => {
 
 function PlaceholderScreen(label: string) {
   return (
-    <View style={{...styles.container, flex: 1, justifyContent: 'space-between', alignItems: 'center'}}>
+    <SafeAreaView style={{...styles.container, flex: 1, justifyContent: 'space-between', alignItems: 'center'}}>
       <Text>This is top text.</Text>
       <Text style={{fontSize: 24, fontWeight: 'bold'}}>View name: {label}</Text>
       <Text>This is bottom text.</Text>
-    </View>
+    </SafeAreaView>
   );
 }
 
@@ -166,46 +166,44 @@ const App = () => {
           <NativeBaseProvider>
             <SafeAreaProvider>
               <NavigationContainer>
-                <SafeAreaView style={styles.container}>
-                  <TabNavigator.Navigator
-                    initialRouteName="Home"
-                    screenOptions={({route}) => ({
-                      headerShown: false,
-                      tabBarIcon: ({color, size}) => {
-                        if (route.name === 'Home') {
-                          return <AntDesign name="search1" size={size} color={color} />;
-                        } else if (route.name === 'Observations') {
-                          return <AntDesign name="filetext1" size={size} color={color} />;
-                        } else if (route.name === 'Weather Data') {
-                          return <AntDesign name="barschart" size={size} color={color} />;
-                        } else if (route.name === 'Menu') {
-                          return <AntDesign name="bars" size={size} color={color} />;
-                        } else if (route.name === 'Debug') {
-                          return <AntDesign name="database" size={size} color={color} />;
-                        }
-                      },
-                    })}>
-                    <TabNavigator.Screen name="Home">{() => AvalancheCenterStackScreen(avalancheCenter, date)}</TabNavigator.Screen>
-                    <TabNavigator.Screen name="Observations">{() => ObservationsStackScreen(avalancheCenter, date)}</TabNavigator.Screen>
-                    <TabNavigator.Screen name="Weather Data">{() => AvalancheCenterTelemetryStackScreen(avalancheCenter, date)}</TabNavigator.Screen>
-                    <TabNavigator.Screen name="Menu" initialParams={{center_id: avalancheCenter}}>
-                      {() => PlaceholderScreen('Menu')}
-                    </TabNavigator.Screen>
-                    {__DEV__ && (
-                      <TabNavigator.Screen name="Debug">
-                        {() => (
-                          <View style={styles.container}>
-                            <View>
-                              <Text>Use staging environment</Text>
-                              <Switch value={staging} onValueChange={toggleStaging} />
-                            </View>
-                            <AvalancheCenterSelector setAvalancheCenter={setAvalancheCenter} />
+                <TabNavigator.Navigator
+                  initialRouteName="Home"
+                  screenOptions={({route}) => ({
+                    headerShown: false,
+                    tabBarIcon: ({color, size}) => {
+                      if (route.name === 'Home') {
+                        return <AntDesign name="search1" size={size} color={color} />;
+                      } else if (route.name === 'Observations') {
+                        return <AntDesign name="filetext1" size={size} color={color} />;
+                      } else if (route.name === 'Weather Data') {
+                        return <AntDesign name="barschart" size={size} color={color} />;
+                      } else if (route.name === 'Menu') {
+                        return <AntDesign name="bars" size={size} color={color} />;
+                      } else if (route.name === 'Debug') {
+                        return <AntDesign name="database" size={size} color={color} />;
+                      }
+                    },
+                  })}>
+                  <TabNavigator.Screen name="Home">{() => AvalancheCenterStackScreen(avalancheCenter, date)}</TabNavigator.Screen>
+                  <TabNavigator.Screen name="Observations">{() => ObservationsStackScreen(avalancheCenter, date)}</TabNavigator.Screen>
+                  <TabNavigator.Screen name="Weather Data">{() => AvalancheCenterTelemetryStackScreen(avalancheCenter, date)}</TabNavigator.Screen>
+                  <TabNavigator.Screen name="Menu" initialParams={{center_id: avalancheCenter}}>
+                    {() => PlaceholderScreen('Menu')}
+                  </TabNavigator.Screen>
+                  {__DEV__ && (
+                    <TabNavigator.Screen name="Debug">
+                      {() => (
+                        <SafeAreaView style={styles.container}>
+                          <View>
+                            <Text>Use staging environment</Text>
+                            <Switch value={staging} onValueChange={toggleStaging} />
                           </View>
-                        )}
-                      </TabNavigator.Screen>
-                    )}
-                  </TabNavigator.Navigator>
-                </SafeAreaView>
+                          <AvalancheCenterSelector setAvalancheCenter={setAvalancheCenter} />
+                        </SafeAreaView>
+                      )}
+                    </TabNavigator.Screen>
+                  )}
+                </TabNavigator.Navigator>
               </NavigationContainer>
             </SafeAreaProvider>
           </NativeBaseProvider>

--- a/App.tsx
+++ b/App.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
-import {AppStateStatus, Platform, StyleSheet, Switch, Text, View} from 'react-native';
+import {AppStateStatus, Platform, StyleSheet, View} from 'react-native';
 import {NavigationContainer} from '@react-navigation/native';
 import {createNativeStackNavigator, NativeStackScreenProps} from '@react-navigation/native-stack';
 import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
-import {SafeAreaProvider, SafeAreaView} from 'react-native-safe-area-context';
+import {SafeAreaProvider} from 'react-native-safe-area-context';
 import {AntDesign} from '@expo/vector-icons';
 
 import Constants from 'expo-constants';
@@ -15,8 +15,7 @@ import {focusManager, QueryClient, QueryClientProvider} from 'react-query';
 
 import {NativeBaseProvider} from 'native-base';
 
-import {ClientContext, productionClientProps, stagingClientProps} from 'clientContext';
-import {AvalancheCenterSelector} from 'components/AvalancheCenterSelector';
+import {ClientContext, contextDefaults, productionHosts, stagingHosts} from 'clientContext';
 import {useAppState} from 'hooks/useAppState';
 import {useOnlineManager} from 'hooks/useOnlineManager';
 import {TelemetryStationMap} from 'components/TelemetryStationMap';
@@ -25,6 +24,7 @@ import {TabNavigatorParamList, HomeStackParamList} from 'routes';
 import {Observations} from 'components/Observations';
 import {Observation} from 'components/Observation';
 import {AvalancheCenterStackScreen} from 'components/screens/HomeScreen';
+import {MenuScreen} from 'components/screens/MenuScreen';
 
 if (Sentry?.init) {
   // we're reading a field that was previously defined in app.json, so we know it's non-null:
@@ -124,21 +124,10 @@ const onAppStateChange = (status: AppStateStatus) => {
   }
 };
 
-function PlaceholderScreen(label: string) {
-  return (
-    <SafeAreaView style={{...styles.container, flex: 1, justifyContent: 'space-between', alignItems: 'center'}}>
-      <Text>This is top text.</Text>
-      <Text style={{fontSize: 24, fontWeight: 'bold'}}>View name: {label}</Text>
-      <Text>This is bottom text.</Text>
-    </SafeAreaView>
-  );
-}
-
 // For now, we are implicitly interested in today's forecast.
 // If you want to investigate an issue on a different day, you can change this value.
 // TODO: add a date picker
 const defaultDate = formatISO(Date.now());
-export const defaultCenterId = 'NWAC';
 
 const App = () => {
   try {
@@ -146,19 +135,22 @@ const App = () => {
 
     useAppState(onAppStateChange);
 
-    const [avalancheCenter, setAvalancheCenter] = React.useState(defaultCenterId);
-    const [date] = React.useState(defaultDate);
-
+    // Set up ClientContext values
+    const [avalancheCenter, setAvalancheCenter] = React.useState(contextDefaults.avalancheCenter);
     const [staging, setStaging] = React.useState(false);
     const toggleStaging = React.useCallback(() => {
       setStaging(!staging);
       console.log(`Switching to ${staging ? 'production' : 'staging'} environment`);
     }, [staging, setStaging]);
     const contextValue = {
-      ...(staging ? stagingClientProps : productionClientProps),
+      ...(staging ? stagingHosts : productionHosts),
+      avalancheCenter,
+      setAvalancheCenter,
       staging,
       toggleStaging,
     };
+
+    const [date] = React.useState(defaultDate);
 
     return (
       <ClientContext.Provider value={contextValue}>
@@ -179,8 +171,6 @@ const App = () => {
                         return <AntDesign name="barschart" size={size} color={color} />;
                       } else if (route.name === 'Menu') {
                         return <AntDesign name="bars" size={size} color={color} />;
-                      } else if (route.name === 'Debug') {
-                        return <AntDesign name="database" size={size} color={color} />;
                       }
                     },
                   })}>
@@ -188,21 +178,8 @@ const App = () => {
                   <TabNavigator.Screen name="Observations">{() => ObservationsStackScreen(avalancheCenter, date)}</TabNavigator.Screen>
                   <TabNavigator.Screen name="Weather Data">{() => AvalancheCenterTelemetryStackScreen(avalancheCenter, date)}</TabNavigator.Screen>
                   <TabNavigator.Screen name="Menu" initialParams={{center_id: avalancheCenter}}>
-                    {() => PlaceholderScreen('Menu')}
+                    {() => MenuScreen()}
                   </TabNavigator.Screen>
-                  {__DEV__ && (
-                    <TabNavigator.Screen name="Debug">
-                      {() => (
-                        <SafeAreaView style={styles.container}>
-                          <View>
-                            <Text>Use staging environment</Text>
-                            <Switch value={staging} onValueChange={toggleStaging} />
-                          </View>
-                          <AvalancheCenterSelector setAvalancheCenter={setAvalancheCenter} />
-                        </SafeAreaView>
-                      )}
-                    </TabNavigator.Screen>
-                  )}
                 </TabNavigator.Navigator>
               </NavigationContainer>
             </SafeAreaProvider>

--- a/clientContext.ts
+++ b/clientContext.ts
@@ -1,25 +1,33 @@
 import React, {Context} from 'react';
 
 export interface ClientProps {
+  avalancheCenter: string;
+  setAvalancheCenter: (center: string) => void;
   nationalAvalancheCenterHost: string;
   snowboundHost: string;
   staging: boolean;
   toggleStaging: () => void;
 }
 
-export const productionClientProps = {
+export const productionHosts = {
   nationalAvalancheCenterHost: 'https://api.avalanche.org',
   snowboundHost: 'https://api.snowobs.com',
 };
 
-export const stagingClientProps = {
+export const stagingHosts = {
   nationalAvalancheCenterHost: 'https://staging-api.avalanche.org',
   // TODO(brian): what's the Staging version for Snowbound?
   snowboundHost: 'https://api.snowobs.com',
 };
 
-export const ClientContext: Context<ClientProps> = React.createContext<ClientProps>({
-  ...productionClientProps,
+export const contextDefaults = {
+  ...productionHosts,
   staging: false,
+  avalancheCenter: 'NWAC',
+};
+
+export const ClientContext: Context<ClientProps> = React.createContext<ClientProps>({
+  ...contextDefaults,
+  setAvalancheCenter: () => undefined,
   toggleStaging: () => undefined,
 });

--- a/components/screens/ForecastScreen.tsx
+++ b/components/screens/ForecastScreen.tsx
@@ -1,4 +1,6 @@
-import {StyleSheet, View} from 'react-native';
+import {StyleSheet} from 'react-native';
+
+import {SafeAreaView} from 'react-native-safe-area-context';
 
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 
@@ -8,9 +10,9 @@ import {HomeStackParamList} from 'routes';
 export const ForecastScreen = ({route}: NativeStackScreenProps<HomeStackParamList, 'forecast'>) => {
   const {center_id, forecast_zone_id, date} = route.params;
   return (
-    <View style={styles.container}>
+    <SafeAreaView style={styles.container}>
       <AvalancheForecast center_id={center_id} forecast_zone_id={forecast_zone_id} date={date} />
-    </View>
+    </SafeAreaView>
   );
 };
 

--- a/components/screens/HomeScreen.tsx
+++ b/components/screens/HomeScreen.tsx
@@ -8,12 +8,7 @@ const AvalancheCenterStack = createNativeStackNavigator<HomeStackParamList>();
 export const AvalancheCenterStackScreen = (center_id: string, date: string) => {
   return (
     <AvalancheCenterStack.Navigator initialRouteName="avalancheCenter">
-      <AvalancheCenterStack.Screen
-        name="avalancheCenter"
-        component={MapScreen}
-        initialParams={{center_id: center_id, date: date}}
-        options={({route}) => ({title: route.params.center_id})}
-      />
+      <AvalancheCenterStack.Screen name="avalancheCenter" component={MapScreen} initialParams={{center_id: center_id, date: date}} options={() => ({headerShown: false})} />
       <AvalancheCenterStack.Screen
         name="forecast"
         component={ForecastScreen}

--- a/components/screens/MenuScreen.tsx
+++ b/components/screens/MenuScreen.tsx
@@ -1,0 +1,32 @@
+import {useContext} from 'react';
+
+import {StyleSheet} from 'react-native';
+import {SafeAreaView} from 'react-native-safe-area-context';
+
+import {Heading, HStack, VStack, Switch, Text} from 'native-base';
+
+import {ClientContext, ClientProps} from 'clientContext';
+import {AvalancheCenterSelector} from 'components/AvalancheCenterSelector';
+
+export const MenuScreen = () => {
+  const {staging, toggleStaging, setAvalancheCenter} = useContext<ClientProps>(ClientContext);
+  return (
+    <SafeAreaView style={styles.fullscreen}>
+      <VStack pt="16" px="4" space="4" style={styles.fullscreen}>
+        <Heading>Settings</Heading>
+        <Heading size="sm">Debug settings</Heading>
+        <HStack justifyContent="space-between" alignItems="center" space="4">
+          <Text>Use staging environment</Text>
+          <Switch value={staging} onValueChange={toggleStaging} />
+        </HStack>
+        <AvalancheCenterSelector setAvalancheCenter={setAvalancheCenter} />
+      </VStack>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  fullscreen: {
+    ...StyleSheet.absoluteFillObject,
+  },
+});


### PR DESCRIPTION
- Remove the top-level SafeAreaView so that the map goes all the way to the top of the screen (matches Figma mocks). Other screens in the app use SafeAreaViews as needed
- Making this change fixes the extra whitespace at the bottom of the tab bar as well
- As previously discussed, moved debug settings to the "Menu" tab and removed "Debug"

iOS screenshots

home | menu
--- | ---
![image](https://user-images.githubusercontent.com/101196/210021143-ebe77464-f1ce-45b8-b8db-eb671bcc0032.png) | ![IMG_7A1E8F447244-1](https://user-images.githubusercontent.com/101196/210022529-5b97ebe5-6c98-4ccc-aeaf-c1e034eb2548.jpeg)



