### PR TITLE
Improve API behavior, add top-level prefetching

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -37,6 +37,7 @@ import {MenuStackScreen} from 'components/screens/MenuScreen';
 import {ObservationsTabScreen} from 'components/screens/ObservationsScreen';
 import {TelemetryTabScreen} from 'components/screens/TelemetryScreen';
 import {AvalancheCenterID} from './types/nationalAvalancheCenter';
+import {usePrefetchAllActiveForecasts} from './hooks/usePrefetchAllActiveForecasts';
 
 // The SplashScreen stays up until we've loaded all of our fonts and other assets
 SplashScreen.preventAutoHideAsync();
@@ -130,88 +131,104 @@ const App = () => {
 
     useAppState(onAppStateChange);
 
-    // Set up ClientContext values
-    const [avalancheCenterId, setAvalancheCenterId] = React.useState(Constants.expoConfig.extra.avalanche_center as AvalancheCenterID);
-    const [staging, setStaging] = React.useState(false);
-
-    const contextValue = {
-      ...(staging ? stagingHosts : productionHosts),
-    };
-
-    const [date] = React.useState(defaultDate);
-
-    const [fontsLoaded] = useFonts({
-      Lato_100Thin,
-      Lato_100Thin_Italic,
-      Lato_300Light,
-      Lato_300Light_Italic,
-      Lato_400Regular_Italic,
-      Lato_400Regular,
-      Lato_700Bold,
-      Lato_700Bold_Italic,
-      Lato_900Black,
-      Lato_900Black_Italic,
-      NAC_Icons: require('./assets/fonts/nac-icons.ttf'),
-    });
-
-    const onLayoutRootView = useCallback(async () => {
-      if (fontsLoaded) {
-        await SplashScreen.hideAsync();
-      }
-    }, [fontsLoaded]);
-
-    if (!fontsLoaded) {
-      // The splash screen keeps rendering while fonts are loading
-      return null;
-    }
-
     return (
-      <ClientContext.Provider value={contextValue}>
-        <QueryClientProvider client={queryClient}>
-          <NativeBaseProvider theme={theme}>
-            <SafeAreaProvider>
-              <NavigationContainer>
-                <View onLayout={onLayoutRootView} style={StyleSheet.absoluteFill}>
-                  <TabNavigator.Navigator
-                    initialRouteName="Home"
-                    screenOptions={({route}) => ({
-                      headerShown: false,
-                      tabBarIcon: ({color, size}) => {
-                        if (route.name === 'Home') {
-                          return <AntDesign name="search1" size={size} color={color} />;
-                        } else if (route.name === 'Observations') {
-                          return <AntDesign name="filetext1" size={size} color={color} />;
-                        } else if (route.name === 'Weather Data') {
-                          return <AntDesign name="barschart" size={size} color={color} />;
-                        } else if (route.name === 'Menu') {
-                          return <AntDesign name="bars" size={size} color={color} />;
-                        }
-                      },
-                    })}>
-                    <TabNavigator.Screen name="Home" initialParams={{center_id: avalancheCenterId, date: date}}>
-                      {state => HomeTabScreen(withParams(state, {center_id: avalancheCenterId, date: date}))}
-                    </TabNavigator.Screen>
-                    <TabNavigator.Screen name="Observations" initialParams={{center_id: avalancheCenterId, date: date}}>
-                      {state => ObservationsTabScreen(withParams(state, {center_id: avalancheCenterId, date: date}))}
-                    </TabNavigator.Screen>
-                    <TabNavigator.Screen name="Weather Data" initialParams={{center_id: avalancheCenterId, date: date}}>
-                      {state => TelemetryTabScreen(withParams(state, {center_id: avalancheCenterId, date: date}))}
-                    </TabNavigator.Screen>
-                    <TabNavigator.Screen name="Menu" initialParams={{center_id: avalancheCenterId}}>
-                      {() => MenuStackScreen(avalancheCenterId, setAvalancheCenterId, staging, setStaging)}
-                    </TabNavigator.Screen>
-                  </TabNavigator.Navigator>
-                </View>
-              </NavigationContainer>
-            </SafeAreaProvider>
-          </NativeBaseProvider>
-        </QueryClientProvider>
-      </ClientContext.Provider>
+      <QueryClientProvider client={queryClient}>
+        <AppWithClientContext />
+      </QueryClientProvider>
     );
   } catch (error) {
     Sentry.Native.captureException(error);
     throw error;
   }
+};
+
+const AppWithClientContext = () => {
+  const [staging, setStaging] = React.useState(false);
+
+  const contextValue = {
+    ...(staging ? stagingHosts : productionHosts),
+  };
+
+  return (
+    <ClientContext.Provider value={contextValue}>
+      <BaseApp staging={staging} setStaging={setStaging} />
+    </ClientContext.Provider>
+  );
+};
+
+const BaseApp: React.FunctionComponent<{
+  staging: boolean;
+  setStaging: React.Dispatch<React.SetStateAction<boolean>>;
+}> = ({staging, setStaging}) => {
+  const [avalancheCenterId, setAvalancheCenterId] = React.useState(Constants.expoConfig.extra.avalanche_center as AvalancheCenterID);
+  const [date] = React.useState(defaultDate);
+
+  usePrefetchAllActiveForecasts(avalancheCenterId, date);
+
+  const [fontsLoaded] = useFonts({
+    Lato_100Thin,
+    Lato_100Thin_Italic,
+    Lato_300Light,
+    Lato_300Light_Italic,
+    Lato_400Regular_Italic,
+    Lato_400Regular,
+    Lato_700Bold,
+    Lato_700Bold_Italic,
+    Lato_900Black,
+    Lato_900Black_Italic,
+    NAC_Icons: require('./assets/fonts/nac-icons.ttf'),
+  });
+
+  const onLayoutRootView = useCallback(async () => {
+    if (fontsLoaded) {
+      await SplashScreen.hideAsync();
+    }
+  }, [fontsLoaded]);
+
+  if (!fontsLoaded) {
+    // The splash screen keeps rendering while fonts are loading
+    return null;
+  }
+
+  return (
+    <NativeBaseProvider theme={theme}>
+      <SafeAreaProvider>
+        <NavigationContainer>
+          <View onLayout={onLayoutRootView} style={StyleSheet.absoluteFill}>
+            <TabNavigator.Navigator
+              initialRouteName="Home"
+              screenOptions={({route}) => ({
+                headerShown: false,
+                tabBarIcon: ({color, size}) => {
+                  if (route.name === 'Home') {
+                    return <AntDesign name="search1" size={size} color={color} />;
+                  } else if (route.name === 'Observations') {
+                    return <AntDesign name="filetext1" size={size} color={color} />;
+                  } else if (route.name === 'Weather Data') {
+                    return <AntDesign name="barschart" size={size} color={color} />;
+                  } else if (route.name === 'Menu') {
+                    return <AntDesign name="bars" size={size} color={color} />;
+                  }
+                },
+              })}>
+              <TabNavigator.Screen name="Home" initialParams={{center_id: avalancheCenterId, date: date}}>
+                {state => HomeTabScreen(withParams(state, {center_id: avalancheCenterId, date: date}))}
+              </TabNavigator.Screen>
+              <TabNavigator.Screen name="Observations" initialParams={{center_id: avalancheCenterId, date: date}}>
+                {state => ObservationsTabScreen(withParams(state, {center_id: avalancheCenterId, date: date}))}
+              </TabNavigator.Screen>
+              <TabNavigator.Screen name="Weather Data" initialParams={{center_id: avalancheCenterId, date: date}}>
+                {state => TelemetryTabScreen(withParams(state, {center_id: avalancheCenterId, date: date}))}
+              </TabNavigator.Screen>
+              <TabNavigator.Screen name="Menu" initialParams={{center_id: avalancheCenterId}}>
+                {() => MenuStackScreen(avalancheCenterId, setAvalancheCenterId, staging, setStaging)}
+              </TabNavigator.Screen>
+            </TabNavigator.Navigator>
+          </View>
+        </NavigationContainer>
+      </SafeAreaProvider>
+    </NativeBaseProvider>
+  );
 };
 
 const withParams = (state, params) => {

--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -16,6 +16,7 @@ import {Body, BodySmSemibold, Caption1, Caption1Black, Title3Black} from 'compon
 import {colorFor} from './AvalancheDangerPyramid';
 import {utcDateToLocalTimeString} from 'utils/date';
 import {parseISO} from 'date-fns';
+import {TravelAdvice} from './helpers/travelAdvice';
 
 export const defaultRegion: Region = {
   // TODO(skuznets): add a sane default for the US?
@@ -161,7 +162,7 @@ const AvalancheForecastZoneCard: React.FunctionComponent<{
           </VStack>
           <Text>
             <Caption1Black>Travel advice: </Caption1Black>
-            <Caption1>{zone.travel_advice}</Caption1>
+            <TravelAdvice dangerLevel={zone.danger_level} />
           </Text>
         </VStack>
       </VStack>

--- a/components/forecast/AvalancheTab.tsx
+++ b/components/forecast/AvalancheTab.tsx
@@ -82,7 +82,7 @@ export const AvalancheTab: React.FunctionComponent<AvalancheTabProps> = React.me
         <AvalancheDangerTable date={parseISO(forecast.published_time)} current={currentDanger} outlook={outlookDanger} elevation_band_names={elevationBandNames} />
       </Card>
       {forecast.forecast_avalanche_problems.map((problem, index) => (
-        <CollapsibleCard startsCollapsed borderRadius={0} borderColor="white" header={<Heading>Avalanche Problem #{index + 1}</Heading>}>
+        <CollapsibleCard key={`avalanche-problem-${index}-card`} startsCollapsed borderRadius={0} borderColor="white" header={<Heading>Avalanche Problem #{index + 1}</Heading>}>
           <AvalancheProblemCard key={`avalanche-problem-${index}`} problem={problem} names={elevationBandNames} />
         </CollapsibleCard>
       ))}

--- a/components/helpers/travelAdvice.tsx
+++ b/components/helpers/travelAdvice.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import {DangerLevel} from 'types/nationalAvalancheCenter';
+import {Caption1, Caption1Semibold} from '../text';
+
+export const TravelAdvice: React.FunctionComponent<{dangerLevel: DangerLevel}> = ({dangerLevel}) => {
+  switch (dangerLevel) {
+    case DangerLevel.GeneralInformation:
+    case DangerLevel.None:
+      return <Caption1>Insufficient data for issuing of danger ratings, but a summary of avalanche conditions exists. Read the summary for more information.</Caption1>;
+    case DangerLevel.Low:
+      return (
+        <Caption1>
+          <Caption1Semibold>Generally safe avalanche conditions.</Caption1Semibold> Watch for unstable snow on isolated terrain features.
+        </Caption1>
+      );
+    case DangerLevel.Moderate:
+      return (
+        <Caption1>
+          <Caption1Semibold>Heightened avalanche conditions on specific terrain features.</Caption1Semibold> Evaluate snow and terrain carefully; identify features of concern.
+        </Caption1>
+      );
+    case DangerLevel.Considerable:
+      return (
+        <Caption1>
+          <Caption1Semibold>Dangerous avalanche conditions.</Caption1Semibold> Careful snowpack evaluation, cautious route-finding and conservative decision-making essential.
+        </Caption1>
+      );
+    case DangerLevel.High:
+      return (
+        <Caption1>
+          <Caption1Semibold>Very dangerous avalanche conditions.</Caption1Semibold> Travel in avalanche terrain not recommended.
+        </Caption1>
+      );
+    case DangerLevel.Extreme:
+      return (
+        <Caption1>
+          <Caption1Semibold>Extraordinarily dangerous avalanche conditions.</Caption1Semibold> Avoid all avalanche terrain.
+        </Caption1>
+      );
+  }
+  const invalid: never = dangerLevel;
+  throw new Error(`Unknown danger level: ${invalid}`);
+};

--- a/hooks/useAvalancheCenterMetadata.ts
+++ b/hooks/useAvalancheCenterMetadata.ts
@@ -11,23 +11,30 @@ import {ZodError} from 'zod';
 
 export const useAvalancheCenterMetadata = (center_id: AvalancheCenterID) => {
   const clientProps = React.useContext<ClientProps>(ClientContext);
-  return useQuery<AvalancheCenter, AxiosError | ZodError>(['avalanche-center', center_id], async () => {
-    const url = `${clientProps.nationalAvalancheCenterHost}/v2/public/avalanche-center/${center_id}`;
-    const {data} = await axios.get(url);
+  return useQuery<AvalancheCenter, AxiosError | ZodError>(
+    ['avalanche-center', center_id],
+    async () => {
+      const url = `${clientProps.nationalAvalancheCenterHost}/v2/public/avalanche-center/${center_id}`;
+      const {data} = await axios.get(url);
 
-    const parseResult = avalancheCenterSchema.safeParse(data);
-    if (parseResult.success === false) {
-      console.warn(`unparsable avalanche center ${center_id}`, url, parseResult.error, JSON.stringify(data, null, 2));
-      Sentry.Native.captureException(parseResult.error, {
-        tags: {
-          zod_error: true,
-          center_id,
-          url,
-        },
-      });
-      throw parseResult.error;
-    } else {
-      return parseResult.data;
-    }
-  });
+      const parseResult = avalancheCenterSchema.safeParse(data);
+      if (parseResult.success === false) {
+        console.warn(`unparsable avalanche center ${center_id}`, url, parseResult.error, JSON.stringify(data, null, 2));
+        Sentry.Native.captureException(parseResult.error, {
+          tags: {
+            zod_error: true,
+            center_id,
+            url,
+          },
+        });
+        throw parseResult.error;
+      } else {
+        return parseResult.data;
+      }
+    },
+    {
+      staleTime: 24 * 60 * 60 * 1000, // don't bother re-fetching for one day (in milliseconds)
+      cacheTime: Infinity, // hold on to this cached data forever
+    },
+  );
 };

--- a/hooks/useAvalancheForecast.ts
+++ b/hooks/useAvalancheForecast.ts
@@ -17,6 +17,8 @@ export const useAvalancheForecast = (center_id: AvalancheCenterID, forecast_zone
 
   return useQuery<Product, AxiosError | ZodError>(['host', clientProps.nationalAvalancheCenterHost, 'product', forecastId], fetchProduct, {
     enabled: !!forecastId,
+    staleTime: 60 * 60 * 1000, // re-fetch in the background once an hour (in milliseconds)
+    cacheTime: 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)
   });
 };
 

--- a/hooks/useAvalancheForecastFragment.ts
+++ b/hooks/useAvalancheForecastFragment.ts
@@ -14,6 +14,8 @@ export const useAvalancheForecastFragment = (center_id: AvalancheCenterID, forec
     },
     {
       enabled: !!fragments,
+      staleTime: 60 * 60 * 1000, // re-fetch in the background once an hour (in milliseconds)
+      cacheTime: 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)
     },
   );
 };

--- a/hooks/useMapLayer.ts
+++ b/hooks/useMapLayer.ts
@@ -33,6 +33,8 @@ export const useMapLayer = (center_id: AvalancheCenterID) => {
     },
     {
       enabled: !!center_id,
+      staleTime: 24 * 60 * 60 * 1000, // don't bother re-fetching for one day (in milliseconds)
+      cacheTime: Infinity, // hold on to this cached data forever
     },
   );
 };

--- a/hooks/useMapViewZones.ts
+++ b/hooks/useMapViewZones.ts
@@ -12,7 +12,6 @@ export type MapViewZone = {
   name?: string;
   danger_level?: DangerLevel;
   danger?: string;
-  travel_advice?: string;
   start_date: string | null;
   end_date: string | null;
   geometry?: FeatureComponent;
@@ -52,9 +51,6 @@ export const useMapViewZones = (center_id: AvalancheCenterID, date: Date) => {
               mapViewZoneData.danger = forecast.danger_level_text ?? mapViewZoneData.danger;
               mapViewZoneData.startDate = forecast.published_time ?? mapViewZoneData.startDate;
               mapViewZoneData.endDate = forecast.expires_time ?? mapViewZoneData.endDate;
-              // TODO(brian): forecasts don't have travel advice, so maybe we want to hardcode travel advice strings?
-              // Otherwise we could display an updated danger level without updated travel advice.
-              // This will definitely be a problem if we aggressively cache the results of `useMapLayer`.
             }
           });
         });

--- a/hooks/usePrefetchAllActiveForecasts.ts
+++ b/hooks/usePrefetchAllActiveForecasts.ts
@@ -1,0 +1,67 @@
+import React from 'react';
+import {Image} from 'react-native';
+
+import {parseISO} from 'date-fns';
+import {useQueries} from 'react-query';
+
+import {AvalancheCenterID, MediaItem, MediaType} from 'types/nationalAvalancheCenter';
+import {useAvalancheCenterMetadata} from 'hooks/useAvalancheCenterMetadata';
+import {useAvalancheForecastFragments} from 'hooks/useAvalancheForecastFragments';
+import {fetchProduct} from 'hooks/useAvalancheForecast';
+import {ClientContext, ClientProps} from '../clientContext';
+
+export const usePrefetchAllActiveForecasts = (center_id: AvalancheCenterID, date: string) => {
+  const clientProps = React.useContext<ClientProps>(ClientContext);
+  useAvalancheCenterMetadata(center_id);
+
+  const prefetchDate: Date = parseISO(date);
+  const {data: fragments} = useAvalancheForecastFragments(center_id, prefetchDate);
+
+  const forecastResults = useQueries(
+    fragments
+      ? fragments.map(forecast => {
+          return {
+            queryKey: ['host', clientProps.nationalAvalancheCenterHost, 'product', forecast.id],
+            queryFn: fetchProduct,
+            enabled: !!fragments,
+          };
+        })
+      : [],
+  );
+
+  return useQueries(
+    forecastResults
+      ? forecastResults
+          .map(result => result.data) // get data from the results
+          .filter(data => data) // only operate on results that have succeeded
+          .map(forecast => {
+            const media: MediaItem[] = [];
+            for (const problem of forecast.forecast_avalanche_problems) {
+              if (problem.media) {
+                media.push(problem.media);
+              }
+              for (const item of forecast.media) {
+                if (item) {
+                  media.push(item);
+                }
+              }
+            }
+
+            return media;
+          }) // map each forecast to the list of media items in it
+          .reduce((accumulator, currentValue) => accumulator.concat(currentValue), []) // MediaItem[][] -> MediaItem[]
+          .filter(item => item.type === MediaType.Image) // TODO: handle prefetching other types of media
+          .map(item => {
+            return {
+              queryKey: ['url', item.url.original],
+              queryFn: prefetchImage,
+              enabled: !!forecastResults,
+            };
+          }) // map each media item to the fetcher for it
+      : [],
+  );
+};
+
+const prefetchImage = async ({queryKey}) => {
+  await Image.prefetch(queryKey[1]);
+};


### PR DESCRIPTION
api: use a client-side mapping for travel advice

We only get travel advice from the map layer and full forecast API, not
the fragment API, which makes relying on that field problematic. It
looks like the extant web application is simply using a client-side
mapping, anyway, instead of the API fields, so we can do that as well.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

hooks: cache ~static data forever

The avalanche center metadata and map layer contain relatively static
data (like the name of the avalanche center and where it is in the
country), so we can cache these values for the lifetime of our app and
re-fetch them infrequently.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

*: pre-fetch all data for the forecasts

On app load, we will now be fetching the center metadata, map layer, all
forecasts that pertain to our zones, and all media in all of the
forecasts. This will allow us to make sure that all data is present for
the user regardless of whether they've looked at all the forecasts
before going out of service.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

AvalancheTab: add a key to the collapsible cards

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Partially addresses #54 