### PR TITLE
Fix avalanche danger size display

### DIFF
--- a/components/AvalancheProblemSizeLine.tsx
+++ b/components/AvalancheProblemSizeLine.tsx
@@ -21,10 +21,14 @@ export const sizeText = (input: AvalancheProblemSize): string => {
 };
 
 export const AvalancheProblemSizeLine: React.FunctionComponent<AvalancheProblemSizeLineProps> = ({size}: AvalancheProblemSizeLineProps) => {
+  // There's a bit of subtlety here: SeverityNumberLine assumes that a value of 0 maps
+  // to the first/top label in the component, so we have to map `size` to a value
+  // where 0 represents Historic.
+  const range = {from: AvalancheProblemSize.Historic - size[0], to: AvalancheProblemSize.Historic - size[1]};
   return (
     <SeverityNumberLine
       labels={[sizeText(AvalancheProblemSize.Historic), sizeText(AvalancheProblemSize.VeryLarge), sizeText(AvalancheProblemSize.Large), sizeText(AvalancheProblemSize.Small)]}
-      range={{from: size[0], to: size[1]}}
+      range={range}
     />
   );
 };

--- a/types/nationalAvalancheCenter/schemas.ts
+++ b/types/nationalAvalancheCenter/schemas.ts
@@ -11,7 +11,6 @@ import {
   DangerLevel,
   ForecastPeriod,
   MediaType,
-  numberToProblemSize,
   ProductStatus,
   ProductType,
   Units,
@@ -49,12 +48,11 @@ export const avalancheProblemLocationSchema = z.nativeEnum(AvalancheProblemLocat
 
 // Fix up data issues before parsing
 // 1) NWAC (and probably others) return strings for avalanche problem size, not numbers
-// 2) NWAC (and probably others) use values outside our enums 1-4
 export const avalancheProblemSizeSchema = z
   .number()
   .or(z.string())
   .transform((val: string, ctx) => {
-    const parsed = parseInt(val);
+    const parsed = parseFloat(val);
     if (isNaN(parsed)) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -63,8 +61,7 @@ export const avalancheProblemSizeSchema = z
       return z.NEVER;
     }
     return parsed;
-  })
-  .transform(val => numberToProblemSize(val));
+  });
 
 export const forecastPeriodSchema = z.nativeEnum(ForecastPeriod);
 


### PR DESCRIPTION
This change does the following:
- stop clamping avalanche danger size to an integer/enumerated value
- fix the logic in `AvalancheProblemSizeLine` so that it renders the danger correctly

I didn't remove `numberToProblemSize` from `enums.ts`, but it's currently unused - so maybe I should? Right now its main usefulness is an example of how to write unit tests, since we don't have any other tests 😬 