### PR TITLE
Use a common renderer to improve HTML render speed

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -38,7 +38,7 @@ import {ObservationsTabScreen} from 'components/screens/ObservationsScreen';
 import {TelemetryTabScreen} from 'components/screens/TelemetryScreen';
 import {AvalancheCenterID} from './types/nationalAvalancheCenter';
 import {prefetchAllActiveForecasts} from './network/prefetchAllActiveForecasts';
-import {HTMLRendererConfig} from 'components/text/HTMLRenderer';
+import {HTMLRendererConfig} from 'components/text/HTML';
 
 // The SplashScreen stays up until we've loaded all of our fonts and other assets
 SplashScreen.preventAutoHideAsync();

--- a/App.tsx
+++ b/App.tsx
@@ -38,6 +38,7 @@ import {ObservationsTabScreen} from 'components/screens/ObservationsScreen';
 import {TelemetryTabScreen} from 'components/screens/TelemetryScreen';
 import {AvalancheCenterID} from './types/nationalAvalancheCenter';
 import {prefetchAllActiveForecasts} from './network/prefetchAllActiveForecasts';
+import {HTMLRendererConfig} from 'components/text/HTMLRenderer';
 
 // The SplashScreen stays up until we've loaded all of our fonts and other assets
 SplashScreen.preventAutoHideAsync();
@@ -198,41 +199,43 @@ const BaseApp: React.FunctionComponent<{
 
   return (
     <NativeBaseProvider theme={theme}>
-      <SafeAreaProvider>
-        <NavigationContainer>
-          <View onLayout={onLayoutRootView} style={StyleSheet.absoluteFill}>
-            <TabNavigator.Navigator
-              initialRouteName="Home"
-              screenOptions={({route}) => ({
-                headerShown: false,
-                tabBarIcon: ({color, size}) => {
-                  if (route.name === 'Home') {
-                    return <AntDesign name="search1" size={size} color={color} />;
-                  } else if (route.name === 'Observations') {
-                    return <AntDesign name="filetext1" size={size} color={color} />;
-                  } else if (route.name === 'Weather Data') {
-                    return <AntDesign name="barschart" size={size} color={color} />;
-                  } else if (route.name === 'Menu') {
-                    return <AntDesign name="bars" size={size} color={color} />;
-                  }
-                },
-              })}>
-              <TabNavigator.Screen name="Home" initialParams={{center_id: avalancheCenterId, date: date}}>
-                {state => HomeTabScreen(withParams(state, {center_id: avalancheCenterId, date: date}))}
-              </TabNavigator.Screen>
-              <TabNavigator.Screen name="Observations" initialParams={{center_id: avalancheCenterId, date: date}}>
-                {state => ObservationsTabScreen(withParams(state, {center_id: avalancheCenterId, date: date}))}
-              </TabNavigator.Screen>
-              <TabNavigator.Screen name="Weather Data" initialParams={{center_id: avalancheCenterId, date: date}}>
-                {state => TelemetryTabScreen(withParams(state, {center_id: avalancheCenterId, date: date}))}
-              </TabNavigator.Screen>
-              <TabNavigator.Screen name="Menu" initialParams={{center_id: avalancheCenterId}}>
-                {() => MenuStackScreen(avalancheCenterId, setAvalancheCenterId, staging, setStaging)}
-              </TabNavigator.Screen>
-            </TabNavigator.Navigator>
-          </View>
-        </NavigationContainer>
-      </SafeAreaProvider>
+      <HTMLRendererConfig>
+        <SafeAreaProvider>
+          <NavigationContainer>
+            <View onLayout={onLayoutRootView} style={StyleSheet.absoluteFill}>
+              <TabNavigator.Navigator
+                initialRouteName="Home"
+                screenOptions={({route}) => ({
+                  headerShown: false,
+                  tabBarIcon: ({color, size}) => {
+                    if (route.name === 'Home') {
+                      return <AntDesign name="search1" size={size} color={color} />;
+                    } else if (route.name === 'Observations') {
+                      return <AntDesign name="filetext1" size={size} color={color} />;
+                    } else if (route.name === 'Weather Data') {
+                      return <AntDesign name="barschart" size={size} color={color} />;
+                    } else if (route.name === 'Menu') {
+                      return <AntDesign name="bars" size={size} color={color} />;
+                    }
+                  },
+                })}>
+                <TabNavigator.Screen name="Home" initialParams={{center_id: avalancheCenterId, date: date}}>
+                  {state => HomeTabScreen(withParams(state, {center_id: avalancheCenterId, date: date}))}
+                </TabNavigator.Screen>
+                <TabNavigator.Screen name="Observations" initialParams={{center_id: avalancheCenterId, date: date}}>
+                  {state => ObservationsTabScreen(withParams(state, {center_id: avalancheCenterId, date: date}))}
+                </TabNavigator.Screen>
+                <TabNavigator.Screen name="Weather Data" initialParams={{center_id: avalancheCenterId, date: date}}>
+                  {state => TelemetryTabScreen(withParams(state, {center_id: avalancheCenterId, date: date}))}
+                </TabNavigator.Screen>
+                <TabNavigator.Screen name="Menu" initialParams={{center_id: avalancheCenterId}}>
+                  {() => MenuStackScreen(avalancheCenterId, setAvalancheCenterId, staging, setStaging)}
+                </TabNavigator.Screen>
+              </TabNavigator.Navigator>
+            </View>
+          </NavigationContainer>
+        </SafeAreaProvider>
+      </HTMLRendererConfig>
     </NativeBaseProvider>
   );
 };

--- a/components/AvalancheProblemCard.tsx
+++ b/components/AvalancheProblemCard.tsx
@@ -9,7 +9,7 @@ import {AvalancheProblemLikelihoodLine} from './AvalancheProblemLikelihoodLine';
 import {AvalancheProblemSizeLine} from './AvalancheProblemSizeLine';
 import {TitledPanel} from './TitledPanel';
 import {AvalancheProblemImage} from './AvalancheProblemImage';
-import {HTMLRenderer} from 'components/text/HTMLRenderer';
+import {HTML} from 'components/text/HTML';
 
 export interface AvalancheProblemCardProps {
   problem: AvalancheProblem;
@@ -42,7 +42,7 @@ export const AvalancheProblemCard: React.FunctionComponent<AvalancheProblemCardP
       </View>
       {problem.media.type === MediaType.Image && problem.media.url !== null && <AvalancheProblemImage media={problem.media} />}
       <View style={styles.content}>
-        <HTMLRenderer source={{html: problem.discussion}} />
+        <HTML source={{html: problem.discussion}} />
       </View>
     </View>
   );

--- a/components/AvalancheProblemCard.tsx
+++ b/components/AvalancheProblemCard.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import {StyleSheet, Text, useWindowDimensions, View} from 'react-native';
-import RenderHTML from 'react-native-render-html';
+import {StyleSheet, Text, View} from 'react-native';
 
 import {AvalancheProblem, ElevationBandNames, MediaType} from 'types/nationalAvalancheCenter';
 import {AnnotatedDangerRose} from './DangerRose';
@@ -10,6 +9,7 @@ import {AvalancheProblemLikelihoodLine} from './AvalancheProblemLikelihoodLine';
 import {AvalancheProblemSizeLine} from './AvalancheProblemSizeLine';
 import {TitledPanel} from './TitledPanel';
 import {AvalancheProblemImage} from './AvalancheProblemImage';
+import {HTMLRenderer} from 'components/text/HTMLRenderer';
 
 export interface AvalancheProblemCardProps {
   problem: AvalancheProblem;
@@ -17,8 +17,6 @@ export interface AvalancheProblemCardProps {
 }
 
 export const AvalancheProblemCard: React.FunctionComponent<AvalancheProblemCardProps> = ({problem, names}: AvalancheProblemCardProps) => {
-  const {width} = useWindowDimensions();
-
   return (
     <View style={styles.horizontalCard}>
       <View
@@ -44,7 +42,7 @@ export const AvalancheProblemCard: React.FunctionComponent<AvalancheProblemCardP
       </View>
       {problem.media.type === MediaType.Image && problem.media.url !== null && <AvalancheProblemImage media={problem.media} />}
       <View style={styles.content}>
-        <RenderHTML source={{html: problem.discussion}} contentWidth={width} />
+        <HTMLRenderer source={{html: problem.discussion}} />
       </View>
     </View>
   );

--- a/components/AvalancheProblemImage.tsx
+++ b/components/AvalancheProblemImage.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {Text, Image, StyleSheet, View, ActivityIndicator} from 'react-native';
 
 import {MediaItem} from 'types/nationalAvalancheCenter';
-import {HTMLRenderer} from 'components/text/HTMLRenderer';
+import {HTML} from 'components/text/HTML';
 
 export interface AvalancheProblemImageProps {
   media: MediaItem;
@@ -44,7 +44,7 @@ export const AvalancheProblemImage: React.FunctionComponent<AvalancheProblemImag
       {!gallery ? (
         <View style={styles.container}>
           <Image source={{uri: media.url.original}} style={{width: '70%', aspectRatio: imageDimensions.height / imageDimensions.width}} />
-          <HTMLRenderer source={{html: `<em>${media.caption}</em>`}} />
+          <HTML source={{html: `<em>${media.caption}</em>`}} />
         </View>
       ) : (
         <></>

--- a/components/AvalancheProblemImage.tsx
+++ b/components/AvalancheProblemImage.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import {Text, Image, StyleSheet, useWindowDimensions, View, ActivityIndicator} from 'react-native';
-import RenderHTML from 'react-native-render-html';
+import {Text, Image, StyleSheet, View, ActivityIndicator} from 'react-native';
 
 import {MediaItem} from 'types/nationalAvalancheCenter';
+import {HTMLRenderer} from 'components/text/HTMLRenderer';
 
 export interface AvalancheProblemImageProps {
   media: MediaItem;
@@ -14,14 +14,8 @@ interface dimensions {
   width: number;
 }
 
-const baseStyle = Object.freeze({
-  fontStyle: 'italic',
-  fontWeight: '300',
-});
-
 export const AvalancheProblemImage: React.FunctionComponent<AvalancheProblemImageProps> = ({media}) => {
   const [gallery] = React.useState<boolean>(false);
-  const {width} = useWindowDimensions();
   const [imageDimensions, setImageDimensions] = React.useState<dimensions>({height: 0, width: 0});
   const [error, setError] = React.useState<string>('');
 
@@ -50,7 +44,7 @@ export const AvalancheProblemImage: React.FunctionComponent<AvalancheProblemImag
       {!gallery ? (
         <View style={styles.container}>
           <Image source={{uri: media.url.original}} style={{width: '70%', aspectRatio: imageDimensions.height / imageDimensions.width}} />
-          <RenderHTML source={{html: media.caption}} baseStyle={baseStyle} contentWidth={width} />
+          <HTMLRenderer source={{html: `<em>${media.caption}</em>`}} />
         </View>
       ) : (
         <></>

--- a/components/Observation.tsx
+++ b/components/Observation.tsx
@@ -30,7 +30,7 @@ import {
   PartnerType,
 } from '../types/nationalAvalancheCenter';
 import {zone} from './Observations';
-import {HTMLRenderer} from './text/HTMLRenderer';
+import {HTML} from './text/HTML';
 import {AvalancheProblemImage} from './AvalancheProblemImage';
 import {NACIcon} from './icons/nac-icons';
 import {utcDateToLocalTimeString} from 'utils/date';
@@ -105,7 +105,7 @@ export const ObservationCard: React.FunctionComponent<{
               <Heading>Observation Summary</Heading>
             </Row>
           }>
-          <HTMLRenderer source={{html: observation.observationSummary}} />
+          <HTML source={{html: observation.observationSummary}} />
           {anySignsOfInstability && (
             <Column space="2" style={{flex: 1}}>
               <Text bold style={{textTransform: 'uppercase'}}>
@@ -154,7 +154,7 @@ export const ObservationCard: React.FunctionComponent<{
               <Text bold style={{textTransform: 'uppercase'}}>
                 {'Instability Comments'}
               </Text>
-              <HTMLRenderer source={{html: observation.instabilitySummary}} />
+              <HTML source={{html: observation.instabilitySummary}} />
             </Column>
           )}
         </CollapsibleCard>
@@ -234,7 +234,7 @@ export const ObservationCard: React.FunctionComponent<{
                         <Text bold style={{textTransform: 'uppercase'}}>
                           {'Avalanche Comments'}
                         </Text>
-                        <HTMLRenderer source={{html: item.comments}} />
+                        <HTML source={{html: item.comments}} />
                       </Column>
                     )}
                   </>
@@ -245,7 +245,7 @@ export const ObservationCard: React.FunctionComponent<{
                 <Text bold style={{textTransform: 'uppercase'}}>
                   {'Avalanche Summary'}
                 </Text>
-                <HTMLRenderer source={{html: observation.avalanchesSummary}} />
+                <HTML source={{html: observation.avalanchesSummary}} />
               </Column>
             )}
           </CollapsibleCard>
@@ -286,7 +286,7 @@ export const ObservationCard: React.FunctionComponent<{
                   <Text bold style={{textTransform: 'uppercase'}}>
                     {'Weather Summary'}
                   </Text>
-                  <HTMLRenderer source={{html: observation.advancedFields.weatherSummary}} />
+                  <HTML source={{html: observation.advancedFields.weatherSummary}} />
                 </Column>
               )}
             </>
@@ -313,7 +313,7 @@ export const ObservationCard: React.FunctionComponent<{
                     <Text bold style={{textTransform: 'uppercase'}}>
                       {'Snowpack Summary'}
                     </Text>
-                    <HTMLRenderer source={{html: observation.advancedFields.snowpackSummary}} />
+                    <HTML source={{html: observation.advancedFields.snowpackSummary}} />
                   </Column>
                 )}
               </>

--- a/components/Observations.tsx
+++ b/components/Observations.tsx
@@ -13,7 +13,7 @@ import {OverviewFragment, useObservationsQuery} from 'hooks/useObservations';
 import {useMapLayer} from 'hooks/useMapLayer';
 import {AvalancheCenterID, FormatAvalancheProblemDistribution, FormatPartnerType, MapLayer, PartnerType} from '../types/nationalAvalancheCenter';
 import {Title3Semibold} from './text';
-import {HTMLRenderer} from './text/HTMLRenderer';
+import {HTML} from './text/HTML';
 import {NACIcon} from './icons/nac-icons';
 import {utcDateToLocalTimeString} from 'utils/date';
 
@@ -165,7 +165,7 @@ export const ObservationSummaryCard: React.FunctionComponent<{
           <Text bold style={{textTransform: 'uppercase'}}>
             {'Observation Summary'}
           </Text>
-          <HTMLRenderer source={{html: observation.observationSummary}} />
+          <HTML source={{html: observation.observationSummary}} />
         </Column>
       )}
     </Card>

--- a/components/forecast/AvalancheTab.tsx
+++ b/components/forecast/AvalancheTab.tsx
@@ -9,7 +9,7 @@ import {AvalancheDangerTable} from 'components/AvalancheDangerTable';
 import {AvalancheDangerIcon} from 'components/AvalancheDangerIcon';
 import {AvalancheProblemCard} from 'components/AvalancheProblemCard';
 import {Card, CollapsibleCard} from 'components/Card';
-import {HTMLRenderer} from 'components/text/HTMLRenderer';
+import {HTML} from 'components/text/HTML';
 import {utcDateToLocalTimeString} from 'utils/date';
 
 interface AvalancheTabProps {
@@ -76,7 +76,7 @@ export const AvalancheTab: React.FunctionComponent<AvalancheTabProps> = React.me
             <Heading>The Bottom Line</Heading>
           </HStack>
         }>
-        <HTMLRenderer source={{html: forecast.bottom_line}} />
+        <HTML source={{html: forecast.bottom_line}} />
       </Card>
       <Card borderRadius={0} borderColor="white" header={<Heading>Avalanche Danger</Heading>}>
         <AvalancheDangerTable date={parseISO(forecast.published_time)} current={currentDanger} elevation_band_names={elevationBandNames} />
@@ -87,7 +87,7 @@ export const AvalancheTab: React.FunctionComponent<AvalancheTabProps> = React.me
         </CollapsibleCard>
       ))}
       <CollapsibleCard startsCollapsed borderRadius={0} borderColor="white" header={<Heading>Forecast Discussion</Heading>}>
-        <HTMLRenderer source={{html: forecast.hazard_discussion}} />
+        <HTML source={{html: forecast.hazard_discussion}} />
       </CollapsibleCard>
       <Card borderRadius={0} borderColor="white" header={<Heading>Media</Heading>}>
         <Text>TBD!</Text>

--- a/components/text/HTML.tsx
+++ b/components/text/HTML.tsx
@@ -45,7 +45,7 @@ export const HTMLRendererConfig: React.FunctionComponent<{children?: ReactNode |
   );
 };
 
-export const HTMLRenderer: React.FunctionComponent<RenderHTMLSourceProps> = props => {
+export const HTML: React.FunctionComponent<RenderHTMLSourceProps> = props => {
   const {width: windowWidth} = useWindowDimensions();
   const defaultProps: Partial<RenderHTMLSourceProps> = {
     contentWidth: windowWidth,

--- a/components/text/HTMLRenderer.tsx
+++ b/components/text/HTMLRenderer.tsx
@@ -1,8 +1,8 @@
-import React, {useState} from 'react';
+import React, {ReactNode, useState} from 'react';
 import * as _ from 'lodash';
 
 import {useToken, Text, ScrollView} from 'native-base';
-import {RenderHTML, RenderHTMLProps} from 'react-native-render-html';
+import {RenderHTMLConfigProvider, RenderHTMLSource, RenderHTMLSourceProps, TRenderEngineProvider} from 'react-native-render-html';
 import {TouchableOpacity, useWindowDimensions} from 'react-native';
 import Constants from 'expo-constants';
 
@@ -20,29 +20,35 @@ const systemFonts = [
   'Lato_900Black_Italic',
 ];
 
-export const HTMLRenderer: React.FunctionComponent<RenderHTMLProps> = props => {
-  const {width: windowWidth} = useWindowDimensions();
+export const HTMLRendererConfig: React.FunctionComponent<{children?: ReactNode | undefined}> = ({children}) => {
   const [textColor] = useToken('colors', ['darkText']);
-  const defaultProps: Partial<RenderHTMLProps> = {
-    contentWidth: windowWidth,
-    defaultTextProps: {
-      style: {
+  return (
+    <TRenderEngineProvider
+      baseStyle={{
         fontSize: 16,
-      },
-    },
-    tagsStyles: {
-      p: {
         fontFamily: 'Lato_400Regular',
         color: textColor,
-      },
-      strong: {
-        fontFamily: 'Lato_700Bold',
-      },
-      em: {
-        fontFamily: 'Lato_400Regular_Italic',
-      },
-    },
-    systemFonts,
+      }}
+      tagsStyles={{
+        strong: {
+          fontFamily: 'Lato_700Bold',
+        },
+        em: {
+          fontFamily: 'Lato_400Regular_Italic',
+        },
+      }}
+      systemFonts={systemFonts}>
+      <RenderHTMLConfigProvider enableExperimentalBRCollapsing enableExperimentalMarginCollapsing>
+        {children}
+      </RenderHTMLConfigProvider>
+    </TRenderEngineProvider>
+  );
+};
+
+export const HTMLRenderer: React.FunctionComponent<RenderHTMLSourceProps> = props => {
+  const {width: windowWidth} = useWindowDimensions();
+  const defaultProps: Partial<RenderHTMLSourceProps> = {
+    contentWidth: windowWidth,
   };
 
   if (__DEV__) {
@@ -56,11 +62,11 @@ export const HTMLRenderer: React.FunctionComponent<RenderHTMLProps> = props => {
             <Text fontFamily="Courier New">{html}</Text>
           </ScrollView>
         ) : (
-          <RenderHTML {..._.merge(defaultProps, props || {})} />
+          <RenderHTMLSource {..._.merge(defaultProps, props || {})} />
         )}
       </TouchableOpacity>
     );
   }
 
-  return <RenderHTML {..._.merge(defaultProps, props || {})} />;
+  return <RenderHTMLSource {..._.merge(defaultProps, props || {})} />;
 };


### PR DESCRIPTION
** not ready to merge yet **

1. As recommended in docs, this PR changes our internals to use the [RenderHTMLSource](https://meliorence.github.io/react-native-render-html/api/renderhtmlsource) component, which decouples renderer setup from actual rendering
2. Converts any remaining instances of the raw `RenderHTML` component to use our `HTMLRenderer` wrapper

Unfortunately this PR exposes the fact that preloading is causing ~50 re-renders of the top-level App. The following gets dumped to the console over and over:
```
 WARN  You seem to update props of the "TRenderEngineProvider" component in short periods of time, causing costly tree rerenders (last update was 59.86ms ago). See https://stackoverflow.com/q/68966120/2779871 
    at TRenderEngineProvider (http://192.168.4.217:19000/node_modules/expo/AppEntry.bundle?platform=ios&dev=true&hot=false:255676:24)
    at HTMLRendererConfig (http://192.168.4.217:19000/node_modules/expo/AppEntry.bundle?platform=ios&dev=true&hot=false:277852:24)
    at $29383e587d62412a$export$9f8ac96af4b1b2ae (http://192.168.4.217:19000/node_modules/expo/AppEntry.bundle?platform=ios&dev=true&hot=false:190871:43)
    at ToastProvider (http://192.168.4.217:19000/node_modules/expo/AppEntry.bundle?platform=ios&dev=true&hot=false:237761:25)
    at PortalProvider (http://192.168.4.217:19000/node_modules/expo/AppEntry.bundle?platform=ios&dev=true&hot=false:234744:50)
    at HybridProvider (http://192.168.4.217:19000/node_modules/expo/AppEntry.bundle?platform=ios&dev=true&hot=false:244259:24)
    at ResponsiveQueryProvider (http://192.168.4.217:19000/node_modules/expo/AppEntry.bundle?platform=ios&dev=true&hot=false:177852:14)
    at RNCSafeAreaProvider
    at SafeAreaProvider (http://192.168.4.217:19000/node_modules/expo/AppEntry.bundle?platform=ios&dev=true&hot=false:107034:24)
    at NativeBaseConfigProviderProvider (http://192.168.4.217:19000/node_modules/expo/AppEntry.bundle?platform=ios&dev=true&hot=false:171498:27)
    at NativeBaseProvider (http://192.168.4.217:19000/node_modules/expo/AppEntry.bundle?platform=ios&dev=true&hot=false:244191:33)
    at BaseApp (http://192.168.4.217:19000/App.bundle?platform=ios&hot=false&dev=true&minify=false&modulesOnly=true&runModule=false&shallow=true:148:23)
    at AppWithClientContext (http://192.168.4.217:19000/App.bundle?platform=ios&hot=false&dev=true&minify=false&modulesOnly=true&runModule=false&shallow=true:131:50)
    at QueryClientProvider (http://192.168.4.217:19000/node_modules/expo/AppEntry.bundle?platform=ios&dev=true&hot=false:168639:22)
    at App (http://192.168.4.217:19000/App.bundle?platform=ios&hot=false&dev=true&minify=false&modulesOnly=true&runModule=false&shallow=true:114:46)
    at withDevTools(App) (http://192.168.4.217:19000/node_modules/expo/AppEntry.bundle?platform=ios&dev=true&hot=false:99275:27)
    at RCTView
    at View
    at RCTView
    at View
    at AppContainer (http://192.168.4.217:19000/node_modules/expo/AppEntry.bundle?platform=ios&dev=true&hot=false:86177:36)
    at main(RootComponent) (http://192.168.4.217:19000/node_modules/expo/AppEntry.bundle?platform=ios&dev=true&hot=false:91377:28)
```

We have to either disable preloading or fix it before merging this.