### PR TITLE
Update AvalancheDangerTable styling

### DIFF
--- a/components/AvalancheDangerPyramid.tsx
+++ b/components/AvalancheDangerPyramid.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import Svg, {Path} from 'react-native-svg';
+import Svg, {Path, SvgProps} from 'react-native-svg';
 import {StyleSheet} from 'react-native';
 
 import Color from 'color';
@@ -28,9 +28,12 @@ export const colorFor = (danger: DangerLevel): Color => {
 
 const shadow: Color = Color('rgb(30, 35, 38)');
 
-export const AvalancheDangerPyramid: React.FunctionComponent<AvalancheDangerForecast> = (forecast: AvalancheDangerForecast) => {
+export interface AvalancheDangerPyramidProps extends SvgProps {
+  forecast: AvalancheDangerForecast;
+}
+export const AvalancheDangerPyramid: React.FunctionComponent<AvalancheDangerPyramidProps> = ({forecast, ...props}) => {
   return (
-    <Svg style={styles.pyramid} viewBox={'0 0 250 300'}>
+    <Svg style={styles.pyramid} viewBox={'0 0 250 300'} {...props}>
       <Path d="M31.504,210l175,0l43.496,90l-250,0l31.504,-90Z" fill={colorFor(forecast.lower).string()} strokeWidth={0} />
       <Path d="M204.087,205l-170.833,0l31.503,-90l95.834,0l43.496,90Z" fill={colorFor(forecast.middle).string()} strokeWidth={0} />
       <Path d="M158.174,110l-91.666,0l38.504,-110l53.162,110Z" fill={colorFor(forecast.upper).string()} strokeWidth={0} />

--- a/components/AvalancheDangerTable.tsx
+++ b/components/AvalancheDangerTable.tsx
@@ -1,190 +1,51 @@
 import React from 'react';
 
-import {Dimensions, ScaledSize, StyleSheet, Text, View} from 'react-native';
-
-import {addDays, format} from 'date-fns';
+import {HStack, View, VStack} from 'native-base';
 
 import {AvalancheDangerForecast, ElevationBandNames} from 'types/nationalAvalancheCenter';
-import {AvalancheDangerPyramid, AvalancheDangerTriangle} from './AvalancheDangerPyramid';
-import {AvalancheDangerIcon} from './AvalancheDangerIcon';
-import {dangerText} from './helpers/dangerText';
+import {dangerText} from 'components/helpers/dangerText';
+import {utcDateToLocalDateString} from 'utils/date';
+import {Body, Caption1, Caption1Semibold} from 'components/text';
 
-const prettyFormat = (date: Date): string => {
-  return format(date, 'EEEE, MMMM d, yyyy');
-};
+import {AvalancheDangerPyramid} from './AvalancheDangerPyramid';
+import {AvalancheDangerIcon} from './AvalancheDangerIcon';
 
 export interface AvalancheDangerTableProps {
   date: Date;
   current: AvalancheDangerForecast;
-  outlook: AvalancheDangerForecast;
   elevation_band_names: ElevationBandNames;
 }
 
-const initialScreen: ScaledSize = Dimensions.get('screen');
-
-export const AvalancheDangerTable: React.FunctionComponent<AvalancheDangerTableProps> = ({date, current, outlook, elevation_band_names}: AvalancheDangerTableProps) => {
-  const [dimensions, setDimensions] = React.useState<ScaledSize>(initialScreen);
-
-  // determine screen size when the orientation changes
-  React.useEffect(() => {
-    const subscription = Dimensions.addEventListener('change', ({screen}) => {
-      setDimensions(screen);
-    });
-    return () => subscription?.remove();
-  });
-
-  const isLandscape = (): boolean => {
-    return dimensions.width > dimensions.height;
-  };
-
+export const AvalancheDangerTable: React.FunctionComponent<AvalancheDangerTableProps> = ({date, current, elevation_band_names}: AvalancheDangerTableProps) => {
   return (
-    <View>
-      <View
-        style={{
-          flexDirection: 'row',
-          justifyContent: 'space-around',
-        }}>
-        <View style={{flexDirection: 'column', flex: 3, marginHorizontal: 10}}>
-          <Text style={styles.title}>Avalanche Danger</Text>
-          <Text>{prettyFormat(date)}</Text>
-          <View style={{flexDirection: 'row', justifyContent: 'space-between'}}>
-            <AvalancheDangerPyramid {...current} />
-            <View style={styles.column}>
-              <Text style={{...styles.elevation, ...styles.rowItem}}>{elevation_band_names.upper}</Text>
-              <Text style={{...styles.elevation, ...styles.rowItem}}>{elevation_band_names.middle}</Text>
-              <Text style={{...styles.elevation, ...styles.rowItem}}>{elevation_band_names.lower}</Text>
-            </View>
-            <View style={{flexDirection: 'row', justifyContent: 'space-between'}}>
-              <View style={styles.column}>
-                <Text style={{...styles.text, ...styles.rowItem}}>{dangerText(current.upper)}</Text>
-                <Text style={{...styles.text, ...styles.rowItem}}>{dangerText(current.middle)}</Text>
-                <Text style={{...styles.text, ...styles.rowItem}}>{dangerText(current.lower)}</Text>
-              </View>
-              <View style={styles.column}>
-                <AvalancheDangerIcon style={styles.rowItem} level={current.upper} />
-                <AvalancheDangerIcon style={styles.rowItem} level={current.middle} />
-                <AvalancheDangerIcon style={styles.rowItem} level={current.lower} />
-              </View>
-            </View>
-          </View>
+    <VStack space={3} alignItems="stretch">
+      <Body>{utcDateToLocalDateString(date)}</Body>
+      <View height="200" width="100%">
+        {/* This view contains 3 layers stacked over each other: the background bars in gray, the avalanche pyramid, and the text labels and icons */}
+        <VStack width="100%" height="100%" position="absolute" justifyContent="stretch" alignItems="stretch" alignContent="stretch" space="3px" paddingTop="13px" zIndex={10}>
+          <View bg="gray.100" flex={1} />
+          <View bg="gray.100" flex={1} />
+          <View bg="gray.100" flex={1} />
+        </VStack>
+        <View width="100%" height="100%" position="absolute" zIndex={20}>
+          <AvalancheDangerPyramid forecast={current} height="100%" />
         </View>
-        {isLandscape() && (
-          <View style={{flexDirection: 'column', flex: 2, marginHorizontal: 10}}>
-            <Text style={styles.title}>Outlook</Text>
-            <Text>{prettyFormat(addDays(date, 1))}</Text>
-            <View style={{flexDirection: 'row', justifyContent: 'space-between'}}>
-              <View style={styles.column}>
-                <Text style={{...styles.text, ...styles.rowItem}}>{dangerText(outlook.upper)}</Text>
-                <Text style={{...styles.text, ...styles.rowItem}}>{dangerText(outlook.middle)}</Text>
-                <Text style={{...styles.text, ...styles.rowItem}}>{dangerText(outlook.lower)}</Text>
+        <VStack width="100%" height="100%" position="absolute" justifyContent="stretch" alignItems="stretch" space="3px" paddingTop="13px" zIndex={30}>
+          {['upper', 'middle', 'lower'].map((layer, index) => (
+            <HStack flex={1} justifyContent="space-between" key={index}>
+              <View bg="white" my={4} px={1} justifyContent="center">
+                <Caption1 color="lightText">{elevation_band_names[layer]}</Caption1>
               </View>
-              <View style={styles.column}>
-                <View style={styles.rowItem}>
-                  <AvalancheDangerIcon style={styles.smallerIconContainer} level={outlook.upper} />
+              <HStack space={2} alignItems="center" px={1}>
+                <View my={4} px={1} justifyContent="center">
+                  <Caption1Semibold style={{textTransform: 'uppercase'}}>{dangerText(current[layer])}</Caption1Semibold>
                 </View>
-                <View style={styles.rowItem}>
-                  <AvalancheDangerIcon style={styles.smallerIconContainer} level={outlook.middle} />
-                </View>
-                <View style={styles.rowItem}>
-                  <AvalancheDangerIcon style={styles.smallerIconContainer} level={outlook.lower} />
-                </View>
-              </View>
-            </View>
-          </View>
-        )}
+                <AvalancheDangerIcon style={{height: 32}} level={current[layer]} />
+              </HStack>
+            </HStack>
+          ))}
+        </VStack>
       </View>
-      {!isLandscape() && (
-        <View
-          style={{
-            flexDirection: 'row',
-            justifyContent: 'flex-end',
-            flexBasis: 1,
-            marginVertical: 10,
-          }}>
-          <View style={{flexDirection: 'column'}}>
-            <Text style={styles.title}>Outlook</Text>
-            <Text>{prettyFormat(addDays(date, 1))}</Text>
-          </View>
-          <View
-            style={{
-              flexDirection: 'column',
-              alignItems: 'center',
-              marginHorizontal: 50,
-            }}>
-            <AvalancheDangerTriangle {...outlook} />
-            <View style={{height: 30}}>
-              <Text
-                style={{
-                  textAlignVertical: 'center',
-                  flex: 1,
-                }}>{`(${outlook.upper})`}</Text>
-            </View>
-            <View style={{height: 30}}>
-              <Text
-                style={{
-                  textAlignVertical: 'center',
-                  flex: 1,
-                }}>{`(${outlook.middle})`}</Text>
-            </View>
-            <View style={{height: 30}}>
-              <Text
-                style={{
-                  textAlignVertical: 'center',
-                  flex: 1,
-                }}>{`(${outlook.lower})`}</Text>
-            </View>
-          </View>
-        </View>
-      )}
-    </View>
+    </VStack>
   );
 };
-
-const styles = StyleSheet.create({
-  iconContainer: {
-    height: 50,
-    width: 90,
-    borderColor: 'rgb(40, 140, 40)',
-    borderWidth: 1,
-  },
-  icon: {
-    resizeMode: 'contain',
-    height: '100%',
-    width: 'auto',
-    borderColor: 'rgb(20, 20, 20)',
-    borderWidth: 1,
-  },
-  smallerIconContainer: {
-    height: 40,
-    flex: 1,
-  },
-  row: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'stretch',
-    alignContent: 'flex-start',
-  },
-  rowItem: {
-    height: 50,
-    textAlignVertical: 'center',
-  },
-  column: {
-    flexDirection: 'column',
-    justifyContent: 'space-between',
-    alignItems: 'flex-start',
-    marginHorizontal: 10,
-  },
-  text: {
-    textTransform: 'uppercase',
-    fontWeight: 'bold',
-    flex: 1,
-  },
-  elevation: {
-    flex: 1,
-  },
-  title: {
-    textTransform: 'uppercase',
-    fontWeight: 'bold',
-    paddingBottom: 10,
-  },
-});

--- a/components/forecast/AvalancheTab.tsx
+++ b/components/forecast/AvalancheTab.tsx
@@ -79,7 +79,7 @@ export const AvalancheTab: React.FunctionComponent<AvalancheTabProps> = React.me
         <HTMLRenderer source={{html: forecast.bottom_line}} />
       </Card>
       <Card borderRadius={0} borderColor="white" header={<Heading>Avalanche Danger</Heading>}>
-        <AvalancheDangerTable date={parseISO(forecast.published_time)} current={currentDanger} outlook={outlookDanger} elevation_band_names={elevationBandNames} />
+        <AvalancheDangerTable date={parseISO(forecast.published_time)} current={currentDanger} elevation_band_names={elevationBandNames} />
       </Card>
       {forecast.forecast_avalanche_problems.map((problem, index) => (
         <CollapsibleCard startsCollapsed borderRadius={0} borderColor="white" header={<Heading>Avalanche Problem #{index + 1}</Heading>}>

--- a/utils/date.tsx
+++ b/utils/date.tsx
@@ -7,3 +7,7 @@ export const utcDateToLocalTimeString = (dateString: string | undefined): string
   const date = parseISO(dateString);
   return format(date, `EEE, MMM d, yyyy h:mm a`);
 };
+
+export const utcDateToLocalDateString = (date: Date): string => {
+  return format(date, `EEEE, MMMM d, yyyy`);
+};


### PR DESCRIPTION
This gets the danger table close to what's in Figma. I expect it could shift somewhat, since the Figma design is actually just a screenshot 😬 - not sure I've picked the right text formats, but that's a quick fix.

Known issue: the Outlook tab needs to be added, that'll be in a future PR.

<img width="644" alt="image" src="https://user-images.githubusercontent.com/101196/211689663-92082116-3949-4b6e-ba4b-b32e8caf2f04.png">
