### PR TITLE
AvalancheForecastZoneCard: render 'general information' better

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,10 @@
 name: CI
 on: workflow_call
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   prettier:
     name: prettier

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -8,6 +8,10 @@ on:
       - '**/*.md'
       - '.github/ISSUE_TEMPLATE/*'
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   ci:
     uses: ./.github/workflows/ci.yaml # use the callable ci job to run CI checks
@@ -37,8 +41,9 @@ jobs:
 
       - name: 🚀 Publish preview
         id: eas-update
+        shell: bash
         run: |
-          output=`eas update --branch=pr-${{ github.event.number }} --message '${{ github.event.pull_request.title }}' --non-interactive --json | jq -c`
+          output="$(eas update --branch=pr-${{ github.event.number }} --message="${{ github.event.pull_request.title }}" --non-interactive --json)"
           echo "ios_id=$( jq --raw-output '.[] | select(.platform == "ios" ) | .id ' <<<"${output}" )" >> "${GITHUB_OUTPUT}"
           echo "android_id=$( jq --raw-output '.[] | select(.platform == "android" ) | .id ' <<<"${output}" )" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,6 +3,11 @@ on:
   push:
     branches:
       - main
+
+defaults:
+  run:
+    shell: bash
+
 jobs:
   ci:
     uses: ./.github/workflows/ci.yaml # use the callable ci job to run CI checks
@@ -32,6 +37,7 @@ jobs:
         run: yarn install
 
       - name: 🚀 Publish update bundle
+        shell: bash
         run: eas update --channel preview --message '${{ github.event.head_commit.message }}' --non-interactive
 
   build-android:

--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -6,7 +6,7 @@ import MapView, {Region} from 'react-native-maps';
 import {useNavigation} from '@react-navigation/native';
 
 import {DangerScale} from 'components/DangerScale';
-import {AvalancheCenterID} from 'types/nationalAvalancheCenter';
+import {AvalancheCenterID, DangerLevel} from 'types/nationalAvalancheCenter';
 import {AvalancheCenterForecastZonePolygons} from './AvalancheCenterForecastZonePolygons';
 import {AvalancheDangerIcon} from './AvalancheDangerIcon';
 import {MapViewZone, useMapViewZones} from 'hooks/useMapViewZones';
@@ -145,15 +145,7 @@ const AvalancheForecastZoneCard: React.FunctionComponent<{
         <VStack px={6} pt={1} pb={3} space={2}>
           <HStack space={2} alignItems="center">
             <AvalancheDangerIcon style={{height: 32}} level={zone.danger_level} />
-            {zone.danger_level === -1 ? (
-              <BodySmSemibold>
-                <Text style={{textTransform: 'capitalize'}}>{zone.danger}</Text>
-              </BodySmSemibold>
-            ) : (
-              <BodySmSemibold>
-                {zone.danger_level} - <Text style={{textTransform: 'capitalize'}}>{zone.danger}</Text> Avalanche Danger
-              </BodySmSemibold>
-            )}
+            <DangerLevelTitle dangerLevel={zone.danger_level} danger={zone.danger} />
           </HStack>
           <Title3Black>{zone.name}</Title3Black>
           <VStack py={2}>
@@ -173,4 +165,31 @@ const AvalancheForecastZoneCard: React.FunctionComponent<{
       </VStack>
     </TouchableOpacity>
   );
+};
+
+const DangerLevelTitle: React.FunctionComponent<{
+  dangerLevel: DangerLevel;
+  danger: string;
+}> = ({dangerLevel, danger}) => {
+  switch (dangerLevel) {
+    case DangerLevel.GeneralInformation:
+    case DangerLevel.None:
+      return (
+        <BodySmSemibold>
+          <Text style={{textTransform: 'capitalize'}}>{danger}</Text>
+        </BodySmSemibold>
+      );
+    case DangerLevel.Low:
+    case DangerLevel.Moderate:
+    case DangerLevel.Considerable:
+    case DangerLevel.High:
+    case DangerLevel.Extreme:
+      return (
+        <BodySmSemibold>
+          {dangerLevel} - <Text style={{textTransform: 'capitalize'}}>{danger}</Text> Avalanche Danger
+        </BodySmSemibold>
+      );
+  }
+  const invalid: never = dangerLevel;
+  throw new Error(`Unknown danger level: ${invalid}`);
 };


### PR DESCRIPTION
Similarly to 'no rating', we just want the words here, not the numerical value.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Follows up on #58 