### PR TITLE
Make reusable Card component, rework top of avy forecast to use it

### DIFF
--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -1,30 +1,23 @@
-import React, { PropsWithChildren, ReactNode, useCallback } from 'react';
-import { compareDesc, format, parseISO, sub } from 'date-fns';
-import { ActivityIndicator, View, Text, FlatList, TouchableOpacity, useWindowDimensions } from 'react-native';
-import { HomeStackNavigationProps } from 'routes';
-import { useNavigation } from '@react-navigation/native';
-import { Box, Divider, VStack, HStack, Text as NBText, Heading } from 'native-base';
-import { useMapLayer } from 'hooks/useMapLayer';
-import { geoContains } from 'd3-geo';
-import RenderHTML from 'react-native-render-html';
+import React, {PropsWithChildren, ReactNode, useCallback} from 'react';
+import {TouchableOpacity} from 'react-native';
+import {Box, IBoxProps, Divider, VStack} from 'native-base';
 
-export interface CardProps {
+export interface CardProps extends IBoxProps {
   header?: ReactNode;
   onPress?: () => void;
+  borderRadius?: number;
+  borderColor?: string;
 }
 
-export const Card: React.FunctionComponent<PropsWithChildren<CardProps>> = ({ header, onPress, children }) => {
-  const pressHandler = useCallback(() => (
-    onPress?.()
-    ), [onPress]);
+export const Card: React.FunctionComponent<PropsWithChildren<CardProps>> = ({header, onPress, borderColor, borderRadius, children, ...boxProps}) => {
+  const pressHandler = useCallback(() => onPress?.(), [onPress]);
 
   return (
-    <Box px="2" pt="2">
-      <TouchableOpacity
-        onPress={pressHandler}>
-        <Box bg="white" borderWidth="2" borderRadius="8" borderColor="light.200" p="4">
+    <Box {...boxProps}>
+      <TouchableOpacity onPress={pressHandler}>
+        <Box bg="white" borderWidth="2" borderRadius={borderRadius ?? 8} borderColor={borderColor ?? 'light.200'} p="4">
           <VStack space="2">
-            {header}
+            <>{header}</>
             <Divider orientation="horizontal" bg="light.200" />
             <>{children}</>
           </VStack>

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -1,0 +1,35 @@
+import React, { PropsWithChildren, ReactNode, useCallback } from 'react';
+import { compareDesc, format, parseISO, sub } from 'date-fns';
+import { ActivityIndicator, View, Text, FlatList, TouchableOpacity, useWindowDimensions } from 'react-native';
+import { HomeStackNavigationProps } from 'routes';
+import { useNavigation } from '@react-navigation/native';
+import { Box, Divider, VStack, HStack, Text as NBText, Heading } from 'native-base';
+import { useMapLayer } from 'hooks/useMapLayer';
+import { geoContains } from 'd3-geo';
+import RenderHTML from 'react-native-render-html';
+
+export interface CardProps {
+  header?: ReactNode;
+  onPress?: () => void;
+}
+
+export const Card: React.FunctionComponent<PropsWithChildren<CardProps>> = ({ header, onPress, children }) => {
+  const pressHandler = useCallback(() => (
+    onPress?.()
+    ), [onPress]);
+
+  return (
+    <Box px="2" pt="2">
+      <TouchableOpacity
+        onPress={pressHandler}>
+        <Box bg="white" borderWidth="2" borderRadius="8" borderColor="light.200" p="4">
+          <VStack space="2">
+            {header}
+            <Divider orientation="horizontal" bg="light.200" />
+            <>{children}</>
+          </VStack>
+        </Box>
+      </TouchableOpacity>
+    </Box>
+  );
+};

--- a/components/Observations.tsx
+++ b/components/Observations.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
-import {OverviewFragment, useObservationsQuery} from 'hooks/useObservations';
+
 import {compareDesc, format, parseISO, sub} from 'date-fns';
 import {ActivityIndicator, View, Text, FlatList, TouchableOpacity, useWindowDimensions} from 'react-native';
-import {HomeStackNavigationProps} from 'routes';
 import {useNavigation} from '@react-navigation/native';
 import {Box, Divider, VStack, HStack, Text as NBText, Heading} from 'native-base';
-import {useMapLayer} from 'hooks/useMapLayer';
 import {geoContains} from 'd3-geo';
 import RenderHTML from 'react-native-render-html';
+
+import {Card} from 'components/Card';
+import {OverviewFragment, useObservationsQuery} from 'hooks/useObservations';
+import {HomeStackNavigationProps} from 'routes';
+import {useMapLayer} from 'hooks/useMapLayer';
 
 // TODO: we could show the Avy center logo for obs that come from forecasters
 
@@ -83,32 +86,27 @@ export const ObservationSummaryCard: React.FunctionComponent<{
   const navigation = useNavigation<HomeStackNavigationProps>();
   const {width} = useWindowDimensions();
   return (
-    <Box px="2" pt="2">
-      <TouchableOpacity
-        onPress={() => {
-          navigation.navigate('observation', {
-            id: observation.id,
-          });
-        }}>
-        <Box bg="white" borderWidth="2" borderRadius="8" borderColor="light.200" p="4">
-          <VStack space="2">
-            <HStack justifyContent="space-between" alignItems="center">
-              <Heading size="md" flex={1} mr="8" fontWeight="normal">
-                {zone + ' - ' + observation.locationName}
-              </Heading>
-              <Heading size="md" color="light.400" fontWeight="normal">
-                {observation.startDate}
-              </Heading>
-            </HStack>
-            <Divider orientation="horizontal" bg="light.200" />
-            <RenderHTML source={{html: observation.observationSummary}} contentWidth={width} />
-            <HStack justifyContent="space-between" pt="4">
-              <NBText color="light.400">{observation.name}</NBText>
-              <NBText color="light.400">{observation.observerType}</NBText>
-            </HStack>
-          </VStack>
-        </Box>
-      </TouchableOpacity>
-    </Box>
+    <Card
+      onPress={() => {
+        navigation.navigate('observation', {
+          id: observation.id,
+        });
+      }}
+      header={
+        <HStack justifyContent="space-between" alignItems="center">
+          <Heading size="md" flex={1} mr="8" fontWeight="normal">
+            {zone + ' - ' + observation.locationName}
+          </Heading>
+          <Heading size="md" color="light.400" fontWeight="normal">
+            {observation.startDate}
+          </Heading>
+        </HStack>
+      }>
+      <RenderHTML source={{html: observation.observationSummary}} contentWidth={width} />
+      <HStack justifyContent="space-between" pt="4">
+        <NBText color="light.400">{observation.name}</NBText>
+        <NBText color="light.400">{observation.observerType}</NBText>
+      </HStack>
+    </Card>
   );
 };

--- a/components/Observations.tsx
+++ b/components/Observations.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
 import {compareDesc, format, parseISO, sub} from 'date-fns';
-import {ActivityIndicator, View, Text, FlatList, TouchableOpacity, useWindowDimensions} from 'react-native';
+import {ActivityIndicator, View, Text, FlatList, useWindowDimensions} from 'react-native';
 import {useNavigation} from '@react-navigation/native';
-import {Box, Divider, VStack, HStack, Text as NBText, Heading} from 'native-base';
+import {HStack, Text as NBText, Heading} from 'native-base';
 import {geoContains} from 'd3-geo';
 import RenderHTML from 'react-native-render-html';
 
@@ -87,6 +87,8 @@ export const ObservationSummaryCard: React.FunctionComponent<{
   const {width} = useWindowDimensions();
   return (
     <Card
+      px="2"
+      pt="2"
       onPress={() => {
         navigation.navigate('observation', {
           id: observation.id,

--- a/components/forecast/AvalancheTab.tsx
+++ b/components/forecast/AvalancheTab.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {StyleSheet} from 'react-native';
 import RenderHTML from 'react-native-render-html';
 
-import {Divider, Heading, HStack, Text, View, VStack} from 'native-base';
+import {Heading, HStack, Text, View, VStack} from 'native-base';
 
 import {format, parseISO} from 'date-fns';
 
@@ -11,6 +11,7 @@ import {AvalancheDangerForecast, AvalancheForecastZone, DangerLevel, ElevationBa
 import {AvalancheDangerTable} from 'components/AvalancheDangerTable';
 import {AvalancheDangerIcon} from 'components/AvalancheDangerIcon';
 import {AvalancheProblemCard} from 'components/AvalancheProblemCard';
+import {Card} from 'components/Card';
 
 interface AvalancheTabProps {
   windowWidth: number;
@@ -54,29 +55,29 @@ export const AvalancheTab: React.FunctionComponent<AvalancheTabProps> = React.me
   const elevationBandNames: ElevationBandNames = zone.config.elevation_band_names;
 
   return (
-    <VStack space="4" px="4">
-      <Heading>Avalanche Forecast</Heading>
-      <Divider orientation="horizontal" bg="light.200" />
-      <HStack justifyContent="space-evenly" space="2">
-        <VStack space="2" style={{flex: 1}}>
-          <Text bold style={{textTransform: 'uppercase'}}>
-            Issued
-          </Text>
-          <Text>{dateToString(forecast.published_time)}</Text>
-        </VStack>
-        <VStack space="2" style={{flex: 1}}>
-          <Text bold style={{textTransform: 'uppercase'}}>
-            Expires
-          </Text>
-          <Text>{dateToString(forecast.expires_time)}</Text>
-        </VStack>
-        <VStack space="2" style={{flex: 1}}>
-          <Text bold style={{textTransform: 'uppercase'}}>
-            Author
-          </Text>
-          <Text>{forecast.author || 'Unknown'}</Text>
-        </VStack>
-      </HStack>
+    <VStack space="4" bgColor={'#f0f2f5'}>
+      <Card paddingTop={2} borderRadius={0} borderColor="white" header={<Heading>Avalanche Forecast</Heading>}>
+        <HStack justifyContent="space-evenly" space="2">
+          <VStack space="2" style={{flex: 1}}>
+            <Text bold style={{textTransform: 'uppercase'}}>
+              Issued
+            </Text>
+            <Text>{dateToString(forecast.published_time)}</Text>
+          </VStack>
+          <VStack space="2" style={{flex: 1}}>
+            <Text bold style={{textTransform: 'uppercase'}}>
+              Expires
+            </Text>
+            <Text>{dateToString(forecast.expires_time)}</Text>
+          </VStack>
+          <VStack space="2" style={{flex: 1}}>
+            <Text bold style={{textTransform: 'uppercase'}}>
+              Author
+            </Text>
+            <Text>{forecast.author || 'Unknown'}</Text>
+          </VStack>
+        </HStack>
+      </Card>
       <View style={styles.bound}>
         <AvalancheDangerIcon style={styles.icon} level={highestDangerToday} />
         <View style={styles.content}>

--- a/components/forecast/AvalancheTab.tsx
+++ b/components/forecast/AvalancheTab.tsx
@@ -23,7 +23,7 @@ const dateToString = (dateString: string | undefined): string => {
     return 'Unknown';
   }
   const date = parseISO(dateString);
-  return format(date, `EEE, MMM d yyyy h:mm a`);
+  return format(date, `EEE, MMM d, yyyy h:mm a`);
 };
 
 export const AvalancheTab: React.FunctionComponent<AvalancheTabProps> = React.memo(({windowWidth, zone, forecast}) => {


### PR DESCRIPTION
pretty close to the figma mocks now (or at least one version of them 😄). not going to spend more time sweating pixels at this point when the designs are still in flux. 

figma | app
--- | ---
<img width="373" alt="image" src="https://user-images.githubusercontent.com/101196/210397888-31a31d5f-fd16-4089-921e-f78234da598f.png"> | <img width="321" alt="image" src="https://user-images.githubusercontent.com/101196/210397653-09f520e9-d60d-4ce7-96b1-b44f6cab96b9.png">
