### PR TITLE
Forecast changes

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -13,7 +13,7 @@ import * as Sentry from 'sentry-expo';
 import {formatISO} from 'date-fns';
 import {focusManager, QueryClient, QueryClientProvider} from 'react-query';
 
-import {NativeBaseProvider} from 'native-base';
+import {NativeBaseProvider, extendTheme} from 'native-base';
 
 import {ClientContext, contextDefaults, productionHosts, stagingHosts} from 'clientContext';
 import {useAppState} from 'hooks/useAppState';
@@ -129,6 +129,12 @@ const onAppStateChange = (status: AppStateStatus) => {
 // TODO: add a date picker
 const defaultDate = formatISO(Date.now());
 
+const theme = extendTheme({
+  colors: {
+    darkText: '#333333',
+  },
+});
+
 const App = () => {
   try {
     useOnlineManager();
@@ -155,7 +161,7 @@ const App = () => {
     return (
       <ClientContext.Provider value={contextValue}>
         <QueryClientProvider client={queryClient}>
-          <NativeBaseProvider>
+          <NativeBaseProvider theme={theme}>
             <SafeAreaProvider>
               <NavigationContainer>
                 <TabNavigator.Navigator

--- a/components/AvalancheForecast.tsx
+++ b/components/AvalancheForecast.tsx
@@ -15,6 +15,7 @@ import {useAvalancheCenterMetadata} from 'hooks/useAvalancheCenterMetadata';
 import {useRefreshByUser} from 'hooks/useRefreshByUser';
 
 export interface AvalancheForecastProps {
+  zoneName: string;
   center_id: string;
   date: string;
   forecast_zone_id: number;

--- a/components/AvalancheForecast.tsx
+++ b/components/AvalancheForecast.tsx
@@ -1,15 +1,27 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 
-import {ActivityIndicator, Alert, RefreshControl, ScrollView, StyleSheet, Text, useWindowDimensions, View} from 'react-native';
+import {ActivityIndicator, Alert, RefreshControl, ScrollView, StyleSheet, useWindowDimensions} from 'react-native';
 import RenderHTML from 'react-native-render-html';
 import {useNavigation} from '@react-navigation/native';
 
+import {Heading, Text, View, VStack} from 'native-base';
+
 import {parseISO} from 'date-fns';
 
-import {AvalancheDangerForecast, AvalancheForecastZone, AvalancheForecastZoneSummary, DangerLevel, ElevationBandNames, ForecastPeriod} from 'types/nationalAvalancheCenter';
+import {
+  AvalancheCenter,
+  AvalancheDangerForecast,
+  AvalancheForecastZone,
+  AvalancheForecastZoneSummary,
+  DangerLevel,
+  ElevationBandNames,
+  ForecastPeriod,
+  Product,
+} from 'types/nationalAvalancheCenter';
 import {AvalancheDangerTable} from './AvalancheDangerTable';
 import {AvalancheDangerIcon} from './AvalancheDangerIcon';
 import {AvalancheProblemCard} from './AvalancheProblemCard';
+import {TabControl} from 'components/TabControl';
 import {useAvalancheForecast} from 'hooks/useAvalancheForecast';
 import {useAvalancheCenterMetadata} from 'hooks/useAvalancheCenterMetadata';
 import {useRefreshByUser} from 'hooks/useRefreshByUser';
@@ -21,42 +33,7 @@ export interface AvalancheForecastProps {
   forecast_zone_id: number;
 }
 
-export const AvalancheForecast: React.FunctionComponent<AvalancheForecastProps> = ({center_id, date, forecast_zone_id}: AvalancheForecastProps) => {
-  const forecastDate: Date = parseISO(date);
-  const navigation = useNavigation();
-
-  const {width} = useWindowDimensions();
-  const {isLoading: isCenterLoading, isError: isCenterError, data: center, error: centerError, refetch: refetchCenter} = useAvalancheCenterMetadata(center_id);
-  const {
-    isLoading: isForecastLoading,
-    isError: isForecastError,
-    data: forecast,
-    error: forecastError,
-    refetch: refetchForecast,
-  } = useAvalancheForecast(center_id, forecast_zone_id, forecastDate);
-  const {isRefetchingByUser, refetchByUser} = useRefreshByUser(refetchCenter, refetchForecast);
-
-  React.useEffect(() => {
-    if (forecast) {
-      const thisZone: AvalancheForecastZoneSummary | undefined = forecast.forecast_zone.find(zone => zone.id === forecast_zone_id);
-      if (thisZone) {
-        navigation.setOptions({title: thisZone.name});
-      }
-    }
-  }, [forecast]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  if (isForecastLoading || isCenterLoading || !center || !forecast) {
-    return <ActivityIndicator />;
-  }
-  if (isForecastError || isCenterError) {
-    return (
-      <View>
-        {isCenterError && <Text>{`Could not fetch ${center_id} properties: ${centerError?.message}.`}</Text>}
-        {isForecastError && <Text>{`Could not fetch forecast for ${center_id} zone ${forecast_zone_id}: ${forecastError?.message}.`}</Text>}
-      </View>
-    );
-  }
-
+const renderAvalancheTab = (windowWidth: number, center: AvalancheCenter, zone: AvalancheForecastZone, forecast: Product) => {
   let currentDanger: AvalancheDangerForecast | undefined = forecast.danger.find(item => item.valid_day === ForecastPeriod.Current);
   if (!currentDanger || !currentDanger.upper) {
     // sometimes, we get an entry of nulls for today
@@ -80,6 +57,79 @@ export const AvalancheForecast: React.FunctionComponent<AvalancheForecastProps> 
     };
   }
 
+  const elevationBandNames: ElevationBandNames = zone.config.elevation_band_names;
+
+  return (
+    <VStack>
+      <View style={styles.bound}>
+        <AvalancheDangerIcon style={styles.icon} level={highestDangerToday} />
+        <View style={styles.content}>
+          <Text style={styles.title}>THE BOTTOM LINE</Text>
+          <RenderHTML source={{html: forecast.bottom_line}} contentWidth={windowWidth} />
+        </View>
+      </View>
+      <AvalancheDangerTable date={parseISO(forecast.published_time)} current={currentDanger} outlook={outlookDanger} elevation_band_names={elevationBandNames} />
+      <Text style={styles.heading}>Avalanche Problems</Text>
+      {forecast.forecast_avalanche_problems.map((problem, index) => (
+        <AvalancheProblemCard key={`avalanche-problem-${index}`} problem={problem} names={elevationBandNames} />
+      ))}
+      <Text style={styles.heading}>Forecast Discussion</Text>
+      <View style={styles.discussion}>
+        <RenderHTML source={{html: forecast.hazard_discussion}} contentWidth={windowWidth} />
+      </View>
+      <Text style={styles.heading}>Media</Text>
+    </VStack>
+  );
+};
+
+const renderWeatherTab = () => {
+  return <Heading>Weather coming soon</Heading>;
+};
+
+const renderObservationsTab = () => {
+  return <Heading>Observations coming soon</Heading>;
+};
+
+export const AvalancheForecast: React.FunctionComponent<AvalancheForecastProps> = ({center_id, date, forecast_zone_id}: AvalancheForecastProps) => {
+  const forecastDate: Date = parseISO(date);
+
+  const {width: windowWidth} = useWindowDimensions();
+  const {isLoading: isCenterLoading, isError: isCenterError, data: center, error: centerError, refetch: refetchCenter} = useAvalancheCenterMetadata(center_id);
+  const {
+    isLoading: isForecastLoading,
+    isError: isForecastError,
+    data: forecast,
+    error: forecastError,
+    refetch: refetchForecast,
+  } = useAvalancheForecast(center_id, forecast_zone_id, forecastDate);
+  const {isRefetchingByUser, refetchByUser} = useRefreshByUser(refetchCenter, refetchForecast);
+
+  // When navigating from elsewhere in the app, the screen title should already
+  // be set to the zone name. But if we warp directly to a forecast link, we
+  // need to load the zone name dynamically.
+  const navigation = useNavigation();
+  useEffect(() => {
+    if (forecast) {
+      const thisZone: AvalancheForecastZoneSummary | undefined = forecast.forecast_zone.find(zone => zone.id === forecast_zone_id);
+      if (thisZone) {
+        navigation.setOptions({title: thisZone.name});
+      }
+    }
+  }, [forecast, forecast_zone_id, navigation]);
+
+  if (isForecastLoading || isCenterLoading || !center || !forecast) {
+    return <ActivityIndicator />;
+  }
+  if (isForecastError || isCenterError) {
+    return (
+      <View>
+        {isCenterError && <Text>{`Could not fetch ${center_id} properties: ${centerError?.message}.`}</Text>}
+        {isForecastError && <Text>{`Could not fetch forecast for ${center_id} zone ${forecast_zone_id}: ${forecastError?.message}.`}</Text>}
+        {/* TODO(brian): we should add a "Try again" button and have that invoke `refetchByUser` */}
+      </View>
+    );
+  }
+
   const zone: AvalancheForecastZone | undefined = center.zones.find(item => item.id === forecast_zone_id);
   if (!zone) {
     const message = `No such zone ${forecast_zone_id} for center ${center_id}.`;
@@ -94,38 +144,31 @@ export const AvalancheForecast: React.FunctionComponent<AvalancheForecastProps> 
       </View>
     );
   }
-  const elevationBandNames: ElevationBandNames = zone.config.elevation_band_names;
 
   return (
-    <ScrollView style={styles.view} refreshControl={<RefreshControl refreshing={isRefetchingByUser} onRefresh={refetchByUser} />}>
-      <View>
-        <Text style={styles.title}>{zone.name}</Text>
-        <View style={styles.bound}>
-          <AvalancheDangerIcon style={styles.icon} level={highestDangerToday} />
-          <View style={styles.content}>
-            <Text style={styles.title}>THE BOTTOM LINE</Text>
-            <RenderHTML source={{html: forecast.bottom_line}} contentWidth={width} />
-          </View>
-        </View>
-      </View>
-      <AvalancheDangerTable date={parseISO(forecast.published_time)} current={currentDanger} outlook={outlookDanger} elevation_band_names={elevationBandNames} />
-      <Text style={styles.heading}>Avalanche Problems</Text>
-      {forecast.forecast_avalanche_problems.map((problem, index) => (
-        <AvalancheProblemCard key={`avalanche-problem-${index}`} problem={problem} names={elevationBandNames} />
-      ))}
-      <Text style={styles.heading}>Forecast Discussion</Text>
-      <View style={styles.discussion}>
-        <RenderHTML source={{html: forecast.hazard_discussion}} contentWidth={width} />
-      </View>
-      <Text style={styles.heading}>Media</Text>
+    <ScrollView style={StyleSheet.absoluteFillObject} refreshControl={<RefreshControl refreshing={isRefetchingByUser} onRefresh={refetchByUser} />}>
+      <TabControl
+        backgroundColor="white"
+        tabs={[
+          {
+            title: 'Avalanche',
+            render: () => renderAvalancheTab(windowWidth, center, zone, forecast),
+          },
+          {
+            title: 'Weather',
+            render: () => renderWeatherTab(),
+          },
+          {
+            title: 'Observations',
+            render: () => renderObservationsTab(),
+          },
+        ]}
+      />
     </ScrollView>
   );
 };
 
 const styles = StyleSheet.create({
-  view: {
-    ...StyleSheet.absoluteFillObject,
-  },
   icon: {
     position: 'absolute',
     top: -25,

--- a/components/AvalancheForecast.tsx
+++ b/components/AvalancheForecast.tsx
@@ -9,7 +9,6 @@ import {Heading, Text, View, VStack} from 'native-base';
 import {parseISO} from 'date-fns';
 
 import {
-  AvalancheCenter,
   AvalancheDangerForecast,
   AvalancheForecastZone,
   AvalancheForecastZoneSummary,
@@ -21,7 +20,7 @@ import {
 import {AvalancheDangerTable} from './AvalancheDangerTable';
 import {AvalancheDangerIcon} from './AvalancheDangerIcon';
 import {AvalancheProblemCard} from './AvalancheProblemCard';
-import {TabControl} from 'components/TabControl';
+import {Tab, TabControl} from 'components/TabControl';
 import {useAvalancheForecast} from 'hooks/useAvalancheForecast';
 import {useAvalancheCenterMetadata} from 'hooks/useAvalancheCenterMetadata';
 import {useRefreshByUser} from 'hooks/useRefreshByUser';
@@ -33,7 +32,13 @@ export interface AvalancheForecastProps {
   forecast_zone_id: number;
 }
 
-const renderAvalancheTab = (windowWidth: number, center: AvalancheCenter, zone: AvalancheForecastZone, forecast: Product) => {
+interface AvalancheTabProps {
+  windowWidth: number;
+  zone: AvalancheForecastZone;
+  forecast: Product;
+}
+
+const AvalancheTab = React.memo(({windowWidth, zone, forecast}: AvalancheTabProps) => {
   let currentDanger: AvalancheDangerForecast | undefined = forecast.danger.find(item => item.valid_day === ForecastPeriod.Current);
   if (!currentDanger || !currentDanger.upper) {
     // sometimes, we get an entry of nulls for today
@@ -80,13 +85,13 @@ const renderAvalancheTab = (windowWidth: number, center: AvalancheCenter, zone: 
       <Text style={styles.heading}>Media</Text>
     </VStack>
   );
-};
+});
 
-const renderWeatherTab = () => {
+const WeatherTab = () => {
   return <Heading>Weather coming soon</Heading>;
 };
 
-const renderObservationsTab = () => {
+const ObservationsTab = () => {
   return <Heading>Observations coming soon</Heading>;
 };
 
@@ -147,23 +152,17 @@ export const AvalancheForecast: React.FunctionComponent<AvalancheForecastProps> 
 
   return (
     <ScrollView style={StyleSheet.absoluteFillObject} refreshControl={<RefreshControl refreshing={isRefetchingByUser} onRefresh={refetchByUser} />}>
-      <TabControl
-        backgroundColor="white"
-        tabs={[
-          {
-            title: 'Avalanche',
-            render: () => renderAvalancheTab(windowWidth, center, zone, forecast),
-          },
-          {
-            title: 'Weather',
-            render: () => renderWeatherTab(),
-          },
-          {
-            title: 'Observations',
-            render: () => renderObservationsTab(),
-          },
-        ]}
-      />
+      <TabControl backgroundColor="white">
+        <Tab title="Avalanche">
+          <AvalancheTab windowWidth={windowWidth} zone={zone} forecast={forecast} />
+        </Tab>
+        <Tab title="Weather">
+          <WeatherTab />
+        </Tab>
+        <Tab title="Observations">
+          <ObservationsTab />
+        </Tab>
+      </TabControl>
     </ScrollView>
   );
 };

--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -7,11 +7,10 @@ import {FontAwesome5} from '@expo/vector-icons';
 
 import {parseISO} from 'date-fns';
 
+import {DangerScale} from 'components/DangerScale';
 import {AvalancheDangerForecast, DangerLevel, Feature, ForecastPeriod} from 'types/nationalAvalancheCenter';
 import {AvalancheCenterForecastZonePolygons} from './AvalancheCenterForecastZonePolygons';
-import {colorFor} from './AvalancheDangerPyramid';
 import {AvalancheDangerIcon} from './AvalancheDangerIcon';
-import {dangerShortText} from './helpers/dangerText';
 import {useMapLayer} from 'hooks/useMapLayer';
 import {useAvalancheForecastFragment} from 'hooks/useAvalancheForecastFragment';
 import {HomeStackNavigationProps} from 'routes';
@@ -80,42 +79,20 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
           provider={'google'}>
           {isReady && centers.map(center_id => <AvalancheCenterForecastZonePolygons key={center_id} center_id={center_id} setRegion={setRegion} date={date} />)}
         </MapView>
-        <View style={styles.legend}>
-          <View style={styles.legendHeader}>
-            <Text style={styles.legendTitle}>Danger Scale</Text>
-            <FontAwesome5 name="info-circle" size={16} color="blue" />
-          </View>
-          <View style={styles.legendItems}>
-            {Object.keys(DangerLevel)
-              .filter(key => Number.isNaN(+key))
-              .filter(key => DangerLevel[key] > DangerLevel.None)
-              .map(key => DangerLevel[key])
-              .map(level => (
-                <View
-                  key={level}
-                  style={{
-                    ...styles.legendColor,
-                    backgroundColor: colorFor(level).alpha(0.85).string(),
-                    borderBottomLeftRadius: level === DangerLevel.Low ? 4 : 0,
-                    borderTopLeftRadius: level === DangerLevel.Low ? 4 : 0,
-                    borderBottomRightRadius: level === DangerLevel.Extreme ? 4 : 0,
-                    borderTopRightRadius: level === DangerLevel.Extreme ? 4 : 0,
-                  }}
-                />
-              ))}
-          </View>
-          <View style={styles.legendItems}>
-            {Object.keys(DangerLevel)
-              .filter(key => Number.isNaN(+key))
-              .filter(key => DangerLevel[key] > DangerLevel.None)
-              .map(key => DangerLevel[key])
-              .map(level => (
-                <Text key={level} style={styles.legendText}>
-                  {dangerShortText(level)}
-                </Text>
-              ))}
-          </View>
-        </View>
+        <DangerScale
+          style={{
+            position: 'absolute',
+            width: '80%',
+            marginLeft: '10%',
+            bottom: 200,
+            borderStyle: 'solid',
+            borderWidth: 1.2,
+            borderColor: 'rgb(200,202,206)',
+            shadowOffset: {width: 1, height: 2},
+            shadowOpacity: 0.8,
+            shadowColor: 'rgb(157,162,165)',
+          }}
+        />
         <View style={styles.footer}>
           {centers.map(center_id => (
             <AvalancheForecastZoneCards key={center_id} center_id={center_id} date={date} cardStyle={styles.horizontalCard} horizontal={true} />
@@ -278,36 +255,6 @@ const styles = StyleSheet.create({
     display: 'flex',
     flex: 1,
     flexDirection: 'column',
-  },
-  legendHeader: {flex: 1, flexDirection: 'row', alignItems: 'center'},
-  legendTitle: {
-    flex: 0,
-    padding: 8,
-    fontWeight: 'bold',
-  },
-  legendIcon: {
-    flex: 0,
-    width: 16,
-    height: 16,
-  },
-  legendItems: {
-    marginLeft: 8,
-    marginRight: 8,
-    display: 'flex',
-    flex: 1,
-    flexDirection: 'row',
-    justifyContent: 'space-evenly',
-  },
-  legendColor: {
-    flex: 1,
-    height: 16,
-  },
-  legendText: {
-    flex: 1,
-    padding: 2,
-    color: 'black',
-    textAlign: 'center',
-    fontSize: 10,
   },
   footer: {
     position: 'absolute',

--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -215,6 +215,7 @@ export const AvalancheForecastZoneCard: React.FunctionComponent<{
     <TouchableOpacity
       onPress={() => {
         navigation.navigate('forecast', {
+          zoneName: feature.properties.name,
           center_id: feature.properties.center_id,
           forecast_zone_id: feature.id,
           date: date,

--- a/components/AvalancheForecastZonePolygon.tsx
+++ b/components/AvalancheForecastZonePolygon.tsx
@@ -132,6 +132,7 @@ export const AvalancheForecastZonePolygon: React.FunctionComponent<AvalancheFore
       tappable={true}
       onPress={() => {
         navigation.navigate('forecast', {
+          zoneName: feature.properties.name,
           center_id: feature.properties.center_id,
           forecast_zone_id: feature.id,
           date: date,

--- a/components/DangerScale.tsx
+++ b/components/DangerScale.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+
+import {StyleSheet, Text, View, ViewStyle} from 'react-native';
+import {FontAwesome5} from '@expo/vector-icons';
+
+import {DangerLevel} from 'types/nationalAvalancheCenter';
+import {colorFor} from './AvalancheDangerPyramid';
+import {dangerShortText} from './helpers/dangerText';
+
+export interface DangerScaleProps {
+  style?: ViewStyle;
+}
+
+export const DangerScale: React.FunctionComponent<DangerScaleProps> = ({style}: DangerScaleProps) => {
+  return (
+    <View style={{...styles.legend, ...style}}>
+      <View style={styles.legendHeader}>
+        <Text style={styles.legendTitle}>Danger Scale</Text>
+        <FontAwesome5 name="info-circle" size={16} color="blue" />
+      </View>
+      <View style={styles.legendItems}>
+        {Object.keys(DangerLevel)
+          .filter(key => Number.isNaN(+key))
+          .filter(key => DangerLevel[key] > DangerLevel.None)
+          .map(key => DangerLevel[key])
+          .map(level => (
+            <View
+              key={level}
+              style={{
+                ...styles.legendColor,
+                backgroundColor: colorFor(level).alpha(0.85).string(),
+                borderBottomLeftRadius: level === DangerLevel.Low ? 4 : 0,
+                borderTopLeftRadius: level === DangerLevel.Low ? 4 : 0,
+                borderBottomRightRadius: level === DangerLevel.Extreme ? 4 : 0,
+                borderTopRightRadius: level === DangerLevel.Extreme ? 4 : 0,
+              }}
+            />
+          ))}
+      </View>
+      <View style={styles.legendItems}>
+        {Object.keys(DangerLevel)
+          .filter(key => Number.isNaN(+key))
+          .filter(key => DangerLevel[key] > DangerLevel.None)
+          .map(key => DangerLevel[key])
+          .map(level => (
+            <Text key={level} style={styles.legendText}>
+              {dangerShortText(level)}
+            </Text>
+          ))}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  legend: {
+    backgroundColor: 'white',
+    padding: 8,
+    borderRadius: 8,
+    display: 'flex',
+    flex: 1,
+    flexDirection: 'column',
+  },
+  legendHeader: {flex: 1, flexDirection: 'row', alignItems: 'center'},
+  legendTitle: {
+    flex: 0,
+    padding: 8,
+    fontWeight: 'bold',
+  },
+  legendIcon: {
+    flex: 0,
+    width: 16,
+    height: 16,
+  },
+  legendItems: {
+    marginLeft: 8,
+    marginRight: 8,
+    display: 'flex',
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-evenly',
+  },
+  legendColor: {
+    flex: 1,
+    height: 16,
+  },
+  legendText: {
+    flex: 1,
+    padding: 2,
+    color: 'black',
+    textAlign: 'center',
+    fontSize: 10,
+  },
+});

--- a/components/TabControl.tsx
+++ b/components/TabControl.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {PropsWithChildren, ReactElement, useState} from 'react';
 
 import {TouchableOpacity} from 'react-native';
 
@@ -6,25 +6,26 @@ import {HStack, Text, VStack, useToken} from 'native-base';
 
 export interface TabProps {
   title: string;
-  render: () => JSX.Element | null;
 }
+
+export const Tab: React.FunctionComponent<PropsWithChildren<TabProps>> = ({children}) => <>{children}</>;
 
 export interface TabControlProps {
-  tabs: TabProps[];
   backgroundColor: string;
+  children: ReactElement<TabProps> | Array<ReactElement<TabProps>>;
 }
 
-export const TabControl: React.FunctionComponent<TabControlProps> = ({tabs, backgroundColor}: TabControlProps) => {
+export const TabControl: React.FunctionComponent<TabControlProps> = ({children, backgroundColor}) => {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [selectedTextColor, textColor] = useToken('colors', ['primary.600', 'darkText']);
   const [fontSizeMd] = useToken('fontSizes', ['md']);
-  console.log(selectedTextColor, textColor);
+  const tabCount = React.Children.count(children);
 
   const tabStyle = {
     borderBottomColor: backgroundColor,
     borderBottomWidth: 4,
     borderRadius: 0,
-    width: '33%',
+    width: `${Math.round(10000.0 / tabCount) / 100}%`,
   } as const;
   const selectedTabStyle = {
     ...tabStyle,
@@ -45,13 +46,13 @@ export const TabControl: React.FunctionComponent<TabControlProps> = ({tabs, back
   return (
     <VStack style={{width: '100%', backgroundColor}}>
       <HStack justifyContent="space-evenly" alignItems="center" style={{width: '100%', backgroundColor, height: 64}}>
-        {tabs.map(({title}, index) => (
+        {React.Children.map(children, (child, index) => (
           <TouchableOpacity onPress={() => setSelectedIndex(index)} style={selectedIndex === index ? selectedTabStyle : tabStyle} key={`tabcontrol-item-${index}`}>
-            <Text style={selectedIndex === index ? selectedTextStyle : textStyle}>{title}</Text>
+            <Text style={selectedIndex === index ? selectedTextStyle : textStyle}>{child.props.title}</Text>
           </TouchableOpacity>
         ))}
       </HStack>
-      {tabs[selectedIndex]?.render()}
+      {React.Children.map(children, (child, index) => index === selectedIndex && child)}
     </VStack>
   );
 };

--- a/components/TabControl.tsx
+++ b/components/TabControl.tsx
@@ -1,0 +1,57 @@
+import React, {useState} from 'react';
+
+import {TouchableOpacity} from 'react-native';
+
+import {HStack, Text, VStack, useToken} from 'native-base';
+
+export interface TabProps {
+  title: string;
+  render: () => JSX.Element | null;
+}
+
+export interface TabControlProps {
+  tabs: TabProps[];
+  backgroundColor: string;
+}
+
+export const TabControl: React.FunctionComponent<TabControlProps> = ({tabs, backgroundColor}: TabControlProps) => {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [selectedTextColor, textColor] = useToken('colors', ['primary.600', 'darkText']);
+  const [fontSizeMd] = useToken('fontSizes', ['md']);
+  console.log(selectedTextColor, textColor);
+
+  const tabStyle = {
+    borderBottomColor: backgroundColor,
+    borderBottomWidth: 4,
+    borderRadius: 0,
+    width: '33%',
+  } as const;
+  const selectedTabStyle = {
+    ...tabStyle,
+    borderBottomColor: selectedTextColor,
+  } as const;
+  const textStyle = {
+    textAlign: 'center',
+    padding: 8,
+    color: textColor,
+    fontSize: fontSizeMd,
+  } as const;
+  const selectedTextStyle = {
+    ...textStyle,
+    color: selectedTextColor,
+    fontWeight: 'bold',
+  } as const;
+
+  return (
+    <VStack style={{width: '100%', backgroundColor}}>
+      <HStack justifyContent="space-evenly" alignItems="center" style={{width: '100%', backgroundColor, height: 64}}>
+        {tabs.map(({title}, index) => (
+          <TouchableOpacity onPress={() => setSelectedIndex(index)} style={selectedIndex === index ? selectedTabStyle : tabStyle} key={`tabcontrol-item-${index}`}>
+            <Text style={selectedIndex === index ? selectedTextStyle : textStyle}>{title}</Text>
+          </TouchableOpacity>
+        ))}
+      </HStack>
+      {tabs[selectedIndex]?.render()}
+    </VStack>
+  );
+};

--- a/components/screens/ForecastScreen.tsx
+++ b/components/screens/ForecastScreen.tsx
@@ -8,10 +8,10 @@ import {AvalancheForecast} from 'components/AvalancheForecast';
 import {HomeStackParamList} from 'routes';
 
 export const ForecastScreen = ({route}: NativeStackScreenProps<HomeStackParamList, 'forecast'>) => {
-  const {center_id, forecast_zone_id, date} = route.params;
+  const {center_id, forecast_zone_id, date, zoneName} = route.params;
   return (
     <SafeAreaView style={styles.container}>
-      <AvalancheForecast center_id={center_id} forecast_zone_id={forecast_zone_id} date={date} />
+      <AvalancheForecast center_id={center_id} forecast_zone_id={forecast_zone_id} date={date} zoneName={zoneName} />
     </SafeAreaView>
   );
 };

--- a/components/screens/HomeScreen.tsx
+++ b/components/screens/HomeScreen.tsx
@@ -13,7 +13,7 @@ export const AvalancheCenterStackScreen = (center_id: string, date: string) => {
         name="forecast"
         component={ForecastScreen}
         initialParams={{center_id: center_id, date: date}}
-        options={({route}) => ({title: String(route.params.forecast_zone_id)})}
+        options={({route}) => ({title: String(route.params.zoneName)})}
       />
     </AvalancheCenterStack.Navigator>
   );

--- a/routes.ts
+++ b/routes.ts
@@ -25,6 +25,7 @@ export type HomeStackParamList = {
     date: string;
   };
   forecast: {
+    zoneName: string;
     center_id: string;
     forecast_zone_id: number;
     date: string;


### PR DESCRIPTION
- set the forecast zone title immediately, if we have it
- set global value for `darkText` to match Figma mocks
- extract `DangerScale` component from MapView, since we'll need it in Forecast view
- create `TabControl` component and add 3 tabs to top of forecast page 