### PR TITLE
Finish configuration of react-native-reanimated

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -10,6 +10,7 @@ module.exports = function (api) {
           extensions: ['.tsx', '.ts', '.js', '.json'],
         },
       ],
+      'react-native-reanimated/plugin',
     ],
   };
 };


### PR DESCRIPTION
I added a reference to `react-native-reanimated` when adding collapsible card support in https://github.com/stevekuznetsov/avalanche-forecast/pull/43. It turns out that the package has 1 additional install step as documented [here](https://docs.expo.dev/versions/latest/sdk/reanimated/), but I missed it because I was just following instructions for installing `react-native-collapsible`.

AFAICT this change is a no-op as we don't use `react-native-reanimated` directly, but without this we would not be able to use it in our own code. 

How I found this: debugging the app on android, and happened to see a warning get thrown! Not sure why the warning is generally swallowed by default - it could be because package init happens so early.