### PR TITLE
Use our own wrapper around View, remove NativeBase wrapper

### DIFF
--- a/components/AvalancheDangerTable.tsx
+++ b/components/AvalancheDangerTable.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
-import {HStack, View, VStack} from 'native-base';
+import {HStack, VStack} from 'native-base';
 
 import {AvalancheDangerForecast, ElevationBandNames} from 'types/nationalAvalancheCenter';
+import {View} from 'components/core/View';
 import {dangerText} from 'components/helpers/dangerText';
 import {utcDateToLocalDateString} from 'utils/date';
 import {Body, Caption1, Caption1Semibold} from 'components/text';
@@ -22,12 +23,12 @@ export interface AvalancheDangerTableProps {
 export const AvalancheDangerTable: React.FunctionComponent<AvalancheDangerTableProps> = ({date, forecast, elevation_band_names, size}: AvalancheDangerTableProps) => {
   const {height, marginLeft, paddingTop} = {
     main: {
-      height: '200',
+      height: 200,
       paddingTop: '13px',
       marginLeft: -6,
     },
     outlook: {
-      height: '150',
+      height: 150,
       paddingTop: '10px',
       marginLeft: 16,
     },

--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -11,10 +11,11 @@ import {
   PanResponderGestureState,
   GestureResponderEvent,
 } from 'react-native';
-import {Alert, Center, HStack, View, VStack} from 'native-base';
+import {Alert, Center, HStack, VStack} from 'native-base';
 import MapView, {Region} from 'react-native-maps';
 import {useNavigation} from '@react-navigation/native';
 
+import {View} from 'components/core/View';
 import {DangerScale} from 'components/DangerScale';
 import {AvalancheCenterID, DangerLevel} from 'types/nationalAvalancheCenter';
 import {AvalancheCenterForecastZonePolygons} from './AvalancheCenterForecastZonePolygons';
@@ -75,7 +76,9 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
         {isReady && <AvalancheCenterForecastZonePolygons key={center} center_id={center} setRegion={setRegion} date={date} />}
       </MapView>
       <SafeAreaView>
-        <DangerScale px="4" width="100%" position="absolute" top="12" />
+        <View flex={1}>
+          <DangerScale px={4} width="100%" position="absolute" top={12} />
+        </View>
       </SafeAreaView>
 
       {isLoading && (
@@ -273,7 +276,7 @@ const AvalancheForecastZoneCard: React.FunctionComponent<{
         });
       }}>
       <VStack borderRadius={8} bg="white" width={width * CARD_WIDTH} marginX={CARD_MARGIN * width}>
-        <View height="8px" width="100%" bg={dangerColor.string()} borderTopRadius={8} pb={0} />
+        <View height={8} width="100%" bg={dangerColor.string()} borderTopLeftRadius={8} borderTopRightRadius={8} pb={0} />
         <VStack px={6} pt={1} pb={3} space={2}>
           <HStack space={2} alignItems="center">
             <AvalancheDangerIcon style={{height: 32}} level={zone.danger_level} />

--- a/components/DangerScale.tsx
+++ b/components/DangerScale.tsx
@@ -4,9 +4,10 @@ import {MaterialIcons} from '@expo/vector-icons';
 
 import {DangerLevel} from 'types/nationalAvalancheCenter';
 import {colorFor} from './AvalancheDangerPyramid';
-import {Center, HStack, View, useToast} from 'native-base';
+import {Center, HStack, useToast} from 'native-base';
 import {BodyXSmBlack, BodyXSmMedium} from 'components/text';
 import {TouchableOpacity} from 'react-native';
+import {View} from 'components/core/View';
 
 export type DangerScaleProps = Omit<React.ComponentProps<typeof View>, 'children'>;
 

--- a/components/core/View.tsx
+++ b/components/core/View.tsx
@@ -1,0 +1,173 @@
+import * as React from 'react';
+
+import {View as RNView, ViewProps as RNViewProps, ViewStyle as RNViewStyle} from 'react-native';
+
+import {colorLookup} from 'theme';
+
+class ViewStyleProps {
+  constructor(
+    readonly backgroundColor?: RNViewStyle['backgroundColor'],
+
+    readonly position?: RNViewStyle['position'],
+    readonly top?: RNViewStyle['top'],
+    readonly left?: RNViewStyle['left'],
+    readonly right?: RNViewStyle['right'],
+    readonly bottom?: RNViewStyle['bottom'],
+    readonly zIndex?: RNViewStyle['zIndex'],
+
+    readonly padding?: RNViewStyle['padding'],
+    readonly paddingHorizontal?: RNViewStyle['paddingHorizontal'],
+    readonly paddingVertical?: RNViewStyle['paddingVertical'],
+    readonly paddingTop?: RNViewStyle['paddingTop'],
+    readonly paddingLeft?: RNViewStyle['paddingLeft'],
+    readonly paddingRight?: RNViewStyle['paddingRight'],
+    readonly paddingBottom?: RNViewStyle['paddingBottom'],
+
+    readonly margin?: RNViewStyle['margin'],
+    readonly marginHorizontal?: RNViewStyle['marginHorizontal'],
+    readonly marginVertical?: RNViewStyle['marginVertical'],
+    readonly marginTop?: RNViewStyle['marginTop'],
+    readonly marginLeft?: RNViewStyle['marginLeft'],
+    readonly marginRight?: RNViewStyle['marginRight'],
+    readonly marginBottom?: RNViewStyle['marginBottom'],
+
+    readonly alignContent?: RNViewStyle['alignContent'],
+    readonly alignItems?: RNViewStyle['alignItems'],
+    readonly alignSelf?: RNViewStyle['alignSelf'],
+    readonly flex?: RNViewStyle['flex'],
+    readonly flexBasis?: RNViewStyle['flexBasis'],
+    readonly flexDirection?: RNViewStyle['flexDirection'],
+    readonly flexGrow?: RNViewStyle['flexGrow'],
+    readonly flexShrink?: RNViewStyle['flexShrink'],
+    readonly flexWrap?: RNViewStyle['flexWrap'],
+    readonly justifyContent?: RNViewStyle['justifyContent'],
+
+    readonly aspectRatio?: RNViewStyle['aspectRatio'],
+    readonly width?: RNViewStyle['width'],
+    readonly height?: RNViewStyle['height'],
+    readonly maxHeight?: RNViewStyle['maxHeight'],
+    readonly maxWidth?: RNViewStyle['maxWidth'],
+    readonly minHeight?: RNViewStyle['minHeight'],
+    readonly minWidth?: RNViewStyle['minWidth'],
+
+    readonly borderBottomLeftRadius?: RNViewStyle['borderBottomLeftRadius'],
+    readonly borderBottomRightRadius?: RNViewStyle['borderBottomRightRadius'],
+    readonly borderTopLeftRadius?: RNViewStyle['borderTopLeftRadius'],
+    readonly borderTopRightRadius?: RNViewStyle['borderTopRightRadius'],
+    readonly borderRadius?: RNViewStyle['borderRadius'],
+    readonly borderBottomWidth?: RNViewStyle['borderBottomWidth'],
+    readonly borderLeftWidth?: RNViewStyle['borderLeftWidth'],
+    readonly borderRightWidth?: RNViewStyle['borderRightWidth'],
+    readonly borderTopWidth?: RNViewStyle['borderTopWidth'],
+    readonly borderWidth?: RNViewStyle['borderWidth'],
+    readonly borderColor?: RNViewStyle['borderColor'],
+
+    readonly display?: RNViewStyle['display'],
+    readonly overflow?: RNViewStyle['overflow'],
+  ) {}
+}
+
+class ViewAliasProps {
+  constructor(
+    readonly bg?: RNViewStyle['backgroundColor'],
+    readonly bgColor?: RNViewStyle['backgroundColor'],
+
+    readonly p?: RNViewStyle['padding'],
+    readonly px?: RNViewStyle['paddingHorizontal'],
+    readonly ph?: RNViewStyle['paddingVertical'],
+    readonly pt?: RNViewStyle['paddingTop'],
+    readonly pl?: RNViewStyle['paddingLeft'],
+    readonly pr?: RNViewStyle['paddingRight'],
+    readonly pb?: RNViewStyle['paddingBottom'],
+
+    readonly m?: RNViewStyle['margin'],
+    readonly mx?: RNViewStyle['marginHorizontal'],
+    readonly my?: RNViewStyle['marginVertical'],
+    readonly mt?: RNViewStyle['marginTop'],
+    readonly ml?: RNViewStyle['marginLeft'],
+    readonly mr?: RNViewStyle['marginRight'],
+    readonly mb?: RNViewStyle['marginBottom'],
+  ) {}
+}
+
+type ViewStyleProp = keyof ViewStyleProps | keyof ViewAliasProps;
+const viewStylePropKeys: ViewStyleProp[] = (Object.keys(new ViewStyleProps()) as ViewStyleProp[]).concat(Object.keys(new ViewAliasProps()) as ViewStyleProp[]);
+
+const propAliasMapping: Record<keyof ViewAliasProps, keyof ViewStyleProps> = {
+  bg: 'backgroundColor',
+  bgColor: 'backgroundColor',
+
+  p: 'padding',
+  px: 'paddingHorizontal',
+  ph: 'paddingVertical',
+  pt: 'paddingTop',
+  pl: 'paddingLeft',
+  pr: 'paddingRight',
+  pb: 'paddingBottom',
+
+  m: 'margin',
+  mx: 'marginHorizontal',
+  my: 'marginVertical',
+  mt: 'marginTop',
+  ml: 'marginLeft',
+  mr: 'marginRight',
+  mb: 'marginBottom',
+} as const;
+
+const dimensionalProps: ViewStyleProp[] = [
+  'bottom',
+  'flexBasis',
+  'height',
+  'left',
+  'margin',
+  'marginBottom',
+  'marginHorizontal',
+  'marginLeft',
+  'marginRight',
+  'marginTop',
+  'marginVertical',
+  'maxHeight',
+  'maxWidth',
+  'minHeight',
+  'minWidth',
+  'padding',
+  'paddingBottom',
+  'paddingHorizontal',
+  'paddingLeft',
+  'paddingRight',
+  'paddingTop',
+  'paddingVertical',
+  'right',
+  'top',
+  'width',
+];
+
+const validateProp = (prop: ViewStyleProp, value): void => {
+  if (dimensionalProps.includes(prop) && typeof value === 'string') {
+    // Dimensions as strings must either specify 'pt' or '%'
+    if (value.slice(-2) !== 'pt' && value.slice(-1) !== '%') {
+      const error = `Invalid string value "${value}" for property ${prop}: string dimensions must specify pt or %`;
+      console.error(error);
+      throw new Error(error);
+    }
+  }
+};
+
+export interface ViewProps extends RNViewProps, ViewStyleProps, ViewAliasProps {}
+export const View: React.FC<ViewProps> = ({children, style = {}, ...props}) => {
+  const resolvedProps: RNViewProps = {style};
+  Object.entries(props).forEach(([key, value]) => {
+    const prop = propAliasMapping[key] || key;
+    if (viewStylePropKeys.includes(prop)) {
+      if (['backgroundColor'].includes(prop) && typeof value === 'string') {
+        value = colorLookup(value);
+      }
+      validateProp(prop, value);
+      style[prop] = value;
+    } else {
+      resolvedProps[prop] = value;
+    }
+  });
+  // console.log(JSON.stringify(resolvedProps, null, 2));
+  return <RNView {...resolvedProps}>{children}</RNView>;
+};

--- a/components/forecast/AvalancheForecast.tsx
+++ b/components/forecast/AvalancheForecast.tsx
@@ -3,7 +3,7 @@ import React, {useEffect} from 'react';
 import {ActivityIndicator, Alert, RefreshControl, ScrollView, StyleSheet} from 'react-native';
 import {useNavigation} from '@react-navigation/native';
 
-import {View} from 'native-base';
+import {View} from 'components/core/View';
 
 import {parseISO} from 'date-fns';
 

--- a/components/screens/MenuScreen.tsx
+++ b/components/screens/MenuScreen.tsx
@@ -5,7 +5,7 @@ import {SafeAreaView} from 'react-native-safe-area-context';
 
 import * as Updates from 'expo-updates';
 
-import {HStack, VStack, Divider, SectionList, View} from 'native-base';
+import {HStack, VStack, Divider, SectionList} from 'native-base';
 
 import {AvalancheCenterCard, AvalancheCenterSelector} from 'components/AvalancheCenterSelector';
 
@@ -13,6 +13,9 @@ import {createNativeStackNavigator, NativeStackScreenProps} from '@react-navigat
 
 import {MenuStackParamList, MenuStackNavigationProps} from 'routes';
 import {useNavigation} from '@react-navigation/native';
+
+import {View} from 'components/core/View';
+
 import {
   AllCapsSm,
   AllCapsSmBlack,
@@ -165,7 +168,7 @@ const TextStylePreview = () => {
         sections={data}
         keyExtractor={item => item.content}
         renderItem={({item}) => <item.Component>{item.content}</item.Component>}
-        renderSectionHeader={() => <View height="4" />}
+        renderSectionHeader={() => <View height={4} />}
       />
     </SafeAreaView>
   );


### PR DESCRIPTION
This mimics the NativeBase View wrapper by adding style props as top-level props to View, and by adding some handy shortcuts to those props, e.g. `mx` for `marginHorizontal`.

I'll add some notes inline!