### PR TITLE
Avalanche outlook changes

### DIFF
--- a/components/AvalancheDangerIcon.tsx
+++ b/components/AvalancheDangerIcon.tsx
@@ -1,5 +1,5 @@
-import React, {ReactElement} from 'react';
-import {Image, ImageStyle} from 'react-native';
+import React from 'react';
+import {Image, ImageSourcePropType, ImageStyle} from 'react-native';
 
 import {DangerLevel} from 'types/nationalAvalancheCenter';
 
@@ -8,52 +8,35 @@ export interface AvalancheDangerIconProps {
   level: DangerLevel;
 }
 
-interface size {
+const icons: Record<DangerLevel, ImageSourcePropType> = {
+  [DangerLevel.GeneralInformation]: require('../assets/danger-icons/0.png'),
+  [DangerLevel.None]: require('../assets/danger-icons/0.png'),
+  [DangerLevel.Low]: require('../assets/danger-icons/1.png'),
+  [DangerLevel.Moderate]: require('../assets/danger-icons/2.png'),
+  [DangerLevel.Considerable]: require('../assets/danger-icons/3.png'),
+  [DangerLevel.High]: require('../assets/danger-icons/4.png'),
+  [DangerLevel.Extreme]: require('../assets/danger-icons/5.png'),
+};
+
+const sizes = Object.keys(icons).reduce((accum, key) => {
+  accum[key] = Image.resolveAssetSource(icons[key]);
+  return accum;
+}, {});
+
+interface Size {
   width: number;
   height: number;
 }
+
+export const iconSize = (dangerLevel: DangerLevel): Size => sizes[dangerLevel];
 
 export const AvalancheDangerIcon: React.FunctionComponent<AvalancheDangerIconProps> = ({style, level}: AvalancheDangerIconProps) => {
   if (level === null) {
     level = DangerLevel.None;
   }
-  /* eslint-disable @typescript-eslint/no-var-requires */
-  const sizes: Record<DangerLevel, size> = {
-    [DangerLevel.GeneralInformation]: Image.resolveAssetSource(require('../assets/danger-icons/0.png')),
-    [DangerLevel.None]: Image.resolveAssetSource(require('../assets/danger-icons/0.png')),
-    [DangerLevel.Low]: Image.resolveAssetSource(require('../assets/danger-icons/1.png')),
-    [DangerLevel.Moderate]: Image.resolveAssetSource(require('../assets/danger-icons/2.png')),
-    [DangerLevel.Considerable]: Image.resolveAssetSource(require('../assets/danger-icons/3.png')),
-    [DangerLevel.High]: Image.resolveAssetSource(require('../assets/danger-icons/4.png')),
-    [DangerLevel.Extreme]: Image.resolveAssetSource(require('../assets/danger-icons/5.png')),
-  };
 
-  const images: Record<DangerLevel, {(s: ImageStyle): ReactElement}> = {
-    [DangerLevel.GeneralInformation]: (s: ImageStyle) => {
-      return <Image style={s} source={require('../assets/danger-icons/0.png')} />;
-    },
-    [DangerLevel.None]: (s: ImageStyle) => {
-      return <Image style={s} source={require('../assets/danger-icons/0.png')} />;
-    },
-    [DangerLevel.Low]: (s: ImageStyle) => {
-      return <Image style={s} source={require('../assets/danger-icons/1.png')} />;
-    },
-    [DangerLevel.Moderate]: (s: ImageStyle) => {
-      return <Image style={s} source={require('../assets/danger-icons/2.png')} />;
-    },
-    [DangerLevel.Considerable]: (s: ImageStyle) => {
-      return <Image style={s} source={require('../assets/danger-icons/3.png')} />;
-    },
-    [DangerLevel.High]: (s: ImageStyle) => {
-      return <Image style={s} source={require('../assets/danger-icons/4.png')} />;
-    },
-    [DangerLevel.Extreme]: (s: ImageStyle) => {
-      return <Image style={s} source={require('../assets/danger-icons/5.png')} />;
-    },
-  };
-  /* eslint-enable @typescript-eslint/no-var-requires */
   const actualStyle: ImageStyle = {...style};
   actualStyle.width = undefined;
   actualStyle.aspectRatio = sizes[level].width / sizes[level].height;
-  return images[level](actualStyle);
+  return <Image style={actualStyle} source={icons[level]} />;
 };

--- a/components/AvalancheDangerPyramid.tsx
+++ b/components/AvalancheDangerPyramid.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import * as _ from 'lodash';
+
 import Svg, {Path, SvgProps} from 'react-native-svg';
 import {StyleSheet} from 'react-native';
 
@@ -33,7 +35,7 @@ export interface AvalancheDangerPyramidProps extends SvgProps {
 }
 export const AvalancheDangerPyramid: React.FunctionComponent<AvalancheDangerPyramidProps> = ({forecast, ...props}) => {
   return (
-    <Svg style={styles.pyramid} viewBox={'0 0 250 300'} {...props}>
+    <Svg viewBox={'0 0 250 300'} {..._.merge(props, {style: styles.pyramid})}>
       <Path d="M31.504,210l175,0l43.496,90l-250,0l31.504,-90Z" fill={colorFor(forecast.lower).string()} strokeWidth={0} />
       <Path d="M204.087,205l-170.833,0l31.503,-90l95.834,0l43.496,90Z" fill={colorFor(forecast.middle).string()} strokeWidth={0} />
       <Path d="M158.174,110l-91.666,0l38.504,-110l53.162,110Z" fill={colorFor(forecast.upper).string()} strokeWidth={0} />

--- a/components/AvalancheDangerTable.tsx
+++ b/components/AvalancheDangerTable.tsx
@@ -10,31 +10,46 @@ import {Body, Caption1, Caption1Semibold} from 'components/text';
 import {AvalancheDangerPyramid} from './AvalancheDangerPyramid';
 import {AvalancheDangerIcon} from './AvalancheDangerIcon';
 
+export type DangerTableSize = 'main' | 'outlook';
+
 export interface AvalancheDangerTableProps {
   date: Date;
   current: AvalancheDangerForecast;
   elevation_band_names: ElevationBandNames;
+  size: DangerTableSize;
 }
 
-export const AvalancheDangerTable: React.FunctionComponent<AvalancheDangerTableProps> = ({date, current, elevation_band_names}: AvalancheDangerTableProps) => {
+export const AvalancheDangerTable: React.FunctionComponent<AvalancheDangerTableProps> = ({date, current, elevation_band_names, size}: AvalancheDangerTableProps) => {
+  const {height, marginLeft, paddingTop} = {
+    main: {
+      height: '200',
+      paddingTop: '13px',
+      marginLeft: -6,
+    },
+    outlook: {
+      height: '150',
+      paddingTop: '10px',
+      marginLeft: 16,
+    },
+  }[size];
   return (
     <VStack space={3} alignItems="stretch">
       <Body>{utcDateToLocalDateString(date)}</Body>
-      <View height="200" width="100%">
+      <View height={height} width="100%">
         {/* This view contains 3 layers stacked over each other: the background bars in gray, the avalanche pyramid, and the text labels and icons */}
-        <VStack width="100%" height="100%" position="absolute" justifyContent="space-evenly" alignItems="stretch" alignContent="stretch" space="3px" paddingTop="13px" zIndex={10}>
+        <VStack width="100%" height="100%" position="absolute" justifyContent="space-evenly" alignItems="stretch" space="3px" paddingTop={paddingTop} zIndex={10}>
           <View bg="gray.100" flex={1} />
           <View bg="gray.100" flex={1} />
           <View bg="gray.100" flex={1} />
         </VStack>
         <View width="100%" height="100%" position="absolute" zIndex={20}>
-          <AvalancheDangerPyramid forecast={current} height="100%" />
+          <AvalancheDangerPyramid forecast={current} height="100%" style={{marginLeft: marginLeft}} />
         </View>
-        <VStack width="100%" height="100%" position="absolute" justifyContent="space-evenly" alignItems="stretch" space="3px" paddingTop="13px" zIndex={30}>
+        <VStack width="100%" height="100%" position="absolute" justifyContent="space-evenly" alignItems="stretch" space="3px" paddingTop={paddingTop} zIndex={30}>
           {['upper', 'middle', 'lower'].map((layer, index) => (
             <HStack flex={1} justifyContent="space-between" key={index}>
-              <View bg="white" my={4} px={1} justifyContent="center">
-                <Caption1 color="lightText">{elevation_band_names[layer]}</Caption1>
+              <View my={4} px={1} justifyContent="center">
+                <Caption1>{elevation_band_names[layer]}</Caption1>
               </View>
               <HStack space={2} alignItems="center" px={1}>
                 <View my={4} px={1} justifyContent="center">

--- a/components/AvalancheDangerTable.tsx
+++ b/components/AvalancheDangerTable.tsx
@@ -8,18 +8,18 @@ import {utcDateToLocalDateString} from 'utils/date';
 import {Body, Caption1, Caption1Semibold} from 'components/text';
 
 import {AvalancheDangerPyramid} from './AvalancheDangerPyramid';
-import {AvalancheDangerIcon} from './AvalancheDangerIcon';
+import {AvalancheDangerIcon, iconSize} from './AvalancheDangerIcon';
 
 export type DangerTableSize = 'main' | 'outlook';
 
 export interface AvalancheDangerTableProps {
   date: Date;
-  current: AvalancheDangerForecast;
+  forecast: AvalancheDangerForecast;
   elevation_band_names: ElevationBandNames;
   size: DangerTableSize;
 }
 
-export const AvalancheDangerTable: React.FunctionComponent<AvalancheDangerTableProps> = ({date, current, elevation_band_names, size}: AvalancheDangerTableProps) => {
+export const AvalancheDangerTable: React.FunctionComponent<AvalancheDangerTableProps> = ({date, forecast: current, elevation_band_names, size}: AvalancheDangerTableProps) => {
   const {height, marginLeft, paddingTop} = {
     main: {
       height: '200',
@@ -32,6 +32,9 @@ export const AvalancheDangerTable: React.FunctionComponent<AvalancheDangerTableP
       marginLeft: 16,
     },
   }[size];
+
+  const maxIconWidth = Math.max(...[current.lower, current.middle, current.upper].map(d => iconSize(d).width));
+
   return (
     <VStack space={3} alignItems="stretch">
       <Body>{utcDateToLocalDateString(date)}</Body>
@@ -55,7 +58,12 @@ export const AvalancheDangerTable: React.FunctionComponent<AvalancheDangerTableP
                 <View my={4} px={1} justifyContent="center">
                   <Caption1Semibold style={{textTransform: 'uppercase'}}>{dangerText(current[layer])}</Caption1Semibold>
                 </View>
-                <AvalancheDangerIcon style={{height: 32}} level={current[layer]} />
+                {(() => {
+                  const size = iconSize(current[layer]);
+                  const scale = 32.0 / size.height;
+                  const rightMargin = Math.max(0, maxIconWidth - size.width) * scale;
+                  return <AvalancheDangerIcon style={{height: 32, marginRight: rightMargin}} level={current[layer]} />;
+                })()}
               </HStack>
             </HStack>
           ))}

--- a/components/forecast/AvalancheTab.tsx
+++ b/components/forecast/AvalancheTab.tsx
@@ -11,7 +11,6 @@ import {AvalancheProblemCard} from 'components/AvalancheProblemCard';
 import {Card, CollapsibleCard} from 'components/Card';
 import {HTML} from 'components/text/HTML';
 import {utcDateToLocalTimeString} from 'utils/date';
-import {AvalancheOutlook} from './AvalancheOutlook';
 
 interface AvalancheTabProps {
   zone: AvalancheForecastZone;
@@ -80,10 +79,10 @@ export const AvalancheTab: React.FunctionComponent<AvalancheTabProps> = React.me
         <HTML source={{html: forecast.bottom_line}} />
       </Card>
       <Card borderRadius={0} borderColor="white" header={<Heading>Avalanche Danger</Heading>}>
-        <AvalancheDangerTable date={parseISO(forecast.published_time)} current={currentDanger} elevation_band_names={elevationBandNames} size={'main'} />
+        <AvalancheDangerTable date={parseISO(forecast.published_time)} forecast={currentDanger} elevation_band_names={elevationBandNames} size={'main'} />
       </Card>
-      <CollapsibleCard startsCollapsed={false} borderRadius={0} borderColor="white" header={<Heading>Outlook</Heading>}>
-        <AvalancheDangerTable date={addDays(parseISO(forecast.published_time), 1)} current={currentDanger} elevation_band_names={elevationBandNames} size={'outlook'} />
+      <CollapsibleCard startsCollapsed borderRadius={0} borderColor="white" header={<Heading>Outlook</Heading>}>
+        <AvalancheDangerTable date={addDays(parseISO(forecast.published_time), 1)} forecast={outlookDanger} elevation_band_names={elevationBandNames} size={'outlook'} />
       </CollapsibleCard>
       {forecast.forecast_avalanche_problems.map((problem, index) => (
         <CollapsibleCard key={`avalanche-problem-${index}-card`} startsCollapsed borderRadius={0} borderColor="white" header={<Heading>Avalanche Problem #{index + 1}</Heading>}>

--- a/components/forecast/AvalancheTab.tsx
+++ b/components/forecast/AvalancheTab.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import {Heading, HStack, Text, VStack} from 'native-base';
 
-import {parseISO} from 'date-fns';
+import {addDays, parseISO} from 'date-fns';
 
 import {AvalancheDangerForecast, AvalancheForecastZone, DangerLevel, ElevationBandNames, ForecastPeriod, Product} from 'types/nationalAvalancheCenter';
 import {AvalancheDangerTable} from 'components/AvalancheDangerTable';
@@ -11,6 +11,7 @@ import {AvalancheProblemCard} from 'components/AvalancheProblemCard';
 import {Card, CollapsibleCard} from 'components/Card';
 import {HTML} from 'components/text/HTML';
 import {utcDateToLocalTimeString} from 'utils/date';
+import {AvalancheOutlook} from './AvalancheOutlook';
 
 interface AvalancheTabProps {
   zone: AvalancheForecastZone;
@@ -79,8 +80,11 @@ export const AvalancheTab: React.FunctionComponent<AvalancheTabProps> = React.me
         <HTML source={{html: forecast.bottom_line}} />
       </Card>
       <Card borderRadius={0} borderColor="white" header={<Heading>Avalanche Danger</Heading>}>
-        <AvalancheDangerTable date={parseISO(forecast.published_time)} current={currentDanger} elevation_band_names={elevationBandNames} />
+        <AvalancheDangerTable date={parseISO(forecast.published_time)} current={currentDanger} elevation_band_names={elevationBandNames} size={'main'} />
       </Card>
+      <CollapsibleCard startsCollapsed={false} borderRadius={0} borderColor="white" header={<Heading>Outlook</Heading>}>
+        <AvalancheDangerTable date={addDays(parseISO(forecast.published_time), 1)} current={currentDanger} elevation_band_names={elevationBandNames} size={'outlook'} />
+      </CollapsibleCard>
       {forecast.forecast_avalanche_problems.map((problem, index) => (
         <CollapsibleCard key={`avalanche-problem-${index}-card`} startsCollapsed borderRadius={0} borderColor="white" header={<Heading>Avalanche Problem #{index + 1}</Heading>}>
           <AvalancheProblemCard key={`avalanche-problem-${index}`} problem={problem} names={elevationBandNames} />


### PR DESCRIPTION
1. Add the Outlook section (collapsed by default, shown expanded here)
2. Use the same component to render the Outlook and the current danger
3. Fix alignment of danger icons by adding right margin as necessary to bring them visually into line with their siblings

<img width="343" alt="image" src="https://user-images.githubusercontent.com/101196/212166865-7ba1fffc-2e5a-427b-9225-c07e7501567f.png">
