### PR TITLE
Add header to avalanche forecast tab

### DIFF
--- a/components/forecast/AvalancheForecast.tsx
+++ b/components/forecast/AvalancheForecast.tsx
@@ -1,29 +1,19 @@
 import React, {useEffect} from 'react';
 
 import {ActivityIndicator, Alert, RefreshControl, ScrollView, StyleSheet, useWindowDimensions} from 'react-native';
-import RenderHTML from 'react-native-render-html';
 import {useNavigation} from '@react-navigation/native';
 
-import {Heading, Text, View, VStack} from 'native-base';
+import {Heading, Text, View} from 'native-base';
 
 import {parseISO} from 'date-fns';
 
-import {
-  AvalancheDangerForecast,
-  AvalancheForecastZone,
-  AvalancheForecastZoneSummary,
-  DangerLevel,
-  ElevationBandNames,
-  ForecastPeriod,
-  Product,
-} from 'types/nationalAvalancheCenter';
-import {AvalancheDangerTable} from './AvalancheDangerTable';
-import {AvalancheDangerIcon} from './AvalancheDangerIcon';
-import {AvalancheProblemCard} from './AvalancheProblemCard';
+import {AvalancheForecastZone, AvalancheForecastZoneSummary} from 'types/nationalAvalancheCenter';
 import {Tab, TabControl} from 'components/TabControl';
 import {useAvalancheForecast} from 'hooks/useAvalancheForecast';
 import {useAvalancheCenterMetadata} from 'hooks/useAvalancheCenterMetadata';
 import {useRefreshByUser} from 'hooks/useRefreshByUser';
+
+import {AvalancheTab} from './AvalancheTab';
 
 export interface AvalancheForecastProps {
   zoneName: string;
@@ -31,61 +21,6 @@ export interface AvalancheForecastProps {
   date: string;
   forecast_zone_id: number;
 }
-
-interface AvalancheTabProps {
-  windowWidth: number;
-  zone: AvalancheForecastZone;
-  forecast: Product;
-}
-
-const AvalancheTab = React.memo(({windowWidth, zone, forecast}: AvalancheTabProps) => {
-  let currentDanger: AvalancheDangerForecast | undefined = forecast.danger.find(item => item.valid_day === ForecastPeriod.Current);
-  if (!currentDanger || !currentDanger.upper) {
-    // sometimes, we get an entry of nulls for today
-    currentDanger = {
-      lower: DangerLevel.None,
-      middle: DangerLevel.None,
-      upper: DangerLevel.None,
-      valid_day: ForecastPeriod.Tomorrow,
-    };
-  }
-  const highestDangerToday: DangerLevel = Math.max(currentDanger.lower, currentDanger.middle, currentDanger.upper);
-
-  let outlookDanger: AvalancheDangerForecast | undefined = forecast.danger.find(item => item.valid_day === ForecastPeriod.Tomorrow);
-  if (!outlookDanger || !outlookDanger.upper) {
-    // sometimes, we get an entry of nulls for tomorrow
-    outlookDanger = {
-      lower: DangerLevel.None,
-      middle: DangerLevel.None,
-      upper: DangerLevel.None,
-      valid_day: ForecastPeriod.Tomorrow,
-    };
-  }
-
-  const elevationBandNames: ElevationBandNames = zone.config.elevation_band_names;
-
-  return (
-    <VStack>
-      <View style={styles.bound}>
-        <AvalancheDangerIcon style={styles.icon} level={highestDangerToday} />
-        <View style={styles.content}>
-          <Text style={styles.title}>THE BOTTOM LINE</Text>
-          <RenderHTML source={{html: forecast.bottom_line}} contentWidth={windowWidth} />
-        </View>
-      </View>
-      <AvalancheDangerTable date={parseISO(forecast.published_time)} current={currentDanger} outlook={outlookDanger} elevation_band_names={elevationBandNames} />
-      <Text style={styles.heading}>Avalanche Problems</Text>
-      {forecast.forecast_avalanche_problems.map((problem, index) => (
-        <AvalancheProblemCard key={`avalanche-problem-${index}`} problem={problem} names={elevationBandNames} />
-      ))}
-      <Text style={styles.heading}>Forecast Discussion</Text>
-      <View style={styles.discussion}>
-        <RenderHTML source={{html: forecast.hazard_discussion}} contentWidth={windowWidth} />
-      </View>
-      <Text style={styles.heading}>Media</Text>
-    </VStack>
-  );
-});
 
 const WeatherTab = () => {
   return <Heading>Weather coming soon</Heading>;
@@ -166,44 +101,3 @@ export const AvalancheForecast: React.FunctionComponent<AvalancheForecastProps> 
     </ScrollView>
   );
 };
-
-const styles = StyleSheet.create({
-  icon: {
-    position: 'absolute',
-    top: -25,
-    left: -25,
-    height: 50,
-  },
-  bound: {
-    margin: 25,
-    borderStyle: 'solid',
-    borderWidth: 1.2,
-    borderColor: 'rgb(200,202,206)',
-    shadowOffset: {width: 1, height: 2},
-    shadowOpacity: 0.8,
-    shadowColor: 'rgb(157,162,165)',
-  },
-  content: {
-    flexDirection: 'column',
-    paddingTop: 15,
-    paddingLeft: 15,
-    paddingBottom: 0,
-    paddingRight: 5,
-  },
-  title: {
-    fontWeight: 'bold',
-  },
-  heading: {
-    textTransform: 'uppercase',
-    fontWeight: 'bold',
-    paddingBottom: 10,
-    marginHorizontal: 10,
-  },
-  discussion: {
-    flexDirection: 'column',
-    paddingTop: 0,
-    paddingLeft: 10,
-    paddingBottom: 0,
-    paddingRight: 10,
-  },
-});

--- a/components/forecast/AvalancheTab.tsx
+++ b/components/forecast/AvalancheTab.tsx
@@ -1,0 +1,140 @@
+import React from 'react';
+
+import {StyleSheet} from 'react-native';
+import RenderHTML from 'react-native-render-html';
+
+import {Divider, Heading, HStack, Text, View, VStack} from 'native-base';
+
+import {format, parseISO} from 'date-fns';
+
+import {AvalancheDangerForecast, AvalancheForecastZone, DangerLevel, ElevationBandNames, ForecastPeriod, Product} from 'types/nationalAvalancheCenter';
+import {AvalancheDangerTable} from 'components/AvalancheDangerTable';
+import {AvalancheDangerIcon} from 'components/AvalancheDangerIcon';
+import {AvalancheProblemCard} from 'components/AvalancheProblemCard';
+
+interface AvalancheTabProps {
+  windowWidth: number;
+  zone: AvalancheForecastZone;
+  forecast: Product;
+}
+
+const dateToString = (dateString: string | undefined): string => {
+  if (!dateString) {
+    return 'Unknown';
+  }
+  const date = parseISO(dateString);
+  return format(date, `EEE, MMM d yyyy h:mm a`);
+};
+
+export const AvalancheTab: React.FunctionComponent<AvalancheTabProps> = React.memo(({windowWidth, zone, forecast}) => {
+  console.dir(forecast);
+  let currentDanger: AvalancheDangerForecast | undefined = forecast.danger.find(item => item.valid_day === ForecastPeriod.Current);
+  if (!currentDanger || !currentDanger.upper) {
+    // sometimes, we get an entry of nulls for today
+    currentDanger = {
+      lower: DangerLevel.None,
+      middle: DangerLevel.None,
+      upper: DangerLevel.None,
+      valid_day: ForecastPeriod.Tomorrow,
+    };
+  }
+  const highestDangerToday: DangerLevel = Math.max(currentDanger.lower, currentDanger.middle, currentDanger.upper);
+
+  let outlookDanger: AvalancheDangerForecast | undefined = forecast.danger.find(item => item.valid_day === ForecastPeriod.Tomorrow);
+  if (!outlookDanger || !outlookDanger.upper) {
+    // sometimes, we get an entry of nulls for tomorrow
+    outlookDanger = {
+      lower: DangerLevel.None,
+      middle: DangerLevel.None,
+      upper: DangerLevel.None,
+      valid_day: ForecastPeriod.Tomorrow,
+    };
+  }
+
+  const elevationBandNames: ElevationBandNames = zone.config.elevation_band_names;
+
+  return (
+    <VStack space="4" px="4">
+      <Heading>Avalanche Forecast</Heading>
+      <Divider orientation="horizontal" bg="light.200" />
+      <HStack justifyContent="space-evenly" space="2">
+        <VStack space="2" style={{flex: 1}}>
+          <Text bold style={{textTransform: 'uppercase'}}>
+            Issued
+          </Text>
+          <Text>{dateToString(forecast.published_time)}</Text>
+        </VStack>
+        <VStack space="2" style={{flex: 1}}>
+          <Text bold style={{textTransform: 'uppercase'}}>
+            Expires
+          </Text>
+          <Text>{dateToString(forecast.expires_time)}</Text>
+        </VStack>
+        <VStack space="2" style={{flex: 1}}>
+          <Text bold style={{textTransform: 'uppercase'}}>
+            Author
+          </Text>
+          <Text>{forecast.author || 'Unknown'}</Text>
+        </VStack>
+      </HStack>
+      <View style={styles.bound}>
+        <AvalancheDangerIcon style={styles.icon} level={highestDangerToday} />
+        <View style={styles.content}>
+          <Text style={styles.title}>THE BOTTOM LINE</Text>
+          <RenderHTML source={{html: forecast.bottom_line}} contentWidth={windowWidth} />
+        </View>
+      </View>
+      <AvalancheDangerTable date={parseISO(forecast.published_time)} current={currentDanger} outlook={outlookDanger} elevation_band_names={elevationBandNames} />
+      <Text style={styles.heading}>Avalanche Problems</Text>
+      {forecast.forecast_avalanche_problems.map((problem, index) => (
+        <AvalancheProblemCard key={`avalanche-problem-${index}`} problem={problem} names={elevationBandNames} />
+      ))}
+      <Text style={styles.heading}>Forecast Discussion</Text>
+      <View style={styles.discussion}>
+        <RenderHTML source={{html: forecast.hazard_discussion}} contentWidth={windowWidth} />
+      </View>
+      <Text style={styles.heading}>Media</Text>
+    </VStack>
+  );
+});
+
+const styles = StyleSheet.create({
+  icon: {
+    position: 'absolute',
+    top: -25,
+    left: -25,
+    height: 50,
+  },
+  bound: {
+    margin: 25,
+    borderStyle: 'solid',
+    borderWidth: 1.2,
+    borderColor: 'rgb(200,202,206)',
+    shadowOffset: {width: 1, height: 2},
+    shadowOpacity: 0.8,
+    shadowColor: 'rgb(157,162,165)',
+  },
+  content: {
+    flexDirection: 'column',
+    paddingTop: 15,
+    paddingLeft: 15,
+    paddingBottom: 0,
+    paddingRight: 5,
+  },
+  title: {
+    fontWeight: 'bold',
+  },
+  heading: {
+    textTransform: 'uppercase',
+    fontWeight: 'bold',
+    paddingBottom: 10,
+    marginHorizontal: 10,
+  },
+  discussion: {
+    flexDirection: 'column',
+    paddingTop: 0,
+    paddingLeft: 10,
+    paddingBottom: 0,
+    paddingRight: 10,
+  },
+});

--- a/components/screens/ForecastScreen.tsx
+++ b/components/screens/ForecastScreen.tsx
@@ -4,7 +4,7 @@ import {SafeAreaView} from 'react-native-safe-area-context';
 
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 
-import {AvalancheForecast} from 'components/AvalancheForecast';
+import {AvalancheForecast} from 'components/forecast/AvalancheForecast';
 import {HomeStackParamList} from 'routes';
 
 export const ForecastScreen = ({route}: NativeStackScreenProps<HomeStackParamList, 'forecast'>) => {


### PR DESCRIPTION
- Split apart rendering for avalanche forecast into its own component (weather and obs will live next to it)
- Add the date / author header to the avalanche forecast tab

<img width="330" alt="image" src="https://user-images.githubusercontent.com/101196/210287616-4139407c-67fc-4036-9234-344320bd8678.png">
