### PR TITLE
Map screen - forecast card styling

### DIFF
--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -14,7 +14,7 @@ import {HomeStackNavigationProps} from 'routes';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {Body, BodySmSemibold, Caption1, Caption1Black, Title3Black} from 'components/text';
 import {colorFor} from './AvalancheDangerPyramid';
-import {dateToString} from 'utils/date';
+import {utcDateToLocalTimeString} from 'utils/date';
 
 export const defaultRegion: Region = {
   // TODO(skuznets): add a sane default for the US?
@@ -159,10 +159,10 @@ const AvalancheForecastZoneCard: React.FunctionComponent<{
           <VStack py={2}>
             <Text>
               <Caption1Black>Published: </Caption1Black>
-              <Caption1>{dateToString(feature.properties.start_date)}</Caption1>
+              <Caption1>{utcDateToLocalTimeString(feature.properties.start_date)}</Caption1>
               {'\n'}
               <Caption1Black>Expires: </Caption1Black>
-              <Caption1>{dateToString(feature.properties.end_date)}</Caption1>
+              <Caption1>{utcDateToLocalTimeString(feature.properties.end_date)}</Caption1>
             </Text>
           </VStack>
           <Text>

--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -1,7 +1,7 @@
 import React, {useState} from 'react';
 
 import {ActivityIndicator, StyleSheet, Text, TouchableOpacity, useWindowDimensions} from 'react-native';
-import {Alert, Center, CloseIcon, FlatList, HStack, IconButton, View, VStack} from 'native-base';
+import {Alert, Center, FlatList, HStack, View, VStack} from 'native-base';
 import MapView, {Region} from 'react-native-maps';
 import {useNavigation} from '@react-navigation/native';
 
@@ -12,7 +12,7 @@ import {AvalancheDangerIcon} from './AvalancheDangerIcon';
 import {useMapLayer} from 'hooks/useMapLayer';
 import {HomeStackNavigationProps} from 'routes';
 import {SafeAreaView} from 'react-native-safe-area-context';
-import {Body, BodySmSemibold, Caption1, Caption1Black, FeatureTitleBlack, Title3Black} from 'components/text';
+import {Body, BodySmSemibold, Caption1, Caption1Black, Title3Black} from 'components/text';
 import {colorFor} from './AvalancheDangerPyramid';
 import {dateToString} from 'utils/date';
 
@@ -48,7 +48,7 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
     latitudeDelta: 1.05 * region.latitudeDelta,
     longitudeDelta: 1.05 * region.longitudeDelta,
   };
-  const {isLoading, isError, data: mapLayer, error} = useMapLayer(center);
+  const {isLoading, isError, data: mapLayer} = useMapLayer(center);
 
   return (
     <>

--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -99,7 +99,6 @@ const AvalancheForecastZoneCards: React.FunctionComponent<{
   return (
     <FlatList
       horizontal
-      px="4"
       width="100%"
       position="absolute"
       bottom="4"

--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -1,7 +1,7 @@
 import React, {useState} from 'react';
 
-import {StyleSheet, Text, TouchableOpacity, useWindowDimensions} from 'react-native';
-import {FlatList, HStack, View, VStack} from 'native-base';
+import {ActivityIndicator, StyleSheet, Text, TouchableOpacity, useWindowDimensions} from 'react-native';
+import {Alert, Center, CloseIcon, FlatList, HStack, IconButton, View, VStack} from 'native-base';
 import MapView, {Region} from 'react-native-maps';
 import {useNavigation} from '@react-navigation/native';
 
@@ -12,7 +12,7 @@ import {AvalancheDangerIcon} from './AvalancheDangerIcon';
 import {useMapLayer} from 'hooks/useMapLayer';
 import {HomeStackNavigationProps} from 'routes';
 import {SafeAreaView} from 'react-native-safe-area-context';
-import {BodySmSemibold, Caption1, Caption1Black, FeatureTitleBlack, Title3Black} from 'components/text';
+import {Body, BodySmSemibold, Caption1, Caption1Black, FeatureTitleBlack, Title3Black} from 'components/text';
 import {colorFor} from './AvalancheDangerPyramid';
 import {dateToString} from 'utils/date';
 
@@ -66,8 +66,21 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
         <DangerScale px="4" width="100%" position="absolute" top="12" />
       </SafeAreaView>
 
-      {isLoading && <FeatureTitleBlack>Loading...</FeatureTitleBlack>}
-      {isError && <FeatureTitleBlack>{`Error...${error}`}</FeatureTitleBlack>}
+      {isLoading && (
+        <Center width="100%" height="100%" position="absolute" top="0">
+          <ActivityIndicator size={'large'} />
+        </Center>
+      )}
+      {isError && (
+        <Center width="100%" position="absolute" bottom="6">
+          <Alert status={'warning'} px={6} py={4}>
+            <HStack space={2} flexShrink={1}>
+              <Alert.Icon mt="1" />
+              <Body>Unable to load forecast data</Body>
+            </HStack>
+          </Alert>
+        </Center>
+      )}
       {!isLoading && !isError && <AvalancheForecastZoneCards key={center} center={center} date={date} mapLayer={mapLayer} />}
     </>
   );

--- a/components/Observation.tsx
+++ b/components/Observation.tsx
@@ -33,7 +33,7 @@ import {zone} from './Observations';
 import {HTMLRenderer} from './text/HTMLRenderer';
 import {AvalancheProblemImage} from './AvalancheProblemImage';
 import {NACIcon} from './icons/nac-icons';
-import {dateToString} from 'utils/date';
+import {utcDateToLocalTimeString} from 'utils/date';
 
 export const Observation: React.FunctionComponent<{
   id: string;
@@ -84,8 +84,8 @@ export const ObservationCard: React.FunctionComponent<{
       <Column space="2" bgColor={'#f0f2f5'}>
         <Card marginTop={2} borderRadius={0} borderColor="white" header={<Heading>{`${FormatPartnerType(observation.observerType as PartnerType)} Field Observation`}</Heading>}>
           <Row flexWrap="wrap" space="2">
-            <IdentifiedInformation header={'Submitted'} body={dateToString(observation.createdAt)} />
-            {observation.endDate && <IdentifiedInformation header={'Expires'} body={dateToString(observation.endDate)} />}
+            <IdentifiedInformation header={'Submitted'} body={utcDateToLocalTimeString(observation.createdAt)} />
+            {observation.endDate && <IdentifiedInformation header={'Expires'} body={utcDateToLocalTimeString(observation.endDate)} />}
             <IdentifiedInformation header={'Author(s)'} body={observation.name || 'Unknown'} />
             <IdentifiedInformation header={'Activity'} body={activityDisplayName(observation.activity)} />
           </Row>
@@ -193,7 +193,10 @@ export const ObservationCard: React.FunctionComponent<{
               observation.avalanches.map((item, index) => (
                 <Column space="2" style={{flex: 1}} key={`avalanche-${index}`}>
                   <Row space={2} alignItems="center">
-                    <IdentifiedInformation header={'Date'} body={`${dateToString(item.date)} (${FormatAvalancheDateUncertainty(item.dateAccuracy as AvalancheDateUncertainty)})`} />
+                    <IdentifiedInformation
+                      header={'Date'}
+                      body={`${utcDateToLocalTimeString(item.date)} (${FormatAvalancheDateUncertainty(item.dateAccuracy as AvalancheDateUncertainty)})`}
+                    />
                     <IdentifiedInformation header={'Location'} body={item.location} />
                     <IdentifiedInformation header={'Size'} body={`D${item.dSize}-R${item.rSize}`} />
                   </Row>

--- a/components/Observation.tsx
+++ b/components/Observation.tsx
@@ -4,7 +4,6 @@ import {ActivityIndicator, View, ScrollView, StyleSheet} from 'react-native';
 import {Heading, Row, Text, Column} from 'native-base';
 import {Card, CollapsibleCard} from 'components/Card';
 import {FontAwesome5, MaterialCommunityIcons, Fontisto} from '@expo/vector-icons';
-import {dateToString} from './forecast/AvalancheTab';
 import {useMapLayer} from '../hooks/useMapLayer';
 import {
   Activity,
@@ -34,6 +33,7 @@ import {zone} from './Observations';
 import {HTMLRenderer} from './text/HTMLRenderer';
 import {AvalancheProblemImage} from './AvalancheProblemImage';
 import {NACIcon} from './icons/nac-icons';
+import {dateToString} from 'utils/date';
 
 export const Observation: React.FunctionComponent<{
   id: string;

--- a/components/Observations.tsx
+++ b/components/Observations.tsx
@@ -13,7 +13,7 @@ import {OverviewFragment, useObservationsQuery} from 'hooks/useObservations';
 import {useMapLayer} from 'hooks/useMapLayer';
 import {AvalancheCenterID, FormatAvalancheProblemDistribution, FormatPartnerType, MapLayer, PartnerType} from '../types/nationalAvalancheCenter';
 import {Title3Semibold} from './text';
-import {dateToString} from './forecast/AvalancheTab';
+import {dateToString} from 'utils/date';
 import {HTMLRenderer} from './text/HTMLRenderer';
 import {NACIcon} from './icons/nac-icons';
 

--- a/components/Observations.tsx
+++ b/components/Observations.tsx
@@ -13,9 +13,9 @@ import {OverviewFragment, useObservationsQuery} from 'hooks/useObservations';
 import {useMapLayer} from 'hooks/useMapLayer';
 import {AvalancheCenterID, FormatAvalancheProblemDistribution, FormatPartnerType, MapLayer, PartnerType} from '../types/nationalAvalancheCenter';
 import {Title3Semibold} from './text';
-import {dateToString} from 'utils/date';
 import {HTMLRenderer} from './text/HTMLRenderer';
 import {NACIcon} from './icons/nac-icons';
+import {utcDateToLocalTimeString} from 'utils/date';
 
 // TODO: we could show the Avy center logo for obs that come from forecasters
 
@@ -113,7 +113,7 @@ export const ObservationSummaryCard: React.FunctionComponent<{
         </Row>
       }>
       <Row flexWrap="wrap" space="2">
-        <IdentifiedInformation header={'Submitted'} body={dateToString(observation.createdAt)} />
+        <IdentifiedInformation header={'Submitted'} body={utcDateToLocalTimeString(observation.createdAt)} />
         <IdentifiedInformation header={'Observer'} body={FormatPartnerType(observation.observerType as PartnerType)} />
         <IdentifiedInformation header={'Author(s)'} body={observation.name || 'Unknown'} />
       </Row>

--- a/components/forecast/AvalancheTab.tsx
+++ b/components/forecast/AvalancheTab.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import {Heading, HStack, Text, VStack} from 'native-base';
 
-import {format, parseISO} from 'date-fns';
+import {parseISO} from 'date-fns';
 
 import {AvalancheDangerForecast, AvalancheForecastZone, DangerLevel, ElevationBandNames, ForecastPeriod, Product} from 'types/nationalAvalancheCenter';
 import {AvalancheDangerTable} from 'components/AvalancheDangerTable';
@@ -10,19 +10,12 @@ import {AvalancheDangerIcon} from 'components/AvalancheDangerIcon';
 import {AvalancheProblemCard} from 'components/AvalancheProblemCard';
 import {Card, CollapsibleCard} from 'components/Card';
 import {HTMLRenderer} from 'components/text/HTMLRenderer';
+import {dateToString} from 'utils/date';
 
 interface AvalancheTabProps {
   zone: AvalancheForecastZone;
   forecast: Product;
 }
-
-export const dateToString = (dateString: string | undefined): string => {
-  if (!dateString) {
-    return 'Unknown';
-  }
-  const date = parseISO(dateString);
-  return format(date, `EEE, MMM d, yyyy h:mm a`);
-};
 
 export const AvalancheTab: React.FunctionComponent<AvalancheTabProps> = React.memo(({zone, forecast}) => {
   let currentDanger: AvalancheDangerForecast | undefined = forecast.danger.find(item => item.valid_day === ForecastPeriod.Current);

--- a/components/forecast/AvalancheTab.tsx
+++ b/components/forecast/AvalancheTab.tsx
@@ -10,7 +10,7 @@ import {AvalancheDangerIcon} from 'components/AvalancheDangerIcon';
 import {AvalancheProblemCard} from 'components/AvalancheProblemCard';
 import {Card, CollapsibleCard} from 'components/Card';
 import {HTMLRenderer} from 'components/text/HTMLRenderer';
-import {dateToString} from 'utils/date';
+import {utcDateToLocalTimeString} from 'utils/date';
 
 interface AvalancheTabProps {
   zone: AvalancheForecastZone;
@@ -51,13 +51,13 @@ export const AvalancheTab: React.FunctionComponent<AvalancheTabProps> = React.me
             <Text bold style={{textTransform: 'uppercase'}}>
               Issued
             </Text>
-            <Text color="lightText">{dateToString(forecast.published_time)}</Text>
+            <Text color="lightText">{utcDateToLocalTimeString(forecast.published_time)}</Text>
           </VStack>
           <VStack space="2" style={{flex: 1}}>
             <Text bold style={{textTransform: 'uppercase'}}>
               Expires
             </Text>
-            <Text color="lightText">{dateToString(forecast.expires_time)}</Text>
+            <Text color="lightText">{utcDateToLocalTimeString(forecast.expires_time)}</Text>
           </VStack>
           <VStack space="2" style={{flex: 1}}>
             <Text bold style={{textTransform: 'uppercase'}}>

--- a/components/screens/MapScreen.tsx
+++ b/components/screens/MapScreen.tsx
@@ -9,7 +9,7 @@ export const MapScreen = ({route}: NativeStackScreenProps<HomeStackParamList, 'a
   const {center_id, date} = route.params;
   return (
     <View style={{...styles.container}}>
-      <AvalancheForecastZoneMap centers={[center_id]} date={date} />
+      <AvalancheForecastZoneMap center={center_id} date={date} />
     </View>
   );
 };

--- a/hooks/useMapViewZones.ts
+++ b/hooks/useMapViewZones.ts
@@ -1,0 +1,69 @@
+import {useQuery} from 'react-query';
+import {format} from 'date-fns';
+
+import {useMapLayer} from './useMapLayer';
+import {useAvalancheForecastFragments} from './useAvalancheForecastFragments';
+
+import {AvalancheCenterID, DangerLevel, FeatureComponent} from 'types/nationalAvalancheCenter';
+
+export type MapViewZone = {
+  center_id: AvalancheCenterID;
+  zone_id?: number;
+  name?: string;
+  danger_level?: DangerLevel;
+  danger?: string;
+  travel_advice?: string;
+  start_date: string | null;
+  end_date: string | null;
+  geometry?: FeatureComponent;
+};
+
+export const useMapViewZones = (center_id: AvalancheCenterID, date: Date) => {
+  const {data: mapLayer} = useMapLayer(center_id);
+  const {data: fragments} = useAvalancheForecastFragments(center_id, date);
+
+  // This query executes as soon as `useMapLayer` finishes, but then tries to augment
+  // data with anything found in `useAvalancheForecastFragments`.
+  return useQuery<MapViewZone[], Error>(
+    [center_id, format(date, 'y-MM-dd')],
+    () => {
+      if (mapLayer.features == null || mapLayer.features.length === 0) {
+        throw new Error('Unexpected error: feature array is empty');
+      }
+
+      // Build up the base layer of data from the result of useMapLayer
+      const featureMap = mapLayer.features.reduce((accum, feature) => {
+        accum[feature.id] = {
+          zone_id: feature.id,
+          center_id,
+          geometry: feature.geometry,
+          ...feature.properties,
+        };
+        return accum;
+      }, {});
+
+      // Freshen up the data with values from useAvalancheForecastFragments, if available
+      if (fragments != null) {
+        fragments.forEach(forecast => {
+          forecast.forecast_zone?.forEach(({zone_id}) => {
+            const mapViewZoneData = featureMap[zone_id];
+            if (mapViewZoneData) {
+              mapViewZoneData.dangerLevel = forecast.danger?.filter(d => d.valid_day === 'current').map(d => Math.max(d.lower, d.middle, d.upper)) ?? mapViewZoneData.dangerLevel;
+              mapViewZoneData.danger = forecast.danger_level_text ?? mapViewZoneData.danger;
+              mapViewZoneData.startDate = forecast.published_time ?? mapViewZoneData.startDate;
+              mapViewZoneData.endDate = forecast.expires_time ?? mapViewZoneData.endDate;
+              // TODO(brian): forecasts don't have travel advice, so maybe we want to hardcode travel advice strings?
+              // Otherwise we could display an updated danger level without updated travel advice.
+              // This will definitely be a problem if we aggressively cache the results of `useMapLayer`.
+            }
+          });
+        });
+      }
+
+      return Object.keys(featureMap).map(k => featureMap[k]);
+    },
+    {
+      enabled: !!mapLayer,
+    },
+  );
+};

--- a/types/nationalAvalancheCenter/schemas.ts
+++ b/types/nationalAvalancheCenter/schemas.ts
@@ -286,6 +286,7 @@ export const productSchema = z.object({
   forecast_avalanche_problems: z.array(avalancheProblemSchema).optional(),
   hazard_discussion: z.string().optional().nullable(),
   danger: z.array(avalancheDangerForecastSchema),
+  danger_level_text: z.string().optional().nullable(),
   weather_discussion: z.string().optional().nullable(),
   weather_data: z.any(),
   media: z.array(mediaItemSchema).optional().nullable(),

--- a/utils/date.tsx
+++ b/utils/date.tsx
@@ -1,0 +1,9 @@
+import {format, parseISO} from 'date-fns';
+
+export const dateToString = (dateString: string | undefined): string => {
+  if (!dateString) {
+    return 'Unknown';
+  }
+  const date = parseISO(dateString);
+  return format(date, `EEE, MMM d, yyyy h:mm a`);
+};

--- a/utils/date.tsx
+++ b/utils/date.tsx
@@ -1,6 +1,6 @@
 import {format, parseISO} from 'date-fns';
 
-export const dateToString = (dateString: string | undefined): string => {
+export const utcDateToLocalTimeString = (dateString: string | undefined): string => {
   if (!dateString) {
     return 'Unknown';
   }


### PR DESCRIPTION
what's in this PR:
- card has been reskinned with font styles and spacing as defined in figma

what's not in this PR
- ~centering cards correctly - they get off center as you scroll through. I broke something here, just haven't looked hard at it yet.~ now fixed
- various selection behaviors
    - starting off with the zone list being partially visible
    - scrolling the correct zone into view when map region is tapped
    - moving the list out of the way when no region is selected

![simulator_screenshot_7BEBF40E-49A9-4422-8750-52F98C31C97A](https://user-images.githubusercontent.com/101196/211106148-8a64ed69-0ada-4508-b8d0-475a9d8eb82a.png)
