### PR TITLE
hooks: correctly de-duplicate requests for products

### DIFF
--- a/hooks/useAvalancheForecastFragment.ts
+++ b/hooks/useAvalancheForecastFragment.ts
@@ -1,49 +1,21 @@
-import React from 'react';
-
-import axios, {AxiosError} from 'axios';
 import {useQuery} from 'react-query';
-import {add, sub, format, isAfter, isBefore, parseISO} from 'date-fns';
+import {format, isAfter, isBefore, parseISO} from 'date-fns';
 
-import * as Sentry from 'sentry-expo';
-
-import {ClientContext, ClientProps} from 'clientContext';
-import {Product, productArraySchema} from 'types/nationalAvalancheCenter';
-import {ZodError} from 'zod';
+import {Product} from 'types/nationalAvalancheCenter';
+import {useAvalancheForecastFragments} from './useAvalancheForecastFragments';
 
 export const useAvalancheForecastFragment = (center_id: string, forecast_zone_id: number, date: Date) => {
-  const clientProps = React.useContext<ClientProps>(ClientContext);
-  return useQuery<Product | undefined, AxiosError | ZodError>(['products', center_id, forecast_zone_id, format(date, 'y-MM-dd')], async () => {
-    const url = `${clientProps.nationalAvalancheCenterHost}/v2/public/products`;
-    const {data} = await axios.get(url, {
-      params: {
-        avalanche_center_id: center_id,
-        forecast_zone_id,
-        // TODO(brian): remove this hack of adding/subtracting two days, which works around issues converting between local day and UTC day
-        date_start: format(sub(date, {days: 2}), 'y-MM-dd'),
-        date_end: format(add(date, {days: 2}), 'y-MM-dd'),
-      },
-    });
+  const {data: fragments} = useAvalancheForecastFragments(center_id, date);
 
-    const parseResult = productArraySchema.safeParse(data);
-    if (parseResult.success === false) {
-      console.warn('unparsable forecast fragment', url, parseResult.error, JSON.stringify(data, null, 2));
-      Sentry.Native.captureException(parseResult.error, {
-        tags: {
-          zod_error: true,
-          center_id,
-          forecast_zone_id,
-          date: date.toString(),
-          url,
-        },
-      });
-      throw parseResult.error;
-    } else {
-      // TODO(brian): This is assuming that a forecast always exists for the given zone/date range. That's not a good assumption!
-      return parseResult.data.find(
-        forecast => isBetween(forecast.published_time, forecast.expires_time, date) && forecast.forecast_zone.find(zone => zone.id === forecast_zone_id),
-      );
-    }
-  });
+  return useQuery<Product, Error>(
+    ['products', center_id, forecast_zone_id, format(date, 'y-MM-dd')],
+    async () => {
+      return fragments?.find(forecast => isBetween(forecast.published_time, forecast.expires_time, date) && forecast.forecast_zone.find(zone => zone.id === forecast_zone_id));
+    },
+    {
+      enabled: !!fragments,
+    },
+  );
 };
 
 const isBetween = (start: string, end: string, date: Date): boolean => {

--- a/hooks/useAvalancheForecastFragments.ts
+++ b/hooks/useAvalancheForecastFragments.ts
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import axios, {AxiosError} from 'axios';
+import {useQuery} from 'react-query';
+import {add, sub, format} from 'date-fns';
+
+import * as Sentry from 'sentry-expo';
+
+import {ClientContext, ClientProps} from 'clientContext';
+import {Product, productArraySchema} from 'types/nationalAvalancheCenter';
+import {ZodError} from 'zod';
+
+export const useAvalancheForecastFragments = (center_id: string, date: Date) => {
+  const clientProps = React.useContext<ClientProps>(ClientContext);
+  return useQuery<Product[] | undefined, AxiosError | ZodError>(['products', center_id, format(date, 'y-MM-dd')], async () => {
+    const url = `${clientProps.nationalAvalancheCenterHost}/v2/public/products`;
+    const {data} = await axios.get(url, {
+      params: {
+        avalanche_center_id: center_id,
+        // TODO(brian): remove this hack of adding/subtracting two days, which works around issues converting between local day and UTC day
+        date_start: format(sub(date, {days: 2}), 'y-MM-dd'),
+        date_end: format(add(date, {days: 2}), 'y-MM-dd'),
+      },
+    });
+
+    const parseResult = productArraySchema.safeParse(data);
+    if (parseResult.success === false) {
+      console.warn('unparsable forecast fragments', url, parseResult.error, JSON.stringify(data, null, 2));
+      Sentry.Native.captureException(parseResult.error, {
+        tags: {
+          zod_error: true,
+          center_id,
+          date: date.toString(),
+          url,
+        },
+      });
+      throw parseResult.error;
+    } else {
+      // TODO(brian): This is assuming that a forecast always exists for the given zone/date range. That's not a good assumption!
+      return parseResult.data;
+    }
+  });
+};


### PR DESCRIPTION
My previous implementation here was incorrectly adding the zone ID to the key-set for the fragments, whivh are zone-agnostic.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Only two requests now @floatplane !
![IMG_0017](https://user-images.githubusercontent.com/7328370/211168392-e8ccae4a-80b2-4263-a39a-c7927347e101.png)
