### PR TITLE
Finish removing NativeBase from app

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -26,8 +26,6 @@ import * as Sentry from 'sentry-expo';
 import {formatISO} from 'date-fns';
 import {focusManager, QueryClient, QueryClientProvider, useQueryClient} from 'react-query';
 
-import {NativeBaseProvider, extendTheme} from 'native-base';
-
 import {ClientContext, ClientProps, productionHosts, stagingHosts} from 'clientContext';
 import {useAppState} from 'hooks/useAppState';
 import {useOnlineManager} from 'hooks/useOnlineManager';
@@ -74,57 +72,6 @@ const onAppStateChange = (status: AppStateStatus) => {
 // If you want to investigate an issue on a different day, you can change this value.
 // TODO: add a date picker
 const defaultDate = formatISO(Date.now());
-
-const theme = extendTheme({
-  colors: {
-    darkText: '#333333',
-    lightText: '#999999',
-  },
-  fontConfig: {
-    Lato: {
-      100: {
-        normal: 'Lato_100Thin',
-        italic: 'Lato_100ThinItalic',
-      },
-      200: {
-        normal: 'Lato_100Thin',
-        italic: 'Lato_100ThinItalic',
-      },
-      300: {
-        normal: 'Lato_300Light',
-        italic: 'Lato_300LightItalic',
-      },
-      400: {
-        normal: 'Lato_400Regular',
-        italic: 'Lato_400RegularItalic',
-      },
-      500: {
-        normal: 'Lato_400Regular',
-        italic: 'Lato_400RegularItalic',
-      },
-      600: {
-        normal: 'Lato_400Regular',
-        italic: 'Lato_400RegularItalic',
-      },
-      700: {
-        normal: 'Lato_700Bold',
-        italic: 'Lato_700BoldItalic',
-      },
-      800: {
-        normal: 'Lato_700Bold',
-        italic: 'Lato_700BoldItalic',
-      },
-      900: {
-        normal: 'Lato_900Black',
-        italic: 'Lato_900BlackItalic',
-      },
-    },
-  },
-  fonts: {
-    heading: 'Lato',
-    body: 'Lato',
-  },
-});
 
 const App = () => {
   try {
@@ -198,45 +145,43 @@ const BaseApp: React.FunctionComponent<{
   }
 
   return (
-    <NativeBaseProvider theme={theme}>
-      <HTMLRendererConfig>
-        <SafeAreaProvider>
-          <NavigationContainer>
-            <View onLayout={onLayoutRootView} style={StyleSheet.absoluteFill}>
-              <TabNavigator.Navigator
-                initialRouteName="Home"
-                screenOptions={({route}) => ({
-                  headerShown: false,
-                  tabBarIcon: ({color, size}) => {
-                    if (route.name === 'Home') {
-                      return <AntDesign name="search1" size={size} color={color} />;
-                    } else if (route.name === 'Observations') {
-                      return <AntDesign name="filetext1" size={size} color={color} />;
-                    } else if (route.name === 'Weather Data') {
-                      return <AntDesign name="barschart" size={size} color={color} />;
-                    } else if (route.name === 'Menu') {
-                      return <AntDesign name="bars" size={size} color={color} />;
-                    }
-                  },
-                })}>
-                <TabNavigator.Screen name="Home" initialParams={{center_id: avalancheCenterId, date: date}}>
-                  {state => HomeTabScreen(withParams(state, {center_id: avalancheCenterId, date: date}))}
-                </TabNavigator.Screen>
-                <TabNavigator.Screen name="Observations" initialParams={{center_id: avalancheCenterId, date: date}}>
-                  {state => ObservationsTabScreen(withParams(state, {center_id: avalancheCenterId, date: date}))}
-                </TabNavigator.Screen>
-                <TabNavigator.Screen name="Weather Data" initialParams={{center_id: avalancheCenterId, date: date}}>
-                  {state => TelemetryTabScreen(withParams(state, {center_id: avalancheCenterId, date: date}))}
-                </TabNavigator.Screen>
-                <TabNavigator.Screen name="Menu" initialParams={{center_id: avalancheCenterId}}>
-                  {() => MenuStackScreen(avalancheCenterId, setAvalancheCenterId, staging, setStaging)}
-                </TabNavigator.Screen>
-              </TabNavigator.Navigator>
-            </View>
-          </NavigationContainer>
-        </SafeAreaProvider>
-      </HTMLRendererConfig>
-    </NativeBaseProvider>
+    <HTMLRendererConfig>
+      <SafeAreaProvider>
+        <NavigationContainer>
+          <View onLayout={onLayoutRootView} style={StyleSheet.absoluteFill}>
+            <TabNavigator.Navigator
+              initialRouteName="Home"
+              screenOptions={({route}) => ({
+                headerShown: false,
+                tabBarIcon: ({color, size}) => {
+                  if (route.name === 'Home') {
+                    return <AntDesign name="search1" size={size} color={color} />;
+                  } else if (route.name === 'Observations') {
+                    return <AntDesign name="filetext1" size={size} color={color} />;
+                  } else if (route.name === 'Weather Data') {
+                    return <AntDesign name="barschart" size={size} color={color} />;
+                  } else if (route.name === 'Menu') {
+                    return <AntDesign name="bars" size={size} color={color} />;
+                  }
+                },
+              })}>
+              <TabNavigator.Screen name="Home" initialParams={{center_id: avalancheCenterId, date: date}}>
+                {state => HomeTabScreen(withParams(state, {center_id: avalancheCenterId, date: date}))}
+              </TabNavigator.Screen>
+              <TabNavigator.Screen name="Observations" initialParams={{center_id: avalancheCenterId, date: date}}>
+                {state => ObservationsTabScreen(withParams(state, {center_id: avalancheCenterId, date: date}))}
+              </TabNavigator.Screen>
+              <TabNavigator.Screen name="Weather Data" initialParams={{center_id: avalancheCenterId, date: date}}>
+                {state => TelemetryTabScreen(withParams(state, {center_id: avalancheCenterId, date: date}))}
+              </TabNavigator.Screen>
+              <TabNavigator.Screen name="Menu" initialParams={{center_id: avalancheCenterId}}>
+                {() => MenuStackScreen(avalancheCenterId, setAvalancheCenterId, staging, setStaging)}
+              </TabNavigator.Screen>
+            </TabNavigator.Navigator>
+          </View>
+        </NavigationContainer>
+      </SafeAreaProvider>
+    </HTMLRendererConfig>
   );
 };
 

--- a/components/AvalancheCenterSelector.tsx
+++ b/components/AvalancheCenterSelector.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {Box, VStack, HStack} from 'native-base';
+import {Box, HStack} from 'native-base';
 import {Text, SectionList, SectionListData, StyleSheet, TouchableOpacity, ActivityIndicator, useWindowDimensions} from 'react-native';
 import {useNavigation} from '@react-navigation/native';
 
@@ -9,6 +9,7 @@ import {useAvalancheCenterMetadata} from 'hooks/useAvalancheCenterMetadata';
 import {TabNavigationProps} from 'routes';
 import {AvalancheCenterID} from '../types/nationalAvalancheCenter';
 import {Body} from './text';
+import {VStack} from 'components/core';
 
 const avalancheCenterIDsByType: SectionListData<AvalancheCenterID>[] = [
   {

--- a/components/AvalancheCenterSelector.tsx
+++ b/components/AvalancheCenterSelector.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import {Box, HStack} from 'native-base';
 import {Text, SectionList, SectionListData, StyleSheet, TouchableOpacity, ActivityIndicator, useWindowDimensions} from 'react-native';
 import {useNavigation} from '@react-navigation/native';
 
@@ -9,7 +8,7 @@ import {useAvalancheCenterMetadata} from 'hooks/useAvalancheCenterMetadata';
 import {TabNavigationProps} from 'routes';
 import {AvalancheCenterID} from '../types/nationalAvalancheCenter';
 import {Body} from './text';
-import {VStack} from 'components/core';
+import {HStack, View, VStack} from 'components/core';
 
 const avalancheCenterIDsByType: SectionListData<AvalancheCenterID>[] = [
   {
@@ -60,50 +59,50 @@ export const AvalancheCenterCard: React.FunctionComponent<AvalancheCenterCardPro
   }
   if (isError) {
     return (
-      <Box>
-        <Box bg="light.100">
+      <View>
+        <View bg="light.100">
           <VStack>
             <HStack justifyContent="flex-start" alignItems="center">
               <Body color="light.400">{`Could not fetch data for ${avalancheCenterId}: ${error?.message}.`}</Body>
             </HStack>
           </VStack>
-        </Box>
-      </Box>
+        </View>
+      </View>
     );
   }
   if (!avalancheCenter) {
     return (
-      <Box>
-        <Box bg="light.100">
+      <View>
+        <View bg="light.100">
           <VStack>
             <HStack justifyContent="flex-start" alignItems="center">
               <Body color="light.400">{`No metadata found for ${avalancheCenterId}.`}</Body>
             </HStack>
           </VStack>
-        </Box>
-      </Box>
+        </View>
+      </View>
     );
   }
 
   return (
-    <Box>
+    <View>
       <TouchableOpacity
         style={styles.item}
         onPress={() => {
           onPress(avalancheCenterId);
         }}>
-        <Box bg={selected ? 'blue.100' : 'light.100'}>
+        <View bg={selected ? 'blue.100' : 'light.100'}>
           <VStack>
-            <HStack justifyContent="flex-start" alignItems="center" px="2" width={width}>
+            <HStack justifyContent="flex-start" alignItems="center" px={8} width={width}>
               <AvalancheCenterLogo style={{height: 36}} avalancheCenterId={avalancheCenterId} />
               <Body style={{paddingHorizontal: 4}} color="light.400">
                 {avalancheCenter.name}
               </Body>
             </HStack>
           </VStack>
-        </Box>
+        </View>
       </TouchableOpacity>
-    </Box>
+    </View>
   );
 };
 

--- a/components/AvalancheDangerTable.tsx
+++ b/components/AvalancheDangerTable.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import {HStack, VStack} from 'native-base';
+import {HStack} from 'native-base';
 
 import {AvalancheDangerForecast, ElevationBandNames} from 'types/nationalAvalancheCenter';
-import {View} from 'components/core/View';
+import {View, VStack} from 'components/core';
 import {dangerText} from 'components/helpers/dangerText';
 import {utcDateToLocalDateString} from 'utils/date';
 import {Body, Caption1, Caption1Semibold} from 'components/text';
@@ -24,12 +24,12 @@ export const AvalancheDangerTable: React.FunctionComponent<AvalancheDangerTableP
   const {height, marginLeft, paddingTop} = {
     main: {
       height: 200,
-      paddingTop: '13px',
+      paddingTop: 13,
       marginLeft: -6,
     },
     outlook: {
       height: 150,
-      paddingTop: '10px',
+      paddingTop: 10,
       marginLeft: 16,
     },
   }[size];
@@ -37,11 +37,11 @@ export const AvalancheDangerTable: React.FunctionComponent<AvalancheDangerTableP
   const maxIconWidth = Math.max(...[forecast.lower, forecast.middle, forecast.upper].map(d => iconSize(d).width));
 
   return (
-    <VStack space={3} alignItems="stretch">
+    <VStack space={12} alignItems="stretch">
       <Body>{utcDateToLocalDateString(date)}</Body>
       <View height={height} width="100%">
         {/* This view contains 3 layers stacked over each other: the background bars in gray, the avalanche pyramid, and the text labels and icons */}
-        <VStack width="100%" height="100%" position="absolute" justifyContent="space-evenly" alignItems="stretch" space="3px" paddingTop={paddingTop} zIndex={10}>
+        <VStack width="100%" height="100%" position="absolute" justifyContent="space-evenly" alignItems="stretch" space={3} paddingTop={paddingTop} zIndex={10}>
           <View bg="gray.100" flex={1} />
           <View bg="gray.100" flex={1} />
           <View bg="gray.100" flex={1} />
@@ -49,7 +49,7 @@ export const AvalancheDangerTable: React.FunctionComponent<AvalancheDangerTableP
         <View width="100%" height="100%" position="absolute" zIndex={20}>
           <AvalancheDangerPyramid forecast={forecast} height="100%" style={{marginLeft: marginLeft}} />
         </View>
-        <VStack width="100%" height="100%" position="absolute" justifyContent="space-evenly" alignItems="stretch" space="3px" paddingTop={paddingTop} zIndex={30}>
+        <VStack width="100%" height="100%" position="absolute" justifyContent="space-evenly" alignItems="stretch" space={3} paddingTop={paddingTop} zIndex={30}>
           {['upper', 'middle', 'lower'].map((layer, index) => (
             <HStack flex={1} justifyContent="space-between" key={index}>
               <View my={4} px={1} justifyContent="center">

--- a/components/AvalancheDangerTable.tsx
+++ b/components/AvalancheDangerTable.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 
-import {HStack} from 'native-base';
-
 import {AvalancheDangerForecast, ElevationBandNames} from 'types/nationalAvalancheCenter';
-import {View, VStack} from 'components/core';
+import {HStack, View, VStack} from 'components/core';
 import {dangerText} from 'components/helpers/dangerText';
 import {utcDateToLocalDateString} from 'utils/date';
 import {Body, Caption1, Caption1Semibold} from 'components/text';
@@ -55,7 +53,7 @@ export const AvalancheDangerTable: React.FunctionComponent<AvalancheDangerTableP
               <View my={4} px={1} justifyContent="center">
                 <Caption1>{elevation_band_names[layer]}</Caption1>
               </View>
-              <HStack space={2} alignItems="center" px={1}>
+              <HStack space={8} alignItems="center" px={1}>
                 <View my={4} px={1} justifyContent="center">
                   <Caption1Semibold style={{textTransform: 'uppercase'}}>{dangerText(forecast[layer])}</Caption1Semibold>
                 </View>

--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -1,17 +1,6 @@
 import React, {useRef, useState} from 'react';
 
-import {
-  Animated,
-  ActivityIndicator,
-  StyleSheet,
-  Text,
-  useWindowDimensions,
-  PanResponder,
-  TouchableWithoutFeedback,
-  PanResponderGestureState,
-  GestureResponderEvent,
-  TouchableOpacity,
-} from 'react-native';
+import {Animated, ActivityIndicator, StyleSheet, Text, useWindowDimensions, PanResponder, PanResponderGestureState, GestureResponderEvent, TouchableOpacity} from 'react-native';
 import MapView, {Region} from 'react-native-maps';
 import {useNavigation} from '@react-navigation/native';
 

--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -11,11 +11,11 @@ import {
   PanResponderGestureState,
   GestureResponderEvent,
 } from 'react-native';
-import {Alert, Center} from 'native-base';
+import {Alert} from 'native-base';
 import MapView, {Region} from 'react-native-maps';
 import {useNavigation} from '@react-navigation/native';
 
-import {HStack, View, VStack} from 'components/core';
+import {Center, HStack, View, VStack} from 'components/core';
 import {DangerScale} from 'components/DangerScale';
 import {AvalancheCenterID, DangerLevel} from 'types/nationalAvalancheCenter';
 import {AvalancheCenterForecastZonePolygons} from './AvalancheCenterForecastZonePolygons';
@@ -82,12 +82,12 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
       </SafeAreaView>
 
       {isLoading && (
-        <Center width="100%" height="100%" position="absolute" top="0">
+        <Center width="100%" height="100%" position="absolute" top={0}>
           <ActivityIndicator size={'large'} />
         </Center>
       )}
       {isError && (
-        <Center width="100%" position="absolute" bottom="6">
+        <Center width="100%" position="absolute" bottom={6}>
           <Alert status={'warning'} px={6} py={4}>
             <HStack space={8} flexShrink={1}>
               <Alert.Icon mt="1" />

--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -11,11 +11,11 @@ import {
   PanResponderGestureState,
   GestureResponderEvent,
 } from 'react-native';
-import {Alert, Center, HStack, VStack} from 'native-base';
+import {Alert, Center, HStack} from 'native-base';
 import MapView, {Region} from 'react-native-maps';
 import {useNavigation} from '@react-navigation/native';
 
-import {View} from 'components/core';
+import {View, VStack} from 'components/core';
 import {DangerScale} from 'components/DangerScale';
 import {AvalancheCenterID, DangerLevel} from 'types/nationalAvalancheCenter';
 import {AvalancheCenterForecastZonePolygons} from './AvalancheCenterForecastZonePolygons';
@@ -275,15 +275,15 @@ const AvalancheForecastZoneCard: React.FunctionComponent<{
           date: date,
         });
       }}>
-      <VStack borderRadius={8} bg="white" width={width * CARD_WIDTH} marginX={CARD_MARGIN * width}>
+      <VStack borderRadius={8} bg="white" width={width * CARD_WIDTH} mx={CARD_MARGIN * width}>
         <View height={8} width="100%" bg={dangerColor.string()} borderTopLeftRadius={8} borderTopRightRadius={8} pb={0} />
-        <VStack px={6} pt={1} pb={3} space={2}>
+        <VStack px={24} pt={4} pb={12} space={8}>
           <HStack space={2} alignItems="center">
             <AvalancheDangerIcon style={{height: 32}} level={zone.danger_level} />
             <DangerLevelTitle dangerLevel={zone.danger_level} danger={zone.danger} />
           </HStack>
           <Title3Black>{zone.name}</Title3Black>
-          <VStack py={2}>
+          <VStack py={8}>
             <Text>
               <Caption1Black>Published: </Caption1Black>
               <Caption1>{utcDateToLocalTimeString(zone.start_date)}</Caption1>

--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -11,7 +11,6 @@ import {
   PanResponderGestureState,
   GestureResponderEvent,
 } from 'react-native';
-import {Alert} from 'native-base';
 import MapView, {Region} from 'react-native-maps';
 import {useNavigation} from '@react-navigation/native';
 
@@ -28,6 +27,8 @@ import {colorFor} from './AvalancheDangerPyramid';
 import {utcDateToLocalTimeString} from 'utils/date';
 import {parseISO} from 'date-fns';
 import {TravelAdvice} from './helpers/travelAdvice';
+import {COLORS} from 'theme/colors';
+import {FontAwesome5} from '@expo/vector-icons';
 
 export const defaultRegion: Region = {
   // TODO(skuznets): add a sane default for the US?
@@ -88,12 +89,14 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
       )}
       {isError && (
         <Center width="100%" position="absolute" bottom={6}>
-          <Alert status={'warning'} px={6} py={4}>
-            <HStack space={8} flexShrink={1}>
-              <Alert.Icon mt="1" />
-              <Body>Unable to load forecast data</Body>
-            </HStack>
-          </Alert>
+          <VStack space={8}>
+            <Center bg={COLORS['warning.200']} px={24} py={16} borderRadius={4}>
+              <HStack space={8} flexShrink={1}>
+                <FontAwesome5 name="exclamation-triangle" size={16} color={COLORS['warning.700']} />
+                <Body>Unable to load forecast data</Body>
+              </HStack>
+            </Center>
+          </VStack>
         </Center>
       )}
       {!isLoading && !isError && <AvalancheForecastZoneCards key={center} date={date} zones={zones} />}

--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -11,11 +11,11 @@ import {
   PanResponderGestureState,
   GestureResponderEvent,
 } from 'react-native';
-import {Alert, Center, HStack} from 'native-base';
+import {Alert, Center} from 'native-base';
 import MapView, {Region} from 'react-native-maps';
 import {useNavigation} from '@react-navigation/native';
 
-import {View, VStack} from 'components/core';
+import {HStack, View, VStack} from 'components/core';
 import {DangerScale} from 'components/DangerScale';
 import {AvalancheCenterID, DangerLevel} from 'types/nationalAvalancheCenter';
 import {AvalancheCenterForecastZonePolygons} from './AvalancheCenterForecastZonePolygons';
@@ -89,7 +89,7 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
       {isError && (
         <Center width="100%" position="absolute" bottom="6">
           <Alert status={'warning'} px={6} py={4}>
-            <HStack space={2} flexShrink={1}>
+            <HStack space={8} flexShrink={1}>
               <Alert.Icon mt="1" />
               <Body>Unable to load forecast data</Body>
             </HStack>
@@ -278,7 +278,7 @@ const AvalancheForecastZoneCard: React.FunctionComponent<{
       <VStack borderRadius={8} bg="white" width={width * CARD_WIDTH} mx={CARD_MARGIN * width}>
         <View height={8} width="100%" bg={dangerColor.string()} borderTopLeftRadius={8} borderTopRightRadius={8} pb={0} />
         <VStack px={24} pt={4} pb={12} space={8}>
-          <HStack space={2} alignItems="center">
+          <HStack space={8} alignItems="center">
             <AvalancheDangerIcon style={{height: 32}} level={zone.danger_level} />
             <DangerLevelTitle dangerLevel={zone.danger_level} danger={zone.danger} />
           </HStack>

--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -10,6 +10,7 @@ import {
   TouchableWithoutFeedback,
   PanResponderGestureState,
   GestureResponderEvent,
+  TouchableOpacity,
 } from 'react-native';
 import MapView, {Region} from 'react-native-maps';
 import {useNavigation} from '@react-navigation/native';
@@ -233,7 +234,7 @@ const AvalancheForecastZoneCards: React.FunctionComponent<{
 
   const panResponder = useRef(
     PanResponder.create({
-      onMoveShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: (_event, {dx, dy}) => dx > 0 || dy > 0,
       onPanResponderGrant: () => panResponderController.onPanResponderGrant(),
       onPanResponderMove: (e, gestureState) => panResponderController.onPanResponderMove(e, gestureState),
       onPanResponderRelease: () => panResponderController.onPanResponderRelease(),
@@ -269,7 +270,8 @@ const AvalancheForecastZoneCard: React.FunctionComponent<{
   const dangerColor = colorFor(zone.danger_level);
 
   return (
-    <TouchableWithoutFeedback
+    <TouchableOpacity
+      activeOpacity={0.9}
       onPress={() => {
         navigation.navigate('forecast', {
           zoneName: zone.name,
@@ -301,7 +303,7 @@ const AvalancheForecastZoneCard: React.FunctionComponent<{
           </Text>
         </VStack>
       </VStack>
-    </TouchableWithoutFeedback>
+    </TouchableOpacity>
   );
 };
 

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -5,9 +5,9 @@ import {TouchableOpacity} from 'react-native';
 
 import {FontAwesome} from '@expo/vector-icons';
 
-import {Box, IBoxProps, Divider, HStack} from 'native-base';
+import {Box, IBoxProps, Divider} from 'native-base';
 import {colorLookup} from 'theme';
-import {VStack} from 'components/core';
+import {HStack, VStack} from 'components/core';
 
 export interface CardProps extends IBoxProps {
   header?: ReactNode;

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -5,11 +5,11 @@ import {TouchableOpacity} from 'react-native';
 
 import {FontAwesome} from '@expo/vector-icons';
 
-import {Box, IBoxProps, Divider} from 'native-base';
+import {Divider} from 'native-base';
 import {colorLookup} from 'theme';
-import {HStack, VStack} from 'components/core';
+import {HStack, View, ViewProps, VStack} from 'components/core';
 
-export interface CardProps extends IBoxProps {
+export interface CardProps extends ViewProps {
   header?: ReactNode;
   onPress?: () => void;
   borderRadius?: number;
@@ -22,17 +22,17 @@ export const Card: React.FunctionComponent<PropsWithChildren<CardProps>> = ({hea
   const pressHandler = useCallback(() => onPress?.(), [onPress]);
 
   return (
-    <Box {...boxProps}>
+    <View {...boxProps}>
       <TouchableOpacity onPress={pressHandler} disabled={!onPress}>
-        <Box bg="white" borderWidth="2" borderRadius={borderRadius ?? 8} borderColor={borderColor ?? 'light.200'} p="4">
+        <View bg="white" borderWidth={2} borderRadius={borderRadius ?? 8} borderColor={borderColor ?? 'light.200'} p={16}>
           <VStack space={noInternalSpace ? 0 : 8}>
             <>{header}</>
             {noDivider || <Divider orientation="horizontal" bg="light.200" />}
             <>{children}</>
           </VStack>
-        </Box>
+        </View>
       </TouchableOpacity>
-    </Box>
+    </View>
   );
 };
 

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -5,9 +5,8 @@ import {TouchableOpacity} from 'react-native';
 
 import {FontAwesome} from '@expo/vector-icons';
 
-import {Divider} from 'native-base';
 import {colorLookup} from 'theme';
-import {HStack, View, ViewProps, VStack} from 'components/core';
+import {Divider, HStack, View, ViewProps, VStack} from 'components/core';
 
 export interface CardProps extends ViewProps {
   header?: ReactNode;
@@ -27,7 +26,7 @@ export const Card: React.FunctionComponent<PropsWithChildren<CardProps>> = ({hea
         <View bg="white" borderWidth={2} borderRadius={borderRadius ?? 8} borderColor={borderColor ?? 'light.200'} p={16}>
           <VStack space={noInternalSpace ? 0 : 8}>
             <>{header}</>
-            {noDivider || <Divider orientation="horizontal" bg="light.200" />}
+            {noDivider || <Divider direction="horizontal" bg="light.200" />}
             <>{children}</>
           </VStack>
         </View>
@@ -59,7 +58,7 @@ export const CollapsibleCard: React.FunctionComponent<PropsWithChildren<Collapsi
       }>
       <Collapsible collapsed={isCollapsed} renderChildrenCollapsed>
         <VStack space={8} pt={8}>
-          <Divider orientation="horizontal" bg="light.200" />
+          <Divider direction="horizontal" bg="light.200" />
           <>{children}</>
         </VStack>
       </Collapsible>

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -5,8 +5,9 @@ import {TouchableOpacity} from 'react-native';
 
 import {FontAwesome} from '@expo/vector-icons';
 
-import {Box, IBoxProps, Divider, VStack, HStack} from 'native-base';
+import {Box, IBoxProps, Divider, HStack} from 'native-base';
 import {colorLookup} from 'theme';
+import {VStack} from 'components/core';
 
 export interface CardProps extends IBoxProps {
   header?: ReactNode;
@@ -24,7 +25,7 @@ export const Card: React.FunctionComponent<PropsWithChildren<CardProps>> = ({hea
     <Box {...boxProps}>
       <TouchableOpacity onPress={pressHandler} disabled={!onPress}>
         <Box bg="white" borderWidth="2" borderRadius={borderRadius ?? 8} borderColor={borderColor ?? 'light.200'} p="4">
-          <VStack space={noInternalSpace ? 0 : 2}>
+          <VStack space={noInternalSpace ? 0 : 8}>
             <>{header}</>
             {noDivider || <Divider orientation="horizontal" bg="light.200" />}
             <>{children}</>
@@ -57,7 +58,7 @@ export const CollapsibleCard: React.FunctionComponent<PropsWithChildren<Collapsi
         </TouchableOpacity>
       }>
       <Collapsible collapsed={isCollapsed} renderChildrenCollapsed>
-        <VStack space={2} pt={2}>
+        <VStack space={8} pt={8}>
           <Divider orientation="horizontal" bg="light.200" />
           <>{children}</>
         </VStack>

--- a/components/DangerScale.tsx
+++ b/components/DangerScale.tsx
@@ -4,10 +4,10 @@ import {MaterialIcons} from '@expo/vector-icons';
 
 import {DangerLevel} from 'types/nationalAvalancheCenter';
 import {colorFor} from './AvalancheDangerPyramid';
-import {Center, HStack, useToast} from 'native-base';
+import {Center, useToast} from 'native-base';
 import {BodyXSmBlack, BodyXSmMedium} from 'components/text';
 import {TouchableOpacity} from 'react-native';
-import {View} from 'components/core';
+import {HStack, View} from 'components/core';
 
 export type DangerScaleProps = Omit<React.ComponentProps<typeof View>, 'children'>;
 
@@ -16,19 +16,19 @@ export const DangerScale: React.FunctionComponent<DangerScaleProps> = props => {
 
   return (
     <View {...props}>
-      <HStack backgroundColor="rgba(0, 0, 0, 0.6)" borderRadius={24} px="4" py="2" justifyContent="space-between" alignItems="center">
+      <HStack backgroundColor="rgba(0, 0, 0, 0.6)" borderRadius={24} px={16} py={8} justifyContent="space-between" alignItems="center">
         <TouchableOpacity
           onPress={() => {
             toast.show({description: 'Not implemented yet'});
           }}>
-          <HStack space="1" alignItems="center">
+          <HStack space={4} alignItems="center">
             <BodyXSmBlack color="white" style={{letterSpacing: -0.61}}>
               Danger Scale
             </BodyXSmBlack>
             <MaterialIcons name="open-in-new" size={16} color="white" />
           </HStack>
         </TouchableOpacity>
-        <HStack space={0}>
+        <HStack>
           {Object.keys(DangerLevel)
             .filter(key => Number.isNaN(+key))
             .filter(key => DangerLevel[key] > DangerLevel.None)

--- a/components/DangerScale.tsx
+++ b/components/DangerScale.tsx
@@ -4,22 +4,19 @@ import {MaterialIcons} from '@expo/vector-icons';
 
 import {DangerLevel} from 'types/nationalAvalancheCenter';
 import {colorFor} from './AvalancheDangerPyramid';
-import {Center, useToast} from 'native-base';
 import {BodyXSmBlack, BodyXSmMedium} from 'components/text';
 import {TouchableOpacity} from 'react-native';
-import {HStack, View} from 'components/core';
+import {Center, HStack, View} from 'components/core';
 
 export type DangerScaleProps = Omit<React.ComponentProps<typeof View>, 'children'>;
 
 export const DangerScale: React.FunctionComponent<DangerScaleProps> = props => {
-  const toast = useToast();
-
   return (
     <View {...props}>
       <HStack backgroundColor="rgba(0, 0, 0, 0.6)" borderRadius={24} px={16} py={8} justifyContent="space-between" alignItems="center">
         <TouchableOpacity
           onPress={() => {
-            toast.show({description: 'Not implemented yet'});
+            console.warn('Not implemented yet');
           }}>
           <HStack space={4} alignItems="center">
             <BodyXSmBlack color="white" style={{letterSpacing: -0.61}}>

--- a/components/Observation.tsx
+++ b/components/Observation.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {EverythingFragment, useObservationQuery} from 'hooks/useObservations';
 import {ActivityIndicator, View, ScrollView, StyleSheet} from 'react-native';
-import {Row, Column} from 'native-base';
 import {Card, CollapsibleCard} from 'components/Card';
 import {FontAwesome5, MaterialCommunityIcons, Fontisto} from '@expo/vector-icons';
 import {useMapLayer} from '../hooks/useMapLayer';
@@ -35,6 +34,7 @@ import {AvalancheProblemImage} from './AvalancheProblemImage';
 import {NACIcon} from './icons/nac-icons';
 import {utcDateToLocalTimeString} from 'utils/date';
 import {Body, BodyBlack, FeatureTitleBlack, Title1Black} from 'components/text';
+import {HStack, VStack} from 'components/core';
 
 export const Observation: React.FunctionComponent<{
   id: string;
@@ -82,81 +82,83 @@ export const ObservationCard: React.FunctionComponent<{
 
   return (
     <ScrollView style={StyleSheet.absoluteFillObject}>
-      <Column space="2" bgColor={'#f0f2f5'}>
+      <VStack space={8} bgColor={'#f0f2f5'}>
         <Card
           marginTop={2}
           borderRadius={0}
           borderColor="white"
           header={<FeatureTitleBlack>{`${FormatPartnerType(observation.observerType as PartnerType)} Field Observation`}</FeatureTitleBlack>}>
-          <Row flexWrap="wrap" space="2">
-            <IdentifiedInformation header={'Submitted'} body={utcDateToLocalTimeString(observation.createdAt)} />
-            {observation.endDate && <IdentifiedInformation header={'Expires'} body={utcDateToLocalTimeString(observation.endDate)} />}
-            <IdentifiedInformation header={'Author(s)'} body={observation.name || 'Unknown'} />
-            <IdentifiedInformation header={'Activity'} body={activityDisplayName(observation.activity)} />
-          </Row>
-          <Row flexWrap="wrap" space="2">
-            <IdentifiedInformation header={'Zone/Region'} body={zone(mapLayer, observation.locationPoint.lat, observation.locationPoint.lng)} />
-            <IdentifiedInformation header={'Location'} body={observation.locationName} />
-            <IdentifiedInformation header={'Route'} body={observation.route} />
-          </Row>
+          <VStack space={8}>
+            <HStack flexWrap="wrap" space={8} alignItems="flex-start">
+              <IdentifiedInformation header={'Submitted'} body={utcDateToLocalTimeString(observation.createdAt)} />
+              {observation.endDate && <IdentifiedInformation header={'Expires'} body={utcDateToLocalTimeString(observation.endDate)} />}
+              <IdentifiedInformation header={'Author(s)'} body={observation.name || 'Unknown'} />
+              <IdentifiedInformation header={'Activity'} body={activityDisplayName(observation.activity)} />
+            </HStack>
+            <HStack flexWrap="wrap" space={8} alignItems="flex-start">
+              <IdentifiedInformation header={'Zone/Region'} body={zone(mapLayer, observation.locationPoint.lat, observation.locationPoint.lng)} />
+              <IdentifiedInformation header={'Location'} body={observation.locationName} />
+              <IdentifiedInformation header={'Route'} body={observation.route} />
+            </HStack>
+          </VStack>
         </Card>
         <CollapsibleCard
           startsCollapsed={false}
           borderRadius={0}
           borderColor="white"
           header={
-            <Row space={2} alignItems="center">
+            <HStack space={8} alignItems="center">
               <FontAwesome5 name="info-circle" size={24} color="black" />
               <Title1Black>Observation Summary</Title1Black>
-            </Row>
+            </HStack>
           }>
           <HTML source={{html: observation.observationSummary}} />
           {anySignsOfInstability && (
-            <Column space="2" style={{flex: 1}}>
+            <VStack space={8} style={{flex: 1}}>
               <BodyBlack style={{textTransform: 'uppercase'}}>{'Signs Of Instability'}</BodyBlack>
               {observation.instability.avalanches_caught && (
-                <Row space={2} alignItems="center">
+                <HStack space={8} alignItems="center">
                   <NACIcon name="avalanche" size={32} color="black" />
                   <Body color="lightText">{'Caught in Avalanche(s)'}</Body>
-                </Row>
+                </HStack>
               )}
               {observation.instability.avalanches_observed && (
-                <Row space={2} alignItems="center">
+                <HStack space={8} alignItems="center">
                   <NACIcon name="avalanche" size={32} color="black" />
                   <Body color="lightText">{'Avalanche(s) Observed'}</Body>
-                </Row>
+                </HStack>
               )}
               {observation.instability.avalanches_triggered && (
-                <Row space={2} alignItems="center">
+                <HStack space={8} alignItems="center">
                   <NACIcon name="avalanche" size={32} color="black" />
                   <Body color="lightText">{'Avalanche(s) Triggered'}</Body>
-                </Row>
+                </HStack>
               )}
               {observation.instability.collapsing && (
-                <Row space={2} alignItems="center">
+                <HStack space={8} alignItems="center">
                   <MaterialCommunityIcons name="arrow-collapse-vertical" size={24} color="black" />
                   <Body color="lightText">
                     {observation.instability.collapsing_description && `${FormatAvalancheProblemDistribution(observation.instability.collapsing_description)} `}
                     {'Collapsing Observed'}
                   </Body>
-                </Row>
+                </HStack>
               )}
               {observation.instability.cracking && (
-                <Row space={2} alignItems="center">
+                <HStack space={8} alignItems="center">
                   <MaterialCommunityIcons name="lightning-bolt" size={24} color="black" />
                   <Body color="lightText">
                     {observation.instability.cracking_description && `${FormatAvalancheProblemDistribution(observation.instability.cracking_description)} `}
                     {'Cracking Observed'}
                   </Body>
-                </Row>
+                </HStack>
               )}
-            </Column>
+            </VStack>
           )}
           {observation.instabilitySummary && (
-            <Column space="2" style={{flex: 1}}>
+            <VStack space={8} style={{flex: 1}}>
               <BodyBlack style={{textTransform: 'uppercase'}}>{'Instability Comments'}</BodyBlack>
               <HTML source={{html: observation.instabilitySummary}} />
-            </Column>
+            </VStack>
           )}
         </CollapsibleCard>
         {observation.media && observation.media.length > 0 && (
@@ -165,10 +167,10 @@ export const ObservationCard: React.FunctionComponent<{
             borderRadius={0}
             borderColor="white"
             header={
-              <Row space={2} alignItems="center">
+              <HStack space={8} alignItems="center">
                 <FontAwesome5 name="photo-video" size={24} color="black" />
                 <Title1Black>Observation Media</Title1Black>
-              </Row>
+              </HStack>
             }>
             {observation.media
               .filter(item => item.type === 'image')
@@ -184,64 +186,64 @@ export const ObservationCard: React.FunctionComponent<{
             borderWidth={0}
             borderColor="white"
             header={
-              <Row space={2} alignItems="center">
+              <HStack space={8} alignItems="center">
                 <NACIcon name="avalanche" size={48} color="black" />
                 <Title1Black>Avalanches</Title1Black>
-              </Row>
+              </HStack>
             }>
             {observation.avalanches &&
               observation.avalanches.length > 0 &&
               observation.avalanches.map((item, index) => (
-                <Column space="2" style={{flex: 1}} key={`avalanche-${index}`}>
-                  <Row space={2} alignItems="center">
+                <VStack space={8} style={{flex: 1}} key={`avalanche-${index}`}>
+                  <HStack space={8} alignItems="center">
                     <IdentifiedInformation
                       header={'Date'}
                       body={`${utcDateToLocalTimeString(item.date)} (${FormatAvalancheDateUncertainty(item.dateAccuracy as AvalancheDateUncertainty)})`}
                     />
                     <IdentifiedInformation header={'Location'} body={item.location} />
                     <IdentifiedInformation header={'Size'} body={`D${item.dSize}-R${item.rSize}`} />
-                  </Row>
-                  <Row space={2} alignItems="center">
+                  </HStack>
+                  <HStack space={8} alignItems="center">
                     <IdentifiedInformation
                       header={'Trigger'}
                       body={`${FormatAvalancheTrigger(item.trigger as AvalancheTrigger)} - ${FormatAvalancheCause(item.cause as AvalancheCause)}`}
                     />
                     <IdentifiedInformation header={'Start Zone'} body={`${FormatAvalancheAspect(item.aspect as AvalancheAspect)}, ${item.slopeAngle}° at ${item.elevation}ft`} />
                     <IdentifiedInformation header={'Vertical Fall'} body={`${item.verticalFall}ft`} />
-                  </Row>
-                  <Row space={2} alignItems="center">
+                  </HStack>
+                  <HStack space={8} alignItems="center">
                     <IdentifiedInformation header={'Crown Thickness'} body={`${item.avgCrownDepth}cm`} />
                     <IdentifiedInformation header={'Width'} body={`${item.width}ft`} />
                     <IdentifiedInformation header={'Type'} body={FormatAvalancheType(item.avalancheType as AvalancheType)} />
                     <IdentifiedInformation header={'Bed Surface'} body={FormatAvalancheBedSurface(item.bedSfc as AvalancheBedSurface)} />
-                  </Row>
+                  </HStack>
                   <>
                     {item.media && item.media.length > 0 && (
-                      <Column space="2" style={{flex: 1}}>
+                      <VStack space={8} style={{flex: 1}}>
                         <BodyBlack style={{textTransform: 'uppercase'}}>{'Avalanche Media'}</BodyBlack>
                         {item.media
                           .filter(mediaItem => mediaItem.type === 'image')
                           .map((mediaItem, mediaIndex) => (
                             <AvalancheProblemImage key={`avalanche-${index}-media-item-${mediaIndex}`} media={mediaItem} />
                           ))}
-                      </Column>
+                      </VStack>
                     )}
                   </>
                   <>
                     {item.comments && (
-                      <Column space="2" style={{flex: 1}}>
+                      <VStack space={8} style={{flex: 1}}>
                         <BodyBlack style={{textTransform: 'uppercase'}}>{'Avalanche Comments'}</BodyBlack>
                         <HTML source={{html: item.comments}} />
-                      </Column>
+                      </VStack>
                     )}
                   </>
-                </Column>
+                </VStack>
               ))}
             {observation.avalanchesSummary && (
-              <Column space="2" style={{flex: 1}}>
+              <VStack space={8} style={{flex: 1}}>
                 <BodyBlack style={{textTransform: 'uppercase'}}>{'Avalanche Summary'}</BodyBlack>
                 <HTML source={{html: observation.avalanchesSummary}} />
-              </Column>
+              </VStack>
             )}
           </CollapsibleCard>
         )}
@@ -251,36 +253,36 @@ export const ObservationCard: React.FunctionComponent<{
             borderRadius={0}
             borderColor="white"
             header={
-              <Row space={2} alignItems="center">
+              <HStack space={8} alignItems="center">
                 <MaterialCommunityIcons name="weather-snowy-heavy" size={24} color="black" />
                 <Title1Black>Weather</Title1Black>
-              </Row>
+              </HStack>
             }>
             <>
               {observation.advancedFields.weather && (
                 <>
-                  <Row flexWrap="wrap" space="2">
+                  <HStack flexWrap="wrap" space={8}>
                     <IdentifiedWeatherInformation header={'Cloud Cover'} body={FormatCloudCover(observation.advancedFields.weather.cloud_cover)} />
                     <IdentifiedWeatherInformation header={'Temperature (F)'} body={observation.advancedFields.weather.air_temp} />
                     <IdentifiedWeatherInformation header={'New or Recent Snowfall'} body={observation.advancedFields.weather.recent_snowfall} />
-                  </Row>
-                  <Row flexWrap="wrap" space="2">
+                  </HStack>
+                  <HStack flexWrap="wrap" space={8}>
                     <IdentifiedWeatherInformation header={'Rain/Snow Line (ft)'} body={observation.advancedFields.weather.rain_elevation} />
                     <IdentifiedWeatherInformation
                       header={'Snow Available For Transport'}
                       body={FormatSnowAvailableForTransport(observation.advancedFields.weather.snow_avail_for_transport)}
                     />
                     <IdentifiedWeatherInformation header={'Wind Loading'} body={FormatWindLoading(observation.advancedFields.weather.wind_loading)} />
-                  </Row>
+                  </HStack>
                 </>
               )}
             </>
             <>
               {observation.advancedFields.weatherSummary && (
-                <Column space="2" style={{flex: 1}}>
+                <VStack space={8} style={{flex: 1}}>
                   <BodyBlack style={{textTransform: 'uppercase'}}>{'Weather Summary'}</BodyBlack>
                   <HTML source={{html: observation.advancedFields.weatherSummary}} />
-                </Column>
+                </VStack>
               )}
             </>
           </CollapsibleCard>
@@ -294,37 +296,37 @@ export const ObservationCard: React.FunctionComponent<{
               borderRadius={0}
               borderColor="white"
               header={
-                <Row space={2} alignItems="center">
+                <HStack space={8} alignItems="center">
                   <Fontisto name="snowflake" size={24} color="black" />
                   <Title1Black>Snowpack Observations</Title1Black>
-                </Row>
+                </HStack>
               }>
               <>{observation.advancedFields.snowpack && <>{/* we don't know what fields could be in this thing ... */}</>}</>
               <>
                 {observation.advancedFields.snowpackSummary && (
-                  <Column space="2" style={{flex: 1}}>
+                  <VStack space={8} style={{flex: 1}}>
                     <BodyBlack style={{textTransform: 'uppercase'}}>{'Snowpack Summary'}</BodyBlack>
                     <HTML source={{html: observation.advancedFields.snowpackSummary}} />
-                  </Column>
+                  </VStack>
                 )}
               </>
               <>
                 {observation.advancedFields.snowpackMedia && observation.advancedFields.snowpackMedia.length > 0 && (
                   <>
-                    <Column space="2" style={{flex: 1}}>
+                    <VStack space={8} style={{flex: 1}}>
                       <BodyBlack style={{textTransform: 'uppercase'}}>{'Snowpack Media'}</BodyBlack>
                       {observation.advancedFields.snowpackMedia
                         .filter(item => item.type === 'image')
                         .map((item, index) => (
                           <AvalancheProblemImage key={`media-item-${index}`} media={item} />
                         ))}
-                    </Column>
+                    </VStack>
                   </>
                 )}
               </>
             </CollapsibleCard>
           )}
-      </Column>
+      </VStack>
     </ScrollView>
   );
 };
@@ -341,10 +343,10 @@ const IdentifiedInformation: React.FunctionComponent<{
   body: string;
 }> = ({header, body}) => {
   return (
-    <Column space="2" style={{flex: 1}}>
+    <VStack space={8} style={{flex: 1}}>
       <BodyBlack style={{textTransform: 'uppercase'}}>{header}</BodyBlack>
       <Body color="lightText">{body}</Body>
-    </Column>
+    </VStack>
   );
 };
 
@@ -353,11 +355,11 @@ const IdentifiedWeatherInformation: React.FunctionComponent<{
   body: string;
 }> = ({header, body}) => {
   return (
-    <Column space="2" style={{flex: 1}}>
+    <VStack space={8} style={{flex: 1}}>
       <BodyBlack style={{textTransform: 'uppercase'}}>{header}</BodyBlack>
       <Body color="lightText" style={{textTransform: 'capitalize', fontStyle: body === '' ? 'italic' : 'normal'}}>
         {body || 'Not Observed'}
       </Body>
-    </Column>
+    </VStack>
   );
 };

--- a/components/Observations.tsx
+++ b/components/Observations.tsx
@@ -4,7 +4,6 @@ import {compareDesc, format, parseISO, sub} from 'date-fns';
 import {ActivityIndicator, View, FlatList} from 'react-native';
 import {ObservationsStackNavigationProps} from 'routes';
 import {useNavigation} from '@react-navigation/native';
-import {Row, Column} from 'native-base';
 import {geoContains} from 'd3-geo';
 import {FontAwesome, MaterialCommunityIcons} from '@expo/vector-icons';
 
@@ -16,6 +15,7 @@ import {Body, BodyBlack, Title3Semibold} from './text';
 import {HTML} from './text/HTML';
 import {NACIcon} from './icons/nac-icons';
 import {utcDateToLocalTimeString} from 'utils/date';
+import {HStack, VStack} from 'components/core';
 
 // TODO: we could show the Avy center logo for obs that come from forecasters
 
@@ -106,63 +106,63 @@ export const ObservationSummaryCard: React.FunctionComponent<{
         });
       }}
       header={
-        <Row alignContent="flex-start" flexWrap="wrap" alignItems="center" space="2">
+        <HStack alignContent="flex-start" flexWrap="wrap" alignItems="center" space={8}>
           <Title3Semibold>{zone}</Title3Semibold>
           <FontAwesome name="angle-right" size={18} style={{paddingHorizontal: 4}} color="black" />
           <Title3Semibold>{observation.locationName}</Title3Semibold>
-        </Row>
+        </HStack>
       }>
-      <Row flexWrap="wrap" space="2">
+      <HStack flexWrap="wrap" space={8}>
         <IdentifiedInformation header={'Submitted'} body={utcDateToLocalTimeString(observation.createdAt)} />
         <IdentifiedInformation header={'Observer'} body={FormatPartnerType(observation.observerType as PartnerType)} />
         <IdentifiedInformation header={'Author(s)'} body={observation.name || 'Unknown'} />
-      </Row>
+      </HStack>
       {anySignsOfInstability && (
-        <Column space="2" style={{flex: 1}}>
+        <VStack space={8} style={{flex: 1}}>
           <BodyBlack style={{textTransform: 'uppercase'}}>{'Signs Of Instability'}</BodyBlack>
           {observation.instability.avalanches_caught && (
-            <Row space={2} alignItems="center">
+            <HStack space={8} alignItems="center">
               <NACIcon name="avalanche" size={32} color="black" />
               <Body color="lightText">{'Caught in Avalanche(s)'}</Body>
-            </Row>
+            </HStack>
           )}
           {observation.instability.avalanches_observed && (
-            <Row space={2} alignItems="center">
+            <HStack space={8} alignItems="center">
               <NACIcon name="avalanche" size={32} color="black" />
               <Body color="lightText">{'Avalanche(s) Observed'}</Body>
-            </Row>
+            </HStack>
           )}
           {observation.instability.avalanches_triggered && (
-            <Row space={2} alignItems="center">
+            <HStack space={8} alignItems="center">
               <NACIcon name="avalanche" size={32} color="black" />
               <Body color="lightText">{'Avalanche(s) Triggered'}</Body>
-            </Row>
+            </HStack>
           )}
           {observation.instability.collapsing && (
-            <Row space={2} alignItems="center">
+            <HStack space={8} alignItems="center">
               <MaterialCommunityIcons name="arrow-collapse-vertical" size={24} color="black" />
               <Body color="lightText">
                 {observation.instability.collapsing_description && `${FormatAvalancheProblemDistribution(observation.instability.collapsing_description)} `}
                 {'Collapsing Observed'}
               </Body>
-            </Row>
+            </HStack>
           )}
           {observation.instability.cracking && (
-            <Row space={2} alignItems="center">
+            <HStack space={8} alignItems="center">
               <MaterialCommunityIcons name="lightning-bolt" size={24} color="black" />
               <Body color="lightText">
                 {observation.instability.cracking_description && `${FormatAvalancheProblemDistribution(observation.instability.cracking_description)} `}
                 {'Cracking Observed'}
               </Body>
-            </Row>
+            </HStack>
           )}
-        </Column>
+        </VStack>
       )}
       {observation.observationSummary && (
-        <Column space="2" style={{flex: 1}}>
+        <VStack space={8} style={{flex: 1}}>
           <BodyBlack style={{textTransform: 'uppercase'}}>{'Observation Summary'}</BodyBlack>
           <HTML source={{html: observation.observationSummary}} />
-        </Column>
+        </VStack>
       )}
     </Card>
   );
@@ -173,9 +173,9 @@ const IdentifiedInformation: React.FunctionComponent<{
   body: string;
 }> = ({header, body}) => {
   return (
-    <Column space="2" style={{flex: 1}}>
+    <VStack space={8} style={{flex: 1}}>
       <BodyBlack style={{textTransform: 'uppercase'}}>{header}</BodyBlack>
       <Body color="lightText">{body}</Body>
-    </Column>
+    </VStack>
   );
 };

--- a/components/TabControl.tsx
+++ b/components/TabControl.tsx
@@ -2,9 +2,10 @@ import React, {PropsWithChildren, ReactElement, useState} from 'react';
 
 import {TouchableOpacity} from 'react-native';
 
-import {HStack, VStack} from 'native-base';
+import {HStack} from 'native-base';
 import {Body, BodySemibold} from './text';
 import {colorLookup} from 'theme';
+import {VStack} from 'components/core';
 
 export interface TabProps {
   title: string;

--- a/components/TabControl.tsx
+++ b/components/TabControl.tsx
@@ -2,10 +2,9 @@ import React, {PropsWithChildren, ReactElement, useState} from 'react';
 
 import {TouchableOpacity} from 'react-native';
 
-import {HStack} from 'native-base';
 import {Body, BodySemibold} from './text';
 import {colorLookup} from 'theme';
-import {VStack} from 'components/core';
+import {HStack, VStack} from 'components/core';
 
 export interface TabProps {
   title: string;

--- a/components/core/Center.tsx
+++ b/components/core/Center.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import {merge} from 'lodash';
+
+import {ViewStyle} from 'react-native';
+import {View, ViewProps} from './View';
+
+const baseStyle: ViewStyle = {
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+};
+
+export const Center: React.FC<ViewProps> = ({children, style: originalStyle = {}, ...props}) => {
+  const style = {};
+  merge(style, baseStyle, originalStyle);
+  return (
+    <View style={style} {...props}>
+      {children}
+    </View>
+  );
+};

--- a/components/core/Center.tsx
+++ b/components/core/Center.tsx
@@ -10,7 +10,7 @@ const baseStyle: ViewStyle = {
   alignItems: 'center',
 };
 
-export const Center: React.FC<ViewProps> = ({children, style: originalStyle = {}, ...props}) => {
+export const Center: React.FC<ViewProps> = React.memo(({children, style: originalStyle = {}, ...props}) => {
   const style = {};
   merge(style, baseStyle, originalStyle);
   return (
@@ -18,4 +18,4 @@ export const Center: React.FC<ViewProps> = ({children, style: originalStyle = {}
       {children}
     </View>
   );
-};
+});

--- a/components/core/Divider.tsx
+++ b/components/core/Divider.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import {merge} from 'lodash';
+
+import {ViewStyle} from 'react-native';
+import {View, ViewProps} from './View';
+
+export interface DividerProps extends ViewProps {
+  direction?: 'horizontal' | 'vertical';
+  size?: number;
+}
+
+export const Divider: React.FC<DividerProps> = ({children, style: originalStyle = {}, direction = 'horizontal', size = 1, ...props}) => {
+  const style: ViewStyle = {
+    width: direction === 'horizontal' ? '100%' : size,
+    height: direction === 'vertical' ? '100%' : size,
+    flex: 1,
+  };
+  merge(style, originalStyle);
+  return (
+    <View style={style} {...props}>
+      {children}
+    </View>
+  );
+};

--- a/components/core/Divider.tsx
+++ b/components/core/Divider.tsx
@@ -9,7 +9,7 @@ export interface DividerProps extends ViewProps {
   size?: number;
 }
 
-export const Divider: React.FC<DividerProps> = ({children, style: originalStyle = {}, direction = 'horizontal', size = 1, ...props}) => {
+export const Divider: React.FC<DividerProps> = React.memo(({children, style: originalStyle = {}, direction = 'horizontal', size = 1, ...props}) => {
   const style: ViewStyle = {
     width: direction === 'horizontal' ? '100%' : size,
     height: direction === 'vertical' ? '100%' : size,
@@ -21,4 +21,4 @@ export const Divider: React.FC<DividerProps> = ({children, style: originalStyle 
       {children}
     </View>
   );
-};
+});

--- a/components/core/HStack.tsx
+++ b/components/core/HStack.tsx
@@ -14,7 +14,7 @@ export interface HStackProps extends ViewProps {
   space?: number;
 }
 
-export const HStack: React.FC<HStackProps> = ({children: originalChildren, style: originalStyle = {}, space, ...props}) => {
+export const HStack: React.FC<HStackProps> = React.memo(({children: originalChildren, style: originalStyle = {}, space, ...props}) => {
   const style = {};
   merge(style, baseStyle, originalStyle);
   const children = (() => {
@@ -30,4 +30,4 @@ export const HStack: React.FC<HStackProps> = ({children: originalChildren, style
       {children}
     </View>
   );
-};
+});

--- a/components/core/HStack.tsx
+++ b/components/core/HStack.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import {merge} from 'lodash';
+
+import {ViewStyle} from 'react-native';
+import {View, ViewProps} from './View';
+
+const baseStyle: ViewStyle = {
+  flexDirection: 'row',
+  justifyContent: 'flex-start',
+  alignItems: 'center',
+};
+
+export interface HStackProps extends ViewProps {
+  space?: number;
+}
+
+export const HStack: React.FC<HStackProps> = ({children: originalChildren, style: originalStyle = {}, space, ...props}) => {
+  const style = {};
+  merge(style, baseStyle, originalStyle);
+  const children = (() => {
+    if (typeof space === 'number') {
+      return React.Children.toArray(originalChildren)
+        .map((child, index) => (index > 0 ? [<View width={space} flex={0} key={`hstack-space-${index}`} />, child] : child))
+        .flat();
+    }
+    return originalChildren;
+  })();
+  return (
+    <View style={style} {...props}>
+      {children}
+    </View>
+  );
+};

--- a/components/core/VStack.tsx
+++ b/components/core/VStack.tsx
@@ -14,7 +14,7 @@ export interface VStackProps extends ViewProps {
   space?: number;
 }
 
-export const VStack: React.FC<VStackProps> = ({children: originalChildren, style: originalStyle = {}, space, ...props}) => {
+export const VStack: React.FC<VStackProps> = React.memo(({children: originalChildren, style: originalStyle = {}, space, ...props}) => {
   const style = {};
   merge(style, baseStyle, originalStyle);
   const children = (() => {
@@ -30,4 +30,4 @@ export const VStack: React.FC<VStackProps> = ({children: originalChildren, style
       {children}
     </View>
   );
-};
+});

--- a/components/core/VStack.tsx
+++ b/components/core/VStack.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import {merge} from 'lodash';
+
+import {ViewStyle} from 'react-native';
+import {View, ViewProps} from './View';
+
+const baseStyle: ViewStyle = {
+  flexDirection: 'column',
+  justifyContent: 'flex-start',
+  alignItems: 'stretch',
+};
+
+export interface VStackProps extends ViewProps {
+  space?: number;
+}
+
+export const VStack: React.FC<VStackProps> = ({children: originalChildren, style: originalStyle = {}, space, ...props}) => {
+  const style = {};
+  merge(style, baseStyle, originalStyle);
+  const children = (() => {
+    if (typeof space === 'number') {
+      return React.Children.toArray(originalChildren)
+        .map((child, index) => (index > 0 ? [<View height={space} flex={0} key={`vstack-space-${index}`} />, child] : child))
+        .flat();
+    }
+    return originalChildren;
+  })();
+  return (
+    <View style={style} {...props}>
+      {children}
+    </View>
+  );
+};

--- a/components/core/View.tsx
+++ b/components/core/View.tsx
@@ -154,7 +154,7 @@ const validateProp = (prop: ViewStyleProp, value): void => {
 };
 
 export interface ViewProps extends RNViewProps, ViewStyleProps, ViewAliasProps {}
-export const View: React.FC<ViewProps> = ({children, style = {}, ...props}) => {
+export const View: React.FC<ViewProps> = React.memo(({children, style = {}, ...props}) => {
   const resolvedProps: RNViewProps = {style};
   Object.entries(props).forEach(([key, value]) => {
     const prop = propAliasMapping[key] || key;
@@ -169,4 +169,4 @@ export const View: React.FC<ViewProps> = ({children, style = {}, ...props}) => {
     }
   });
   return <RNView {...resolvedProps}>{children}</RNView>;
-};
+});

--- a/components/core/index.ts
+++ b/components/core/index.ts
@@ -1,2 +1,3 @@
 export * from './View';
+export * from './HStack';
 export * from './VStack';

--- a/components/core/index.ts
+++ b/components/core/index.ts
@@ -1,3 +1,4 @@
+export * from './Center';
 export * from './View';
 export * from './HStack';
 export * from './VStack';

--- a/components/core/index.ts
+++ b/components/core/index.ts
@@ -1,1 +1,2 @@
 export * from './View';
+export * from './VStack';

--- a/components/core/index.ts
+++ b/components/core/index.ts
@@ -1,4 +1,10 @@
-export * from './Center';
+// Basic View wrapper
 export * from './View';
+
+// Utility components
+export * from './Center';
+export * from './Divider';
+
+// Layout components
 export * from './HStack';
 export * from './VStack';

--- a/components/forecast/AvalancheTab.tsx
+++ b/components/forecast/AvalancheTab.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {HStack, VStack} from 'native-base';
+import {HStack} from 'native-base';
 
 import {addDays, parseISO} from 'date-fns';
 
@@ -12,6 +12,7 @@ import {Card, CollapsibleCard} from 'components/Card';
 import {HTML} from 'components/text/HTML';
 import {utcDateToLocalTimeString} from 'utils/date';
 import {AllCapsSm, AllCapsSmBlack, Body, BodyBlack, Title3Black} from 'components/text';
+import {VStack} from 'components/core';
 
 interface AvalancheTabProps {
   zone: AvalancheForecastZone;
@@ -45,22 +46,22 @@ export const AvalancheTab: React.FunctionComponent<AvalancheTabProps> = React.me
   const elevationBandNames: ElevationBandNames = zone.config.elevation_band_names;
 
   return (
-    <VStack space="2" bgColor={'#f0f2f5'}>
+    <VStack space={8} bgColor={'#f0f2f5'}>
       <Card marginTop={2} borderRadius={0} borderColor="white" header={<Title3Black>Avalanche Forecast</Title3Black>}>
         <HStack justifyContent="space-evenly" space="2">
-          <VStack space="2" style={{flex: 1}}>
+          <VStack space={8} style={{flex: 1}}>
             <AllCapsSmBlack>Issued</AllCapsSmBlack>
             <AllCapsSm style={{textTransform: 'none'}} color="lightText">
               {utcDateToLocalTimeString(forecast.published_time)}
             </AllCapsSm>
           </VStack>
-          <VStack space="2" style={{flex: 1}}>
+          <VStack space={8} style={{flex: 1}}>
             <AllCapsSmBlack>Expires</AllCapsSmBlack>
             <AllCapsSm style={{textTransform: 'none'}} color="lightText">
               {utcDateToLocalTimeString(forecast.expires_time)}
             </AllCapsSm>
           </VStack>
-          <VStack space="2" style={{flex: 1}}>
+          <VStack space={8} style={{flex: 1}}>
             <AllCapsSmBlack>Author</AllCapsSmBlack>
             <AllCapsSm style={{textTransform: 'none'}} color="lightText">
               {forecast.author || 'Unknown'}

--- a/components/forecast/AvalancheTab.tsx
+++ b/components/forecast/AvalancheTab.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import {HStack} from 'native-base';
-
 import {addDays, parseISO} from 'date-fns';
 
 import {AvalancheDangerForecast, AvalancheForecastZone, DangerLevel, ElevationBandNames, ForecastPeriod, Product} from 'types/nationalAvalancheCenter';
@@ -12,7 +10,7 @@ import {Card, CollapsibleCard} from 'components/Card';
 import {HTML} from 'components/text/HTML';
 import {utcDateToLocalTimeString} from 'utils/date';
 import {AllCapsSm, AllCapsSmBlack, Body, BodyBlack, Title3Black} from 'components/text';
-import {VStack} from 'components/core';
+import {HStack, VStack} from 'components/core';
 
 interface AvalancheTabProps {
   zone: AvalancheForecastZone;
@@ -48,7 +46,7 @@ export const AvalancheTab: React.FunctionComponent<AvalancheTabProps> = React.me
   return (
     <VStack space={8} bgColor={'#f0f2f5'}>
       <Card marginTop={2} borderRadius={0} borderColor="white" header={<Title3Black>Avalanche Forecast</Title3Black>}>
-        <HStack justifyContent="space-evenly" space="2">
+        <HStack justifyContent="space-evenly" space={8}>
           <VStack space={8} style={{flex: 1}}>
             <AllCapsSmBlack>Issued</AllCapsSmBlack>
             <AllCapsSm style={{textTransform: 'none'}} color="lightText">
@@ -73,7 +71,7 @@ export const AvalancheTab: React.FunctionComponent<AvalancheTabProps> = React.me
         borderRadius={0}
         borderColor="white"
         header={
-          <HStack space={2} alignItems="center">
+          <HStack space={8} alignItems="center">
             <AvalancheDangerIcon style={{height: 32}} level={highestDangerToday} />
             <BodyBlack>The Bottom Line</BodyBlack>
           </HStack>

--- a/components/screens/MenuScreen.tsx
+++ b/components/screens/MenuScreen.tsx
@@ -5,7 +5,7 @@ import {SafeAreaView} from 'react-native-safe-area-context';
 
 import * as Updates from 'expo-updates';
 
-import {HStack, VStack, Divider, SectionList} from 'native-base';
+import {HStack, Divider, SectionList} from 'native-base';
 
 import {AvalancheCenterCard, AvalancheCenterSelector} from 'components/AvalancheCenterSelector';
 
@@ -14,7 +14,7 @@ import {createNativeStackNavigator, NativeStackScreenProps} from '@react-navigat
 import {MenuStackParamList, MenuStackNavigationProps} from 'routes';
 import {useNavigation} from '@react-navigation/native';
 
-import {View} from 'components/core';
+import {View, VStack} from 'components/core';
 
 import {
   AllCapsSm,
@@ -70,7 +70,7 @@ export const MenuScreen = (avalancheCenterId: AvalancheCenterID, staging: boolea
   return function (_: NativeStackScreenProps<MenuStackParamList, 'menu'>) {
     return (
       <SafeAreaView style={styles.fullscreen}>
-        <VStack pt="16" px="4" space="4" style={styles.fullscreen}>
+        <VStack pt={16} px={16} space={16} style={styles.fullscreen}>
           <FeatureTitleBlack>Settings</FeatureTitleBlack>
           <Divider orientation="horizontal" bg="light.200" />
           {Updates.channel !== 'production' && (

--- a/components/screens/MenuScreen.tsx
+++ b/components/screens/MenuScreen.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
-import {Button, StyleSheet, Switch} from 'react-native';
+import {Button, SectionList, StyleSheet, Switch} from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
 
 import * as Updates from 'expo-updates';
 
-import {Divider, SectionList} from 'native-base';
+import {Divider} from 'native-base';
 
 import {AvalancheCenterCard, AvalancheCenterSelector} from 'components/AvalancheCenterSelector';
 
@@ -164,7 +164,7 @@ const TextStylePreview = () => {
   return (
     <SafeAreaView style={styles.fullscreen}>
       <SectionList
-        paddingX={4}
+        style={{paddingHorizontal: 4}}
         sections={data}
         keyExtractor={item => item.content}
         renderItem={({item}) => <item.Component>{item.content}</item.Component>}

--- a/components/screens/MenuScreen.tsx
+++ b/components/screens/MenuScreen.tsx
@@ -5,7 +5,7 @@ import {SafeAreaView} from 'react-native-safe-area-context';
 
 import * as Updates from 'expo-updates';
 
-import {HStack, Divider, SectionList} from 'native-base';
+import {Divider, SectionList} from 'native-base';
 
 import {AvalancheCenterCard, AvalancheCenterSelector} from 'components/AvalancheCenterSelector';
 
@@ -14,7 +14,7 @@ import {createNativeStackNavigator, NativeStackScreenProps} from '@react-navigat
 import {MenuStackParamList, MenuStackNavigationProps} from 'routes';
 import {useNavigation} from '@react-navigation/native';
 
-import {View, VStack} from 'components/core';
+import {HStack, View, VStack} from 'components/core';
 
 import {
   AllCapsSm,
@@ -74,9 +74,9 @@ export const MenuScreen = (avalancheCenterId: AvalancheCenterID, staging: boolea
           <FeatureTitleBlack>Settings</FeatureTitleBlack>
           <Divider orientation="horizontal" bg="light.200" />
           {Updates.channel !== 'production' && (
-            <>
+            <VStack space={16}>
               <Title1Black>Debug Settings</Title1Black>
-              <HStack justifyContent="space-between" alignItems="center" space="4">
+              <HStack justifyContent="space-between" alignItems="center" space={16}>
                 <BodyBlack>Use staging environment</BodyBlack>
                 <Switch value={staging} onValueChange={toggleStaging} />
               </HStack>
@@ -91,7 +91,7 @@ export const MenuScreen = (avalancheCenterId: AvalancheCenterID, staging: boolea
                 />
               </VStack>
               <Button onPress={() => navigation.navigate('textStylePreview')} title="Open text style preview" />
-            </>
+            </VStack>
           )}
         </VStack>
       </SafeAreaView>

--- a/components/screens/MenuScreen.tsx
+++ b/components/screens/MenuScreen.tsx
@@ -5,8 +5,6 @@ import {SafeAreaView} from 'react-native-safe-area-context';
 
 import * as Updates from 'expo-updates';
 
-import {Divider} from 'native-base';
-
 import {AvalancheCenterCard, AvalancheCenterSelector} from 'components/AvalancheCenterSelector';
 
 import {createNativeStackNavigator, NativeStackScreenProps} from '@react-navigation/native-stack';
@@ -14,7 +12,7 @@ import {createNativeStackNavigator, NativeStackScreenProps} from '@react-navigat
 import {MenuStackParamList, MenuStackNavigationProps} from 'routes';
 import {useNavigation} from '@react-navigation/native';
 
-import {HStack, View, VStack} from 'components/core';
+import {Divider, HStack, View, VStack} from 'components/core';
 
 import {
   AllCapsSm,
@@ -72,7 +70,7 @@ export const MenuScreen = (avalancheCenterId: AvalancheCenterID, staging: boolea
       <SafeAreaView style={styles.fullscreen}>
         <VStack pt={16} px={16} space={16} style={styles.fullscreen}>
           <FeatureTitleBlack>Settings</FeatureTitleBlack>
-          <Divider orientation="horizontal" bg="light.200" />
+          <Divider direction="horizontal" bg="light.200" />
           {Updates.channel !== 'production' && (
             <VStack space={16}>
               <Title1Black>Debug Settings</Title1Black>

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "jest": "^26.6.3",
     "jest-expo": "^47.0.1",
     "lodash": "^4.17.21",
-    "native-base": "^3.4.25",
     "polylabel": "^1.1.0",
     "react": "18.1.0",
     "react-native": "0.70.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1149,13 +1149,6 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
-"@babel/runtime@^7.8.7":
-  version "7.20.7"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.7.tgz#fcb41a5a70550e04a7b708037c7c32f7f356d8fd"
-  integrity sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==
-  dependencies:
-    regenerator-runtime "^0.13.11"
-
 "@babel/template@^7.0.0", "@babel/template@^7.18.10":
   version "7.18.10"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.18.10.tgz#6f9134835970d1dbf0835c0d100c9f38de0c5e71"
@@ -1608,45 +1601,6 @@
     chalk "^4.1.0"
     find-up "^5.0.0"
     js-yaml "^4.1.0"
-
-"@formatjs/ecma402-abstract@1.14.3":
-  version "1.14.3"
-  resolved "https://registry.yarnpkg.com/@formatjs/ecma402-abstract/-/ecma402-abstract-1.14.3.tgz#6428f243538a11126180d121ce8d4b2f17465738"
-  integrity sha512-SlsbRC/RX+/zg4AApWIFNDdkLtFbkq3LNoZWXZCE/nHVKqoIJyaoQyge/I0Y38vLxowUn9KTtXgusLD91+orbg==
-  dependencies:
-    "@formatjs/intl-localematcher" "0.2.32"
-    tslib "^2.4.0"
-
-"@formatjs/fast-memoize@1.2.7":
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/@formatjs/fast-memoize/-/fast-memoize-1.2.7.tgz#90d5de031fc80e0027b2d4e8a3197b0df4a94457"
-  integrity sha512-hPeM5LXUUjtCKPybWOUAWpv8lpja8Xz+uKprFPJcg5F2Rd+/bf1E0UUsLRpaAgOReAf5HMRtoIgv/UcyPICrTQ==
-  dependencies:
-    tslib "^2.4.0"
-
-"@formatjs/icu-messageformat-parser@2.1.14":
-  version "2.1.14"
-  resolved "https://registry.yarnpkg.com/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.1.14.tgz#d7bc8c82bfce1eb8e3232e6d7e3d6ea92ba390cc"
-  integrity sha512-0KqeVOb72losEhUW+59vhZGGd14s1f35uThfEMVKZHKLEObvJdFTiI3ZQwvTMUCzLEMxnS6mtnYPmG4mTvwd3Q==
-  dependencies:
-    "@formatjs/ecma402-abstract" "1.14.3"
-    "@formatjs/icu-skeleton-parser" "1.3.18"
-    tslib "^2.4.0"
-
-"@formatjs/icu-skeleton-parser@1.3.18":
-  version "1.3.18"
-  resolved "https://registry.yarnpkg.com/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.18.tgz#7aed3d60e718c8ad6b0e64820be44daa1e29eeeb"
-  integrity sha512-ND1ZkZfmLPcHjAH1sVpkpQxA+QYfOX3py3SjKWMUVGDow18gZ0WPqz3F+pJLYQMpS2LnnQ5zYR2jPVYTbRwMpg==
-  dependencies:
-    "@formatjs/ecma402-abstract" "1.14.3"
-    tslib "^2.4.0"
-
-"@formatjs/intl-localematcher@0.2.32":
-  version "0.2.32"
-  resolved "https://registry.yarnpkg.com/@formatjs/intl-localematcher/-/intl-localematcher-0.2.32.tgz#00d4d307cd7d514b298e15a11a369b86c8933ec1"
-  integrity sha512-k/MEBstff4sttohyEpXxCmC3MqbUn9VvHGlZ8fauLzkbwXmVrEeyzS+4uhrvAk9DWU9/7otYWxyDox4nT/KVLQ==
-  dependencies:
-    tslib "^2.4.0"
 
 "@gar/promisify@^1.0.1":
   version "1.1.3"
@@ -2370,35 +2324,6 @@
   resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.5.tgz#b32366c89b43c6f8cefbdefac778b9c828e3ba8c"
   integrity sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==
 
-"@internationalized/date@^3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@internationalized/date/-/date-3.0.2.tgz#1566a0bcbd82dce4dd54a5b26456bb701068cb89"
-  integrity sha512-9V1IxesP6ASZj/hYyOXOC4yPJvidbbStyWQKLCQSqhhKACMOXoo+BddXZJy47ju9mqOMpWdrJ2rTx4yTxK9oag==
-  dependencies:
-    "@swc/helpers" "^0.4.14"
-
-"@internationalized/message@^3.0.10":
-  version "3.0.10"
-  resolved "https://registry.yarnpkg.com/@internationalized/message/-/message-3.0.10.tgz#340dcfd14ace37234e09419427c991a0c466b96e"
-  integrity sha512-vfLqEop/NH68IgqMcXJNSDqZ5Leg3EEgCxhuuSefU7vvdbptD3pwpUWXaK9igYPa+aZfUU0eqv86yqm76obtsw==
-  dependencies:
-    "@swc/helpers" "^0.4.14"
-    intl-messageformat "^10.1.0"
-
-"@internationalized/number@^3.1.2":
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/@internationalized/number/-/number-3.1.2.tgz#4482a6ac573acfb18efd354a42008af20da6c89c"
-  integrity sha512-Mbys8SGsn0ApXz3hJLNU+d95B8luoUbwnmCpBwl7d63UmYAlcT6TRDyvaS/vwdbElXLcsQJjQCu0gox2cv/Tig==
-  dependencies:
-    "@swc/helpers" "^0.4.14"
-
-"@internationalized/string@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@internationalized/string/-/string-3.0.1.tgz#2c70a81ae5eb84f156f40330369c2469bad6d504"
-  integrity sha512-2+rHfXZ56YgsC6i3fKvBue/xatnSm0Jv+C/x4+n3wg5xAcLh4LPW3GvZ/9ifxNAz9+IWplgZHa1FRIbSuUvNWg==
-  dependencies:
-    "@swc/helpers" "^0.4.14"
-
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -2925,393 +2850,6 @@
     tslib "^2.4.1"
     webcrypto-core "^1.7.4"
 
-"@react-aria/checkbox@^3.2.1":
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/checkbox/-/checkbox-3.7.1.tgz#217ea3173ad37ae85cb39bcb9932eb5c1cde2e0b"
-  integrity sha512-3KRg/KrTRwQdw5Yg7gpbIKWWVt57PbGSEXAS/diQvRf9pTXbOuChTES8uVlcwF8q+3mKXc4ppzE3gsNQ5jOMqg==
-  dependencies:
-    "@react-aria/label" "^3.4.4"
-    "@react-aria/toggle" "^3.4.2"
-    "@react-aria/utils" "^3.14.2"
-    "@react-stately/checkbox" "^3.3.2"
-    "@react-stately/toggle" "^3.4.4"
-    "@react-types/checkbox" "^3.4.1"
-    "@react-types/shared" "^3.16.0"
-    "@swc/helpers" "^0.4.14"
-
-"@react-aria/combobox@^3.0.0-alpha.1":
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/@react-aria/combobox/-/combobox-3.4.4.tgz#0a968bfefedc9106e4b098ea84707f6da93dfc83"
-  integrity sha512-aviSDt4JkYZC1Ww83gvrNB4cHetXu73n5NuEfMNBC3B6fiL0MP5Av5+lMgf8FzpQks39QkZNxBtQ/h4I3D7SBA==
-  dependencies:
-    "@react-aria/i18n" "^3.6.3"
-    "@react-aria/interactions" "^3.13.1"
-    "@react-aria/listbox" "^3.7.2"
-    "@react-aria/live-announcer" "^3.1.2"
-    "@react-aria/menu" "^3.7.1"
-    "@react-aria/overlays" "^3.12.1"
-    "@react-aria/selection" "^3.12.1"
-    "@react-aria/textfield" "^3.8.1"
-    "@react-aria/utils" "^3.14.2"
-    "@react-stately/collections" "^3.5.1"
-    "@react-stately/combobox" "^3.3.1"
-    "@react-stately/layout" "^3.10.0"
-    "@react-types/button" "^3.7.0"
-    "@react-types/combobox" "^3.5.5"
-    "@react-types/shared" "^3.16.0"
-    "@swc/helpers" "^0.4.14"
-
-"@react-aria/focus@^3.10.1", "@react-aria/focus@^3.2.3":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/focus/-/focus-3.10.1.tgz#624d02d2565151030a4156aeb17685d87f18ad58"
-  integrity sha512-HjgFUC1CznuYC7CxtBIFML6bOBxW3M3cSNtvmXU9QWlrPSwwOLkXCnfY6+UkjCc5huP4v7co4PoRDX8Vbe/cVQ==
-  dependencies:
-    "@react-aria/interactions" "^3.13.1"
-    "@react-aria/utils" "^3.14.2"
-    "@react-types/shared" "^3.16.0"
-    "@swc/helpers" "^0.4.14"
-    clsx "^1.1.1"
-
-"@react-aria/i18n@^3.2.0", "@react-aria/i18n@^3.3.0", "@react-aria/i18n@^3.6.3":
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/@react-aria/i18n/-/i18n-3.6.3.tgz#2b4d72d0baf07b514d2c35eb6ac356d0247ea84a"
-  integrity sha512-cDWl8FXJIXsw/raWcThywBueCJ5ncoogq81wYVS6hfZVmSyncONIB3bwUL12cojmjX1VEP31sN0ujT/83QP95Q==
-  dependencies:
-    "@internationalized/date" "^3.0.2"
-    "@internationalized/message" "^3.0.10"
-    "@internationalized/number" "^3.1.2"
-    "@internationalized/string" "^3.0.1"
-    "@react-aria/ssr" "^3.4.1"
-    "@react-aria/utils" "^3.14.2"
-    "@react-types/shared" "^3.16.0"
-    "@swc/helpers" "^0.4.14"
-
-"@react-aria/interactions@^3.13.1", "@react-aria/interactions@^3.3.2":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/interactions/-/interactions-3.13.1.tgz#75e102c50a5c1d002cad4ee8d59677aee226186b"
-  integrity sha512-WCvfZOi1hhussVTHxVq76OR48ry13Zvp9U5hmuQufyxIUlf4hOvDk4/cbK4o4JiCs8X7C7SRzcwFM34M4NHzmg==
-  dependencies:
-    "@react-aria/utils" "^3.14.2"
-    "@react-types/shared" "^3.16.0"
-    "@swc/helpers" "^0.4.14"
-
-"@react-aria/label@^3.1.1", "@react-aria/label@^3.4.4":
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/@react-aria/label/-/label-3.4.4.tgz#b891d3cebeeffc7a1413a492d8a694083dc3253e"
-  integrity sha512-1fuYf2UctNhBy31uYN7OhdcrwzlB5GS0+C49gDkwWzccB7yr+CoOJ5UQUoVB7WBmzrc+CuzwWxSDd4OupSYIZQ==
-  dependencies:
-    "@react-aria/utils" "^3.14.2"
-    "@react-types/label" "^3.7.1"
-    "@react-types/shared" "^3.16.0"
-    "@swc/helpers" "^0.4.14"
-
-"@react-aria/listbox@^3.2.4", "@react-aria/listbox@^3.7.2":
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/@react-aria/listbox/-/listbox-3.7.2.tgz#0cbbd4dc39712ac927542259bf4663e087353448"
-  integrity sha512-e3O/u2T3TccinmfS/UvHywxLbASmh28U4020WTpZnIrsaoriVCkGZvG1AYNNPDIESz2WO0oRF6vDrmGunglJ2A==
-  dependencies:
-    "@react-aria/focus" "^3.10.1"
-    "@react-aria/interactions" "^3.13.1"
-    "@react-aria/label" "^3.4.4"
-    "@react-aria/selection" "^3.12.1"
-    "@react-aria/utils" "^3.14.2"
-    "@react-stately/collections" "^3.5.1"
-    "@react-stately/list" "^3.6.1"
-    "@react-types/listbox" "^3.3.5"
-    "@react-types/shared" "^3.16.0"
-    "@swc/helpers" "^0.4.14"
-
-"@react-aria/live-announcer@^3.0.0-alpha.0", "@react-aria/live-announcer@^3.1.2":
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/@react-aria/live-announcer/-/live-announcer-3.1.2.tgz#a492c7ec1e664c8f41a572368cdbc53e22241a0c"
-  integrity sha512-BqtVLPWU10sZssoOJF1lJiRvZe5zqZ5BM39PsFyO7dWhVkR/9O9bZviqvKXnC1oXCnypfa+85gUshbK9unFcWA==
-  dependencies:
-    "@swc/helpers" "^0.4.14"
-
-"@react-aria/menu@^3.7.1":
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/menu/-/menu-3.7.1.tgz#74c60dcd33bba47faa79deb89523ad21d9855221"
-  integrity sha512-5KIUTs3xYSmERB8qzofFghznMVLcG3RWDnJcQjpRtrrYjm6Oc39TJeodDH874fiEr6o3i5WwMrEYVp7NSxz/TQ==
-  dependencies:
-    "@react-aria/i18n" "^3.6.3"
-    "@react-aria/interactions" "^3.13.1"
-    "@react-aria/overlays" "^3.12.1"
-    "@react-aria/selection" "^3.12.1"
-    "@react-aria/utils" "^3.14.2"
-    "@react-stately/collections" "^3.5.1"
-    "@react-stately/menu" "^3.4.4"
-    "@react-stately/tree" "^3.4.1"
-    "@react-types/button" "^3.7.0"
-    "@react-types/menu" "^3.7.3"
-    "@react-types/shared" "^3.16.0"
-    "@swc/helpers" "^0.4.14"
-
-"@react-aria/overlays@^3.12.1", "@react-aria/overlays@^3.6.1", "@react-aria/overlays@^3.7.0":
-  version "3.12.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/overlays/-/overlays-3.12.1.tgz#429fe33b0da7b920334f241c688d73dc9a750a28"
-  integrity sha512-OSgSopk2uQI5unvC3+fUyngbRFFe4GnF0iopCmrsI7qSQEusJUd4M2SuPVXUBBwWFt5TsiH7TnxmIPWeh5LSoA==
-  dependencies:
-    "@react-aria/focus" "^3.10.1"
-    "@react-aria/i18n" "^3.6.3"
-    "@react-aria/interactions" "^3.13.1"
-    "@react-aria/ssr" "^3.4.1"
-    "@react-aria/utils" "^3.14.2"
-    "@react-aria/visually-hidden" "^3.6.1"
-    "@react-stately/overlays" "^3.4.4"
-    "@react-types/button" "^3.7.0"
-    "@react-types/overlays" "^3.6.5"
-    "@react-types/shared" "^3.16.0"
-    "@swc/helpers" "^0.4.14"
-
-"@react-aria/radio@^3.1.2":
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/@react-aria/radio/-/radio-3.4.2.tgz#bcd2deb8326f934046545fee9b2568f9d3b0655b"
-  integrity sha512-PpEsQjwkYOkSfKfnqXpBzf0FM/V2GSC0g/NG2ZAI5atDIACeic+kHCcs8fm2QzXtUDaRltNurvYdDJ+XzZ8g1g==
-  dependencies:
-    "@react-aria/focus" "^3.10.1"
-    "@react-aria/i18n" "^3.6.3"
-    "@react-aria/interactions" "^3.13.1"
-    "@react-aria/label" "^3.4.4"
-    "@react-aria/utils" "^3.14.2"
-    "@react-stately/radio" "^3.6.2"
-    "@react-types/radio" "^3.3.1"
-    "@react-types/shared" "^3.16.0"
-    "@swc/helpers" "^0.4.14"
-
-"@react-aria/selection@^3.12.1", "@react-aria/selection@^3.3.1", "@react-aria/selection@^3.3.2":
-  version "3.12.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/selection/-/selection-3.12.1.tgz#a21ea85952c55b5a7ce8c846478226fe3d03f1f8"
-  integrity sha512-UX1vSY+iUdHe0itFZIOizX1BCI8SAeFnEh5VIQ1bYRt93+kAxeC914fsxFPPgrodJyqWRCX1dblPyRUIWAzQiw==
-  dependencies:
-    "@react-aria/focus" "^3.10.1"
-    "@react-aria/i18n" "^3.6.3"
-    "@react-aria/interactions" "^3.13.1"
-    "@react-aria/utils" "^3.14.2"
-    "@react-stately/collections" "^3.5.1"
-    "@react-stately/selection" "^3.11.2"
-    "@react-types/shared" "^3.16.0"
-    "@swc/helpers" "^0.4.14"
-
-"@react-aria/slider@^3.0.1":
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/@react-aria/slider/-/slider-3.2.4.tgz#b272c13b5651f7e76a5b9d4ef300226ae315a64d"
-  integrity sha512-+BDPFaCgm0gtGewO33ZDNZz1b3Fc1p5Y/HSuwCcru+jHetODJXy23IIVpWsDri1vG3fHECRnWcDZAjLZgkVnAw==
-  dependencies:
-    "@react-aria/focus" "^3.10.1"
-    "@react-aria/i18n" "^3.6.3"
-    "@react-aria/interactions" "^3.13.1"
-    "@react-aria/label" "^3.4.4"
-    "@react-aria/utils" "^3.14.2"
-    "@react-stately/radio" "^3.6.2"
-    "@react-stately/slider" "^3.2.4"
-    "@react-types/radio" "^3.3.1"
-    "@react-types/shared" "^3.16.0"
-    "@react-types/slider" "^3.3.1"
-    "@swc/helpers" "^0.4.14"
-
-"@react-aria/ssr@^3.0.1", "@react-aria/ssr@^3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/ssr/-/ssr-3.4.1.tgz#79e8bb621487e8f52890c917d3c734f448ba95e7"
-  integrity sha512-NmhoilMDyIfQiOSdQgxpVH2tC2u85Y0mVijtBNbI9kcDYLEiW/r6vKYVKtkyU+C4qobXhGMPfZ70PTc0lysSVA==
-  dependencies:
-    "@swc/helpers" "^0.4.14"
-
-"@react-aria/tabs@3.0.0-alpha.2":
-  version "3.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@react-aria/tabs/-/tabs-3.0.0-alpha.2.tgz#3b931d9c752c2dca4c2a1b975248b0ee751077a2"
-  integrity sha512-yHpz1HujxBcMq8e4jrHkkowzrJwuVyssCB+DuA91kt6LC0eIMZsDZY9tEhhOq+TyOhI3nbyXaDKJG6y1qB0A5A==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-    "@react-aria/i18n" "^3.2.0"
-    "@react-aria/interactions" "^3.3.2"
-    "@react-aria/selection" "^3.3.1"
-    "@react-aria/utils" "^3.4.1"
-    "@react-stately/list" "^3.2.2"
-    "@react-stately/tabs" "3.0.0-alpha.0"
-    "@react-types/shared" "^3.2.1"
-    "@react-types/tabs" "3.0.0-alpha.2"
-
-"@react-aria/textfield@^3.8.1":
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/textfield/-/textfield-3.8.1.tgz#b6df2decc587824a3757ec33bd9b432fed1bacc5"
-  integrity sha512-jgun/B9ecuRCfBSJLX2xDuNwfuj1lL0oibMWoSv6Y++W+CSS8a7LjR1f9Kll5TDVkQiRRUm9qHwI0og9xTJrNw==
-  dependencies:
-    "@react-aria/focus" "^3.10.1"
-    "@react-aria/label" "^3.4.4"
-    "@react-aria/utils" "^3.14.2"
-    "@react-types/shared" "^3.16.0"
-    "@react-types/textfield" "^3.6.2"
-    "@swc/helpers" "^0.4.14"
-
-"@react-aria/toggle@^3.4.2":
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/@react-aria/toggle/-/toggle-3.4.2.tgz#1c57539a26722219979c80dcebfbd0701c518789"
-  integrity sha512-xokCGf0fn96mOMqQku5QW672iQoMsN9RMpFbKvvgg2seceh8ifblyAXElWf/6YmluOZSgUSZljDkFrbMMYlzVA==
-  dependencies:
-    "@react-aria/focus" "^3.10.1"
-    "@react-aria/interactions" "^3.13.1"
-    "@react-aria/utils" "^3.14.2"
-    "@react-stately/toggle" "^3.4.4"
-    "@react-types/checkbox" "^3.4.1"
-    "@react-types/shared" "^3.16.0"
-    "@react-types/switch" "^3.2.5"
-    "@swc/helpers" "^0.4.14"
-
-"@react-aria/utils@^3.14.2", "@react-aria/utils@^3.3.0", "@react-aria/utils@^3.4.1", "@react-aria/utils@^3.6.0":
-  version "3.14.2"
-  resolved "https://registry.yarnpkg.com/@react-aria/utils/-/utils-3.14.2.tgz#3a8d0d14abab4bb1095e101ee44dc5e3e43e6217"
-  integrity sha512-3nr5gsAf/J/W+6Tu4NF3Q7m+1mXjfpXESh7TPa6UR6v3tVDTsJVMrITg2BkHN1jM8xELcl2ZxyUffOWqOXzWuA==
-  dependencies:
-    "@react-aria/ssr" "^3.4.1"
-    "@react-stately/utils" "^3.5.2"
-    "@react-types/shared" "^3.16.0"
-    "@swc/helpers" "^0.4.14"
-    clsx "^1.1.1"
-
-"@react-aria/visually-hidden@^3.2.1", "@react-aria/visually-hidden@^3.6.1":
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/visually-hidden/-/visually-hidden-3.6.1.tgz#b0a94b1531b9a8942d0d9a5cc6ed88109b8f5487"
-  integrity sha512-7rUbiaIiR1nok9HAHPn/WcyQlvuldUqxnvh81V4dlI3NtXOgMw7/QaNc5Xo5FFWlsSVpbyK3UVJgzIui0Ns0Xg==
-  dependencies:
-    "@react-aria/interactions" "^3.13.1"
-    "@react-aria/utils" "^3.14.2"
-    "@react-types/shared" "^3.16.0"
-    "@swc/helpers" "^0.4.14"
-    clsx "^1.1.1"
-
-"@react-native-aria/button@^0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@react-native-aria/button/-/button-0.2.4.tgz#ce0c994449011f4b852a222afd90e027fb839de0"
-  integrity sha512-wlu6SXI20U+N4fbPX8oh9pkL9hx8W41+cra3fa3s2xfQ6czT4KAkyvSsr1ALUBH4dRkoxxSPOcGJMGnq2K3djw==
-  dependencies:
-    "@react-aria/utils" "^3.6.0"
-    "@react-native-aria/interactions" "^0.2.3"
-    "@react-stately/toggle" "^3.2.1"
-    "@react-types/checkbox" "^3.2.1"
-
-"@react-native-aria/checkbox@^0.2.2":
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/@react-native-aria/checkbox/-/checkbox-0.2.3.tgz#b6c99c215677df872f1bb4e596b54573f1c7a5f0"
-  integrity sha512-YtWtXGg5tvOaV6v1CmbusXoOZvGRAVYygms9qNeUF7/B8/iDNGSKjlxHE5LVOLRtJO/B9ndZnr6RkL326ceyng==
-  dependencies:
-    "@react-aria/checkbox" "^3.2.1"
-    "@react-aria/utils" "^3.6.0"
-    "@react-native-aria/toggle" "^0.2.3"
-    "@react-native-aria/utils" "^0.2.6"
-    "@react-stately/toggle" "^3.2.1"
-
-"@react-native-aria/combobox@^0.2.4-alpha.0":
-  version "0.2.4-alpha.1"
-  resolved "https://registry.yarnpkg.com/@react-native-aria/combobox/-/combobox-0.2.4-alpha.1.tgz#2ec7c5c2e87aba4dda62e494a4c3538066275e2b"
-  integrity sha512-MOxKMKVus9MsOL3l+mNRDYHeVr5kj5fYnretLofWh/dHBO2W5H7H70ZfOPDEr9s+vgaBBjHCtbbfOiimKRk6Kg==
-  dependencies:
-    "@react-aria/combobox" "^3.0.0-alpha.1"
-    "@react-aria/live-announcer" "^3.0.0-alpha.0"
-    "@react-aria/overlays" "^3.6.1"
-    "@react-aria/utils" "^3.6.0"
-    "@react-native-aria/utils" "^0.2.6"
-    "@react-types/button" "^3.3.1"
-
-"@react-native-aria/focus@^0.2.6":
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/@react-native-aria/focus/-/focus-0.2.7.tgz#fd339d5ec8384cee6afe0c0115a528f360d04a27"
-  integrity sha512-7Ol8AoTzEN7qC4t4AzclPzjQZ0oRkNBePmVBm2lAQwOnmkKwa+TdiVGtU7MgvsQxUV3aTTMY2Nu1Z5YwCwhUkA==
-  dependencies:
-    "@react-aria/focus" "^3.2.3"
-
-"@react-native-aria/interactions@^0.2.2", "@react-native-aria/interactions@^0.2.3", "@react-native-aria/interactions@^0.2.7":
-  version "0.2.8"
-  resolved "https://registry.yarnpkg.com/@react-native-aria/interactions/-/interactions-0.2.8.tgz#5ced4bd3391c647699fa79275472f784a44c2488"
-  integrity sha512-+LsLghBnp1fEVdLdIZGfE2izbZS0GPwc7eyiLHndnAXwXdLmyDRw71UCEjsUuNh7SO7BBR5QjHlk0cTHmyynQg==
-  dependencies:
-    "@react-aria/interactions" "^3.3.2"
-    "@react-aria/utils" "^3.6.0"
-    "@react-native-aria/utils" "^0.2.6"
-
-"@react-native-aria/listbox@^0.2.4-alpha.3":
-  version "0.2.4-alpha.3"
-  resolved "https://registry.yarnpkg.com/@react-native-aria/listbox/-/listbox-0.2.4-alpha.3.tgz#1a8df0de6c932c8143ea73e43713a5d37070203c"
-  integrity sha512-e/y+Wdoyy/PbpFj4DVYDYMsKI+uUqnZ/0yLByqHQvzs8Ys8o69CQkyEYzHhxvFT5lCLegkLbuQN2cJd8bYNQsA==
-  dependencies:
-    "@react-aria/interactions" "^3.3.2"
-    "@react-aria/label" "^3.1.1"
-    "@react-aria/listbox" "^3.2.4"
-    "@react-aria/selection" "^3.3.2"
-    "@react-aria/utils" "^3.6.0"
-    "@react-native-aria/interactions" "^0.2.2"
-    "@react-native-aria/utils" "^0.2.6"
-    "@react-types/listbox" "^3.1.1"
-    "@react-types/shared" "^3.4.0"
-
-"@react-native-aria/overlays@0.3.3-rc.0":
-  version "0.3.3-rc.0"
-  resolved "https://registry.yarnpkg.com/@react-native-aria/overlays/-/overlays-0.3.3-rc.0.tgz#9041ddd6f151e6edb50c971d29920c458aa41459"
-  integrity sha512-RgaIYIHMltt0RdMrVwfXLAVxc22TIUY1Yx07HbQRMdt4LcSmU8pyp5CEtJ/MQCXceuqocnXfsUxyHOSnfhmfpA==
-  dependencies:
-    "@react-aria/interactions" "^3.3.2"
-    "@react-aria/overlays" "^3.7.0"
-    "@react-native-aria/utils" "^0.2.8"
-    "@react-stately/overlays" "^3.1.1"
-    "@react-types/overlays" "^3.4.0"
-    dom-helpers "^5.0.0"
-
-"@react-native-aria/radio@^0.2.4":
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/@react-native-aria/radio/-/radio-0.2.5.tgz#436d3abdbb48bcaf6e9c5c045ff9c5bf87b71248"
-  integrity sha512-kTfCjRMZH+Z2C70VxjomPO8eXBcHPa5zcuOUotyhR10WsrKZJlwwnA75t2xDq8zsxKnABJRfThv7rSlAjkFSeg==
-  dependencies:
-    "@react-aria/radio" "^3.1.2"
-    "@react-aria/utils" "^3.6.0"
-    "@react-native-aria/interactions" "^0.2.3"
-    "@react-native-aria/utils" "^0.2.6"
-    "@react-stately/radio" "^3.2.1"
-    "@react-types/radio" "^3.1.1"
-
-"@react-native-aria/slider@^0.2.5-alpha.1":
-  version "0.2.5-alpha.2"
-  resolved "https://registry.yarnpkg.com/@react-native-aria/slider/-/slider-0.2.5-alpha.2.tgz#e613c2ac338de8d8ef8999ed664ea743174ee8da"
-  integrity sha512-eYCAGEgcmgs2x5yC1q3edq/VpZWd8P9x1ZoB6uhiyIpDViTDFTz82IWTK0jrbHC70WxWfoY+876VjiKzbjyNxw==
-  dependencies:
-    "@react-aria/focus" "^3.2.3"
-    "@react-aria/interactions" "^3.3.2"
-    "@react-aria/label" "^3.1.1"
-    "@react-aria/slider" "^3.0.1"
-    "@react-aria/utils" "^3.6.0"
-    "@react-native-aria/utils" "^0.2.6"
-    "@react-stately/slider" "^3.0.1"
-
-"@react-native-aria/tabs@^0.2.7":
-  version "0.2.8"
-  resolved "https://registry.yarnpkg.com/@react-native-aria/tabs/-/tabs-0.2.8.tgz#8b721261a277fe0459154f70c25b81e23217c864"
-  integrity sha512-coAiaj9NFFh8vYr/kiugqLwip8IhB6m2dL/GXPcmbK0WH531pIPXKSwgePjniETJtEP84L4PYCTZ705pRlVN8A==
-  dependencies:
-    "@react-aria/selection" "^3.3.1"
-    "@react-aria/tabs" "3.0.0-alpha.2"
-    "@react-native-aria/interactions" "^0.2.7"
-    "@react-native-aria/utils" "^0.2.7"
-    "@react-stately/tabs" "3.0.0-alpha.1"
-    "@react-types/tabs" "3.0.0-alpha.2"
-
-"@react-native-aria/toggle@^0.2.3":
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/@react-native-aria/toggle/-/toggle-0.2.3.tgz#a387f03480aa0d97dc0191acbcae66122f7bcf7f"
-  integrity sha512-3aOlchMxpR0b2h3Z7V0aYZaQMVJD6uKOWKWJm82VsLrni4iDnDX/mLv30ujuuK3+LclUhVlJd2kRuCl+xnf3XQ==
-  dependencies:
-    "@react-aria/focus" "^3.2.3"
-    "@react-aria/utils" "^3.6.0"
-    "@react-native-aria/interactions" "^0.2.3"
-    "@react-native-aria/utils" "^0.2.6"
-    "@react-stately/toggle" "^3.2.1"
-    "@react-types/checkbox" "^3.2.1"
-
-"@react-native-aria/utils@^0.2.6", "@react-native-aria/utils@^0.2.7", "@react-native-aria/utils@^0.2.8":
-  version "0.2.8"
-  resolved "https://registry.yarnpkg.com/@react-native-aria/utils/-/utils-0.2.8.tgz#da433606506125483080f18dbcd97b526ca46fd5"
-  integrity sha512-x375tG1itv3irLFRnURLsdK2djuvhFJHizSDUtLCo8skQwfjslED5t4sUkQ49di4G850gaVJz0fCcCx/pHX7CA==
-  dependencies:
-    "@react-aria/ssr" "^3.0.1"
-    "@react-aria/utils" "^3.3.0"
-
 "@react-native-camera-roll/camera-roll@^5.2.0":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@react-native-camera-roll/camera-roll/-/camera-roll-5.2.0.tgz#a30dca7c486379650c03fb8cc6fe35b7de6eeb82"
@@ -3593,388 +3131,6 @@
   dependencies:
     nanoid "^3.1.23"
 
-"@react-stately/checkbox@3.0.3":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@react-stately/checkbox/-/checkbox-3.0.3.tgz#18ee6bd3b544334b6f853bb5c5f7017ac3bb9c37"
-  integrity sha512-amT889DTLdbjAVjZ9j9TytN73PszynGIspKi1QSUCvXeA2OVyCwShxhV0Pn7yYX8cMinvGXrjhWdhn0nhYeMdg==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-    "@react-stately/toggle" "^3.2.3"
-    "@react-stately/utils" "^3.2.2"
-    "@react-types/checkbox" "^3.2.3"
-
-"@react-stately/checkbox@^3.3.2":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/@react-stately/checkbox/-/checkbox-3.3.2.tgz#fd81866a7624c79cab2ec2c32234f164205a85e8"
-  integrity sha512-eU3zvWgQrcqS8UK8ZVkb3fMP816PeuN9N0/dOJKuOXXhkoLPuxtuja1oEqKU3sFMa5+bx3czZhhNIRpr60NAdw==
-  dependencies:
-    "@react-stately/toggle" "^3.4.4"
-    "@react-stately/utils" "^3.5.2"
-    "@react-types/checkbox" "^3.4.1"
-    "@react-types/shared" "^3.16.0"
-    "@swc/helpers" "^0.4.14"
-
-"@react-stately/collections@3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@react-stately/collections/-/collections-3.3.0.tgz#d1e66077b47a8b6a9abcac66f1052d4b8851ce47"
-  integrity sha512-Y8Pfugw/tYbcR9F6GTiTkd9O4FiXErxi5aDLSZ/knS6v0pvr3EHsC3T7jLW+48dSNrwl+HkMe5ECMhWSUA1jRQ==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-    "@react-types/shared" "^3.2.1"
-
-"@react-stately/collections@^3.5.1":
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/@react-stately/collections/-/collections-3.5.1.tgz#502a56658e4859aa7d31bd4b9189879b5b5a0255"
-  integrity sha512-egzVrZC5eFc5RJBpqUkzxd2aJOHZ2T1o7horEi8tAWZkg4YI+AmKrqela4ijVrrB9l1GO9z06qPT1UoPkFrC1w==
-  dependencies:
-    "@react-types/shared" "^3.16.0"
-    "@swc/helpers" "^0.4.14"
-
-"@react-stately/combobox@3.0.0-alpha.1":
-  version "3.0.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@react-stately/combobox/-/combobox-3.0.0-alpha.1.tgz#d3240ba528b021965998950a615e715c2eccbcee"
-  integrity sha512-v0DNGLx0KGvNgBbXoSKzfHGcy65eP0Wx4uY3dqj+u9k3ru2BEvIqB8fo6CWhQqu8VHBX4AlhoxcyrloIKvjD/g==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-    "@react-stately/list" "^3.2.2"
-    "@react-stately/menu" "^3.1.0"
-    "@react-stately/select" "^3.1.0"
-    "@react-stately/utils" "^3.2.0"
-    "@react-types/combobox" "3.0.0-alpha.1"
-    "@react-types/shared" "^3.4.0"
-
-"@react-stately/combobox@^3.3.1":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@react-stately/combobox/-/combobox-3.3.1.tgz#5be13467dd64ddd09199b5e00e9f7d4a1aec5688"
-  integrity sha512-DgYn0MyfbDySf54o7ofXRd29TWznqtRRRbMG8TWgi/RaB0piDckT/TYWWSYOH3iMgnOEhReJhUUdMiQG4QLpIg==
-  dependencies:
-    "@react-stately/list" "^3.6.1"
-    "@react-stately/menu" "^3.4.4"
-    "@react-stately/select" "^3.3.4"
-    "@react-stately/utils" "^3.5.2"
-    "@react-types/combobox" "^3.5.5"
-    "@react-types/shared" "^3.16.0"
-    "@swc/helpers" "^0.4.14"
-
-"@react-stately/grid@^3.4.2":
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/@react-stately/grid/-/grid-3.4.2.tgz#d7d1a4ed4b5bb431b5e5429f8f557cf7d88a7ae8"
-  integrity sha512-NeIUykQeA7Hen+dV4771ARW5SRrHYNn5VTOsQwn3KBUd2Z2gZ01OwUl3gETl5u0e3/tzMUdJ1LUoSPhDMwcmKw==
-  dependencies:
-    "@react-stately/selection" "^3.11.2"
-    "@react-types/grid" "^3.1.5"
-    "@react-types/shared" "^3.16.0"
-    "@swc/helpers" "^0.4.14"
-
-"@react-stately/layout@^3.10.0":
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/@react-stately/layout/-/layout-3.10.0.tgz#86bcb9117a05df56f02d7b55d1d24c5593285c18"
-  integrity sha512-ThFgivQSD5ksLMX7tbu0HqIxbxac/E8a/0vA21wB9QF9IQnUKO796QAQqwfA5rwPvTT41LL2Xn00GkrwQ9g/zg==
-  dependencies:
-    "@react-stately/table" "^3.7.0"
-    "@react-stately/virtualizer" "^3.4.1"
-    "@react-types/grid" "^3.1.5"
-    "@react-types/shared" "^3.16.0"
-    "@react-types/table" "^3.4.0"
-    "@swc/helpers" "^0.4.14"
-
-"@react-stately/list@^3.2.2", "@react-stately/list@^3.6.1":
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/@react-stately/list/-/list-3.6.1.tgz#75d07a4e04111b804fb13c975df5a0c1265f3aa1"
-  integrity sha512-+/fVkK3UO+N2NoUGpe57k9gcnfIsyEgWP8SD6CXZUkJho7BTp6mwrH0Wm8tcOclT3uBk+fZaQrk8mR3uWsPZGw==
-  dependencies:
-    "@react-stately/collections" "^3.5.1"
-    "@react-stately/selection" "^3.11.2"
-    "@react-stately/utils" "^3.5.2"
-    "@react-types/shared" "^3.16.0"
-    "@swc/helpers" "^0.4.14"
-
-"@react-stately/menu@^3.1.0", "@react-stately/menu@^3.4.4":
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/@react-stately/menu/-/menu-3.4.4.tgz#222ffd283691f1c4137a85ff0484b98a4385b099"
-  integrity sha512-WKak1NSV9yDY0tDB4mzsbj0FboTtR06gekio0VmKb1+FmnrC07mef8eGKUn974F0WhTNUy5A1iI5eM0W2YNynA==
-  dependencies:
-    "@react-stately/overlays" "^3.4.4"
-    "@react-stately/utils" "^3.5.2"
-    "@react-types/menu" "^3.7.3"
-    "@react-types/shared" "^3.16.0"
-    "@swc/helpers" "^0.4.14"
-
-"@react-stately/overlays@^3.1.1", "@react-stately/overlays@^3.4.4":
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/@react-stately/overlays/-/overlays-3.4.4.tgz#a228a230f46f0d593ffb7bc8f836439bbc08e9ed"
-  integrity sha512-IIlx+VXtXS4snDXrocUOls8QZ5XBQ4SNonaz1ox8/5W7Nsvq4VtdKsIaXsUP4agOudswaimlpj3pTDO/KuF5tQ==
-  dependencies:
-    "@react-stately/utils" "^3.5.2"
-    "@react-types/overlays" "^3.6.5"
-    "@swc/helpers" "^0.4.14"
-
-"@react-stately/radio@3.2.1":
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/@react-stately/radio/-/radio-3.2.1.tgz#d3fb0b28c2e7accdee47912c9802ab4a886a3092"
-  integrity sha512-WGYMWCDJQOicFLf+bW2CbAnlRWaqsUd028WpsS41GWyIx/w7DVpUeGFwTSvyCXC5SCQZuambsWHgXNz8Ng5WIA==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-    "@react-stately/utils" "^3.1.1"
-    "@react-types/radio" "^3.1.1"
-
-"@react-stately/radio@^3.2.1", "@react-stately/radio@^3.6.2":
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/@react-stately/radio/-/radio-3.6.2.tgz#6a13e3f97d130fccc1b404673cbe1414ac018621"
-  integrity sha512-qjbebR0YSkdEocLsPSzNnCsUYllWY938/5Z8mETxk4+74PJLxC3z0qjqVRq+aDO8hOgIfqSgrRRp3cJz9vIsBg==
-  dependencies:
-    "@react-stately/utils" "^3.5.2"
-    "@react-types/radio" "^3.3.1"
-    "@react-types/shared" "^3.16.0"
-    "@swc/helpers" "^0.4.14"
-
-"@react-stately/select@^3.1.0", "@react-stately/select@^3.3.4":
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/@react-stately/select/-/select-3.3.4.tgz#61c3e739175e86babf0e585f8c68e30f3bf6363c"
-  integrity sha512-gD4JnF9/OIrQNdA4VqPIbifqpBC84BXHR5N7KmG7Ef06K9WGGVNB4FS538wno/znKg7lR6A45CPlaV53qfvWHg==
-  dependencies:
-    "@react-stately/collections" "^3.5.1"
-    "@react-stately/list" "^3.6.1"
-    "@react-stately/menu" "^3.4.4"
-    "@react-stately/selection" "^3.11.2"
-    "@react-stately/utils" "^3.5.2"
-    "@react-types/select" "^3.6.5"
-    "@react-types/shared" "^3.16.0"
-    "@swc/helpers" "^0.4.14"
-
-"@react-stately/selection@^3.11.2":
-  version "3.11.2"
-  resolved "https://registry.yarnpkg.com/@react-stately/selection/-/selection-3.11.2.tgz#15c35dfb386e5218b8106070137a8b3ecded5a8b"
-  integrity sha512-g21Y36xhYkXO3yzz0BYSBqnD38olvEwsJUqBXGZfx//bshMC2FNmI5sRYMAi36stxWbwzBvB01OytxfLLxCXCA==
-  dependencies:
-    "@react-stately/collections" "^3.5.1"
-    "@react-stately/utils" "^3.5.2"
-    "@react-types/shared" "^3.16.0"
-    "@swc/helpers" "^0.4.14"
-
-"@react-stately/slider@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@react-stately/slider/-/slider-3.0.1.tgz#076c149947ae45f5eda30178b368ad0c4052f2a3"
-  integrity sha512-gGpfdVbTmdsOvrmZvFx4hJ5b7nczvAWdHR/tFFJKfxH0/V8NudZ5hGnawY84R3x+OvgV+tKUfifEUKA+oJyG5w==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-    "@react-aria/i18n" "^3.3.0"
-    "@react-aria/utils" "^3.6.0"
-    "@react-stately/utils" "^3.2.0"
-    "@react-types/slider" "^3.0.1"
-
-"@react-stately/slider@^3.0.1", "@react-stately/slider@^3.2.4":
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/@react-stately/slider/-/slider-3.2.4.tgz#4e9e22cd8c2c449497e8476f2bc8d1399a5b0f80"
-  integrity sha512-J97lTLqQKsrVSovYr4dTz7IJO/+j9OStT78N6bumDklnIKT7bsH3g857zITUFjs8yCcq0Jt3sfOvEU0ts6vyww==
-  dependencies:
-    "@react-aria/i18n" "^3.6.3"
-    "@react-aria/utils" "^3.14.2"
-    "@react-stately/utils" "^3.5.2"
-    "@react-types/shared" "^3.16.0"
-    "@react-types/slider" "^3.3.1"
-    "@swc/helpers" "^0.4.14"
-
-"@react-stately/table@^3.7.0":
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/@react-stately/table/-/table-3.7.0.tgz#fbb50081805c391d43de8ca4153bcd89edb82368"
-  integrity sha512-oPvMEabRUD4LSJ/NZsal3TT2YjoRmpEK8t2pqG20+Vapxy5tC6QKEZQvrDxJwF4Z8fqQnX/GvnqmfypvqWDUSA==
-  dependencies:
-    "@react-stately/collections" "^3.5.1"
-    "@react-stately/grid" "^3.4.2"
-    "@react-stately/selection" "^3.11.2"
-    "@react-types/grid" "^3.1.5"
-    "@react-types/shared" "^3.16.0"
-    "@react-types/table" "^3.4.0"
-    "@swc/helpers" "^0.4.14"
-
-"@react-stately/tabs@3.0.0-alpha.0":
-  version "3.0.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@react-stately/tabs/-/tabs-3.0.0-alpha.0.tgz#41451c7957ab2773fc4edb78ec02fcb94c6ab226"
-  integrity sha512-QJZ9N7DT89RkP18btvQhJvxWuv/JkSwtm14ftfk+5LBbzyxyLsD2KP6jDrNhXgmkRMmIyEaMt2w2VmI6fQ6UAA==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-    "@react-stately/list" "^3.2.2"
-    "@react-stately/utils" "^3.0.0-alpha.1"
-    "@react-types/tabs" "3.0.0-alpha.2"
-
-"@react-stately/tabs@3.0.0-alpha.1":
-  version "3.0.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@react-stately/tabs/-/tabs-3.0.0-alpha.1.tgz#b166ca9733ebebcc3bb2223116b8b070af104812"
-  integrity sha512-aEG5lVLqmfx7A/dS5gkPXmD2ERAo69RtC0aHPo/Dw1XjzalYyo6QbQ5WtiuQxsCVx/naWGEJCcMEAD5/vt+cUQ==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-    "@react-stately/list" "^3.2.2"
-    "@react-stately/utils" "^3.2.0"
-    "@react-types/tabs" "3.0.0-alpha.2"
-
-"@react-stately/toggle@3.2.1":
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/@react-stately/toggle/-/toggle-3.2.1.tgz#8b10b5eb99c3c4df2c36d17a5f23b77773ed7722"
-  integrity sha512-gZVuJ8OYoATUoXzdprsyx6O1w3wCrN+J0KnjhrjjKTrBG68n3pZH0p6dM0XpsaCzlSv0UgNa4fhHS3dYfr/ovw==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-    "@react-stately/utils" "^3.1.1"
-    "@react-types/checkbox" "^3.2.1"
-    "@react-types/shared" "^3.2.1"
-
-"@react-stately/toggle@^3.2.1", "@react-stately/toggle@^3.2.3", "@react-stately/toggle@^3.4.4":
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/@react-stately/toggle/-/toggle-3.4.4.tgz#b7825bf900725dcee0444fe6132b06948be36b44"
-  integrity sha512-OwVJpd2M7P7fekTWpl3TUdD3Brq+Z/xElOCJYP5QuVytXCa5seKsk40YPld8JQnA5dRKojpbUxMDOJpb6hOOfw==
-  dependencies:
-    "@react-stately/utils" "^3.5.2"
-    "@react-types/checkbox" "^3.4.1"
-    "@react-types/shared" "^3.16.0"
-    "@swc/helpers" "^0.4.14"
-
-"@react-stately/tree@^3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@react-stately/tree/-/tree-3.4.1.tgz#bb267784000b22c7c1aa6415103ad1b9f3566677"
-  integrity sha512-kIXeJOHgGGaUFnAD2wyRIiOwOw/+PN1OXo46n8+dPTFIYwR4+IWFNG8OMjVlIiSLPYWMCzzxZBE9a5grmbmNWQ==
-  dependencies:
-    "@react-stately/collections" "^3.5.1"
-    "@react-stately/selection" "^3.11.2"
-    "@react-stately/utils" "^3.5.2"
-    "@react-types/shared" "^3.16.0"
-    "@swc/helpers" "^0.4.14"
-
-"@react-stately/utils@^3.0.0-alpha.1", "@react-stately/utils@^3.1.1", "@react-stately/utils@^3.2.0", "@react-stately/utils@^3.2.2", "@react-stately/utils@^3.5.2":
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/@react-stately/utils/-/utils-3.5.2.tgz#9b5f3bb9ad500bf9c5b636a42988dba60a221669"
-  integrity sha512-639gSKqamPHIEPaApb9ahVJS0HgAqNdVF3tQRoh+Ky6759Mbk6i3HqG4zk4IGQ1tVlYSYZvCckwehF7b2zndMg==
-  dependencies:
-    "@swc/helpers" "^0.4.14"
-
-"@react-stately/virtualizer@^3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@react-stately/virtualizer/-/virtualizer-3.4.1.tgz#00c7b36b989244cf985b9ad5fb13dc1ecbb81a0f"
-  integrity sha512-2S7GARkZl41X7fN0Xa94TkN8ELAUbA89zn1xH59d02NOvAKLAFXHkCe69AivvVvbhXo8/nONzO8NXqqgBS/XQw==
-  dependencies:
-    "@react-aria/utils" "^3.14.2"
-    "@react-types/shared" "^3.16.0"
-    "@swc/helpers" "^0.4.14"
-
-"@react-types/button@^3.3.1", "@react-types/button@^3.7.0":
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/@react-types/button/-/button-3.7.0.tgz#774c043d8090a505e60fdf26f026d5f0cc968f0f"
-  integrity sha512-81BQO3QxSgF9PTXsVozNdNCKxBOB1lpbCWocV99dN1ws9s8uaYw8pmJJZ0LJKLiOsIECQ/3QrhQjmWTDW/qTug==
-  dependencies:
-    "@react-types/shared" "^3.16.0"
-
-"@react-types/checkbox@^3.2.1", "@react-types/checkbox@^3.2.3", "@react-types/checkbox@^3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@react-types/checkbox/-/checkbox-3.4.1.tgz#75a78b3f21f4cc72d2382761ba4c326aefd699db"
-  integrity sha512-kDMpy9SntjGQ7x00m5zmW8GENPouOtyiDgiEDKsPXUr2iYqHsNtricqVyG9S9+6hqpzuu8BzTcvZamc/xYjzlg==
-  dependencies:
-    "@react-types/shared" "^3.16.0"
-
-"@react-types/combobox@3.0.0-alpha.1":
-  version "3.0.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@react-types/combobox/-/combobox-3.0.0-alpha.1.tgz#4c390d11bc52c248fda92dc7e755f6dc2dc71b82"
-  integrity sha512-td8pZmzZx5L32DuJ5iQk0Y4DNPerHWc2NXjx88jiQGxtorzvfrIQRKh3sy13PH7AMplGSEdAxG0llfCKrIy0Ow==
-  dependencies:
-    "@react-types/shared" "^3.4.0"
-
-"@react-types/combobox@^3.5.5":
-  version "3.5.5"
-  resolved "https://registry.yarnpkg.com/@react-types/combobox/-/combobox-3.5.5.tgz#13410106fc2df8e3d02d53a33e9d2a6f3f2f6b61"
-  integrity sha512-gpDo/NTQFd5IfCZoNnG16N4/JfvwXpZBNc15Kn7bF+NcpSDhDpI26BZN4mvK4lljKCheD4VrEl9/3PtImCg7cA==
-  dependencies:
-    "@react-types/shared" "^3.16.0"
-
-"@react-types/grid@^3.1.5":
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/@react-types/grid/-/grid-3.1.5.tgz#b0efef48202b40aa05913f1fe5b05d80e7d26c15"
-  integrity sha512-KiEywsOJ+wdzLmJerAKEMADdvdItaLfhdo3bFfn1lgNUaKiNDJctDYWlhOYsRePf7MIrzoZuXEFnJj45jfpiOQ==
-  dependencies:
-    "@react-types/shared" "^3.16.0"
-
-"@react-types/label@^3.7.1":
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/@react-types/label/-/label-3.7.1.tgz#ad4d3d7a6b5ea6aca70f89661d7c358cf2ab5f94"
-  integrity sha512-wFpdtjSDBWO4xQQGF57V3PqvVVyE9TPj9ELWLs1yzL09fpXosycuEl5d79RywVlC9aF9dQYUfES09q/DZhRhMQ==
-  dependencies:
-    "@react-types/shared" "^3.16.0"
-
-"@react-types/listbox@^3.1.1", "@react-types/listbox@^3.3.5":
-  version "3.3.5"
-  resolved "https://registry.yarnpkg.com/@react-types/listbox/-/listbox-3.3.5.tgz#c2222e3f50fbf377ed20b2d16e761b9c09d7adc8"
-  integrity sha512-7SMRJWUi7ayzQ7SUPCXXwgI/Ua3vg0PPQOZFsmJ4/E8VG/xK82IV7BYSZiNjUQuGpVZJL0VPndt/RwIrQO4S3w==
-  dependencies:
-    "@react-types/shared" "^3.16.0"
-
-"@react-types/menu@^3.7.3":
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/@react-types/menu/-/menu-3.7.3.tgz#beb8d0fb7f1e50254e2e7661dfbfa4bb38826dad"
-  integrity sha512-3Pax24I/FyNKBjKyNR4ePD8eZs35Th57HzJAVjamQg2fHEDRomg9GQ7fdmfGj72Dv3x3JRCoPYqhJ3L5R3kbzg==
-  dependencies:
-    "@react-types/overlays" "^3.6.5"
-    "@react-types/shared" "^3.16.0"
-
-"@react-types/overlays@^3.4.0", "@react-types/overlays@^3.6.5":
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/@react-types/overlays/-/overlays-3.6.5.tgz#466b325d9be51f67beb98b7bec3fd9295c72efac"
-  integrity sha512-IeWcF+YTucCYYHagNh8fZLH6R4YUONO1VHY57WJyIHwMy0qgEaKSQCwq72VO1fQJ0ySZgOgm31FniOyKkg6+eQ==
-  dependencies:
-    "@react-types/shared" "^3.16.0"
-
-"@react-types/radio@^3.1.1", "@react-types/radio@^3.3.1":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@react-types/radio/-/radio-3.3.1.tgz#688570ba9901d21850a16c2aaafed5dd83e09966"
-  integrity sha512-q/x0kMvBsu6mH4bIkp/Jjrm9ff5y/p3UR0V4CmQFI7604gQd2Dt1dZMU/2HV9x70r1JfWRrDeRrVjUHVfFL5Vg==
-  dependencies:
-    "@react-types/shared" "^3.16.0"
-
-"@react-types/select@^3.6.5":
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/@react-types/select/-/select-3.6.5.tgz#798abf0073b39eef041952198a9e84eff0ce9edc"
-  integrity sha512-FDeSA7TYMNnhsbXREnD4dWRSu21T5M4BLy+J/5VgwDpr3IN9pzbvngK8a3jc8Yg2S3igKYLMLYfmcsx+yk7ohA==
-  dependencies:
-    "@react-types/shared" "^3.16.0"
-
-"@react-types/shared@^3.16.0", "@react-types/shared@^3.2.1", "@react-types/shared@^3.4.0":
-  version "3.16.0"
-  resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.16.0.tgz#cab7bf0376969d1773480ecb2d6da5aa91391db5"
-  integrity sha512-IQgU4oAEvMwylEvaTsr2XB1G/mAoMe1JFYLD6G78v++oAR9l8o9MQxZ0YSeANDkqTamb2gKezGoT1RxvSKjVxw==
-
-"@react-types/slider@^3.0.1", "@react-types/slider@^3.3.1":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@react-types/slider/-/slider-3.3.1.tgz#0e6a8d0767b1ab94f8c32541d50aaa6d93683df4"
-  integrity sha512-CbEa1v1IcUJD7VrFhWyOOlT7VyQ5DHEf/pNMkvICOBLMAwnWxS+tnTiRFgA/EbvV/vp24ydeszHYtMvsyRONRw==
-  dependencies:
-    "@react-types/shared" "^3.16.0"
-
-"@react-types/switch@^3.2.5":
-  version "3.2.5"
-  resolved "https://registry.yarnpkg.com/@react-types/switch/-/switch-3.2.5.tgz#e1db722e8beeed846cfcf9de94cad81b4e0ead78"
-  integrity sha512-DlUL0Bz79SUTRje/i8m6qn4Ipn+q8QnyIkyJhkoHeH1R0YNude8xZrBPWbj3zfdddAGDFSF1NzP69q0xmNAcTQ==
-  dependencies:
-    "@react-types/checkbox" "^3.4.1"
-    "@react-types/shared" "^3.16.0"
-
-"@react-types/table@^3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@react-types/table/-/table-3.4.0.tgz#64715f6c355b880467f67b1e5288e6c28d6092e8"
-  integrity sha512-G2L5WtaBMeG3v/5Kj/ZXH4ywz95vyPUBj7qy9UZJOYNaAR7uJWZkbe+Ka4xD4H/AaOk4mqW8dSo8cj7gtD66GQ==
-  dependencies:
-    "@react-types/grid" "^3.1.5"
-    "@react-types/shared" "^3.16.0"
-
-"@react-types/tabs@3.0.0-alpha.2":
-  version "3.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@react-types/tabs/-/tabs-3.0.0-alpha.2.tgz#f18c71f4843ae2117b41fdb012f89cc2dd43adf4"
-  integrity sha512-HQNS2plzuNhKPo88OGEW2Ja9aLeiWqgNqEemSxh0KAjkA8IsvDGaoQEpr9ZQIyBZ3PQIljvOpEJ/IwHU5LztrQ==
-  dependencies:
-    "@react-types/shared" "^3.2.1"
-
-"@react-types/textfield@^3.6.2":
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/@react-types/textfield/-/textfield-3.6.2.tgz#6cc87c2bac286a06ba04b9465d23fa9078bf280e"
-  integrity sha512-QhFcpXvmSEW1/PwkWkvHJkcjsVezLW0OAvA0kMt/FMOChQNxnO36Pha+WjfcVbiFHXMhCBl6akbY2xG9NsHJrQ==
-  dependencies:
-    "@react-types/shared" "^3.16.0"
-
 "@repeaterjs/repeater@3.0.4":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@repeaterjs/repeater/-/repeater-3.0.4.tgz#a04d63f4d1bf5540a41b01a921c9a7fddc3bd1ca"
@@ -4160,13 +3316,6 @@
   integrity sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
-
-"@swc/helpers@^0.4.14":
-  version "0.4.14"
-  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.4.14.tgz#1352ac6d95e3617ccb7c1498ff019654f1e12a74"
-  integrity sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==
-  dependencies:
-    tslib "^2.4.0"
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
@@ -5755,11 +4904,6 @@ clone@^2.1.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
   integrity sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==
 
-clsx@^1.1.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
-  integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
-
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -6128,13 +5272,6 @@ css-color-keywords@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
   integrity sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==
-
-css-in-js-utils@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-3.1.0.tgz#640ae6a33646d401fc720c54fc61c42cd76ae2bb"
-  integrity sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==
-  dependencies:
-    hyphenate-style-name "^1.0.3"
 
 css-select@^5.1.0:
   version "5.1.0"
@@ -6733,14 +5870,6 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
-
-dom-helpers@^5.0.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
-  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
-  dependencies:
-    "@babel/runtime" "^7.8.7"
-    csstype "^3.0.2"
 
 dom-serializer@^1.0.1:
   version "1.4.1"
@@ -7583,11 +6712,6 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
-
-fast-loops@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/fast-loops/-/fast-loops-1.1.3.tgz#ce96adb86d07e7bf9b4822ab9c6fac9964981f75"
-  integrity sha512-8EZzEP0eKkEEVX+drtd9mtuQ+/QrlfW/5MlwcwK5Nds6EkZ/tRzEexkzUY2mIssnAyVLT+TKHuRXmFNNXYUd6g==
 
 fast-safe-stringify@^2.0.7:
   version "2.1.1"
@@ -8529,11 +7653,6 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
-hyphenate-style-name@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz#691879af8e220aea5750e8827db4ef62a54e361d"
-  integrity sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==
-
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -8647,14 +7766,6 @@ ini@~1.3.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
-inline-style-prefixer@^6.0.1:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-6.0.4.tgz#4290ed453ab0e4441583284ad86e41ad88384f44"
-  integrity sha512-FwXmZC2zbeeS7NzGjJ6pAiqRhXR0ugUShSNb6GApMl6da0/XGc4MOJsoWAywia52EEWbXNSy0pzkwz/+Y+swSg==
-  dependencies:
-    css-in-js-utils "^3.1.0"
-    fast-loops "^1.1.3"
-
 inquirer@7.3.3:
   version "7.3.3"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.3.3.tgz#04d176b2af04afc157a83fd7c100e98ee0aad003"
@@ -8735,16 +7846,6 @@ internal-slot@^1.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/internmap/-/internmap-2.0.3.tgz#6685f23755e43c524e251d29cbc97248e3061009"
   integrity sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==
-
-intl-messageformat@^10.1.0:
-  version "10.2.5"
-  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-10.2.5.tgz#a51e6e2700d82b5b7ccd7a9f3bd45d967d95afc0"
-  integrity sha512-AievYMN6WLLHwBeCTv4aRKG+w3ZNyZtkObwgsKk3Q7GNTq8zDRvDbJSBQkb2OPeVCcAKcIXvak9FF/bRNavoww==
-  dependencies:
-    "@formatjs/ecma402-abstract" "1.14.3"
-    "@formatjs/fast-memoize" "1.2.7"
-    "@formatjs/icu-messageformat-parser" "2.1.14"
-    tslib "^2.4.0"
 
 invariant@^2.2.4:
   version "2.2.4"
@@ -10263,16 +9364,6 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
 
-lodash.get@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-  integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
-
-lodash.has@^4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/lodash.has/-/lodash.has-4.5.2.tgz#d19f4dc1095058cccbe2b0cdf4ee0fe4aa37c862"
-  integrity sha512-rnYUdIo6xRCJnQmbVFEwcxF144erlD+M3YcJUVesflU9paQaE8p+fJDcIQrlMYbxoANFL+AB9hZrzSBBk5PL+g==
-
 lodash.includes@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
@@ -10283,11 +9374,6 @@ lodash.isboolean@^3.0.3:
   resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
   integrity sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==
 
-lodash.isempty@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
-  integrity sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg==
-
 lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
@@ -10297,11 +9383,6 @@ lodash.isinteger@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
   integrity sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==
-
-lodash.isnil@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/lodash.isnil/-/lodash.isnil-4.0.0.tgz#49e28cd559013458c814c5479d3c663a21bfaa6c"
-  integrity sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==
 
 lodash.isnumber@^3.0.3:
   version "3.0.3"
@@ -10328,35 +9409,15 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash.mergewith@^4.6.2:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
-  integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
-
 lodash.minby@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.minby/-/lodash.minby-4.6.0.tgz#8b105765ae973954ae944a8029999b8080bdf8c4"
   integrity sha512-/BQsNmceLCn6priGkiihvV5w/G9da7tqI6Wb4rS+PeaZcsFOv4PjNRs9/3ZQPY1sqpfhRtJQkAYLiaohlTUt0g==
 
-lodash.omit@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
-  integrity sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==
-
-lodash.omitby@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.omitby/-/lodash.omitby-4.6.0.tgz#5c15ff4754ad555016b53c041311e8f079204791"
-  integrity sha512-5OrRcIVR75M288p4nbI2WLAf3ndw2GD9fyNv3Bc15+WCxJDdZ4lYndSxGd7hnG6PVjiJTeJE2dHEGhIuKGicIQ==
-
 lodash.once@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
-
-lodash.pick@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
-  integrity sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q==
 
 lodash.throttle@^4.1.1:
   version "4.1.1"
@@ -11103,46 +10164,6 @@ nanomatch@^1.2.9:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
-
-native-base@^3.4.25:
-  version "3.4.25"
-  resolved "https://registry.yarnpkg.com/native-base/-/native-base-3.4.25.tgz#0b5871855be4c48ef72768e50db002d6a0e1ad23"
-  integrity sha512-MOeqNji6eAXge9uWsKgfyna8kakdoQuynxoDlVgzTrXXT0o/UrmIUAz+xNPM7rjYHd0MM+UdohPilV1/Z5pB9Q==
-  dependencies:
-    "@react-aria/visually-hidden" "^3.2.1"
-    "@react-native-aria/button" "^0.2.4"
-    "@react-native-aria/checkbox" "^0.2.2"
-    "@react-native-aria/combobox" "^0.2.4-alpha.0"
-    "@react-native-aria/focus" "^0.2.6"
-    "@react-native-aria/interactions" "^0.2.2"
-    "@react-native-aria/listbox" "^0.2.4-alpha.3"
-    "@react-native-aria/overlays" "0.3.3-rc.0"
-    "@react-native-aria/radio" "^0.2.4"
-    "@react-native-aria/slider" "^0.2.5-alpha.1"
-    "@react-native-aria/tabs" "^0.2.7"
-    "@react-native-aria/utils" "^0.2.8"
-    "@react-stately/checkbox" "3.0.3"
-    "@react-stately/collections" "3.3.0"
-    "@react-stately/combobox" "3.0.0-alpha.1"
-    "@react-stately/radio" "3.2.1"
-    "@react-stately/slider" "3.0.1"
-    "@react-stately/tabs" "3.0.0-alpha.1"
-    "@react-stately/toggle" "3.2.1"
-    inline-style-prefixer "^6.0.1"
-    lodash.clonedeep "^4.5.0"
-    lodash.get "^4.4.2"
-    lodash.has "^4.5.2"
-    lodash.isempty "^4.4.0"
-    lodash.isequal "^4.5.0"
-    lodash.isnil "^4.0.0"
-    lodash.merge "^4.6.2"
-    lodash.mergewith "^4.6.2"
-    lodash.omit "^4.5.0"
-    lodash.omitby "^4.6.0"
-    lodash.pick "^4.4.0"
-    stable-hash "^0.0.2"
-    tinycolor2 "^1.4.2"
-    use-subscription "^1.8.0"
 
 natural-compare-lite@^1.4.0:
   version "1.4.0"
@@ -13405,11 +12426,6 @@ ssri@^8.0.1:
   dependencies:
     minipass "^3.1.1"
 
-stable-hash@^0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/stable-hash/-/stable-hash-0.0.2.tgz#a909deaa5b9d430b100ca0a10132a533f2665e94"
-  integrity sha512-tPwQ3c1rLIwbJpq59duoznegEbmgfV630C2n4R4G96LKBFljgK8j+O9AxjqB6cAzu4gE7s4pByrLWtZel8E+Mg==
-
 stack-utils@^2.0.2, stack-utils@^2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.6.tgz#aaf0748169c02fc33c8232abccf933f54a1cc34f"
@@ -13865,11 +12881,6 @@ through@2, through@^2.3.6, through@^2.3.8:
   integrity sha512-pJ70wq5EAqTAEl9IkGzA+fN0836rycEuz2Cn6yeZ6FRzlVS5IDOkFHpIoEsksPRQV34GDqXm65+OlnZqUSyK2g==
   dependencies:
     esm "^3.2.25"
-
-tinycolor2@^1.4.2:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.5.1.tgz#df11c5f14e6b7fdd8a9c27c2c6a5f2565fb776b7"
-  integrity sha512-BHlrsGeYN2OpkRpfAgkEwCMu6w8Quq8JkK/mp4c55NZP7OwceJObR1CPZt62TqiA0Y3J5pwuDX+fXDqc35REtg==
 
 tinyqueue@^2.0.3:
   version "2.0.3"
@@ -14400,14 +13411,7 @@ use-latest-callback@^0.1.5:
   resolved "https://registry.yarnpkg.com/use-latest-callback/-/use-latest-callback-0.1.5.tgz#a4a836c08fa72f6608730b5b8f4bbd9c57c04f51"
   integrity sha512-HtHatS2U4/h32NlkhupDsPlrbiD27gSH5swBdtXbCAlc6pfOFzaj0FehW/FO12rx8j2Vy4/lJScCiJyM01E+bQ==
 
-use-subscription@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.8.0.tgz#f118938c29d263c2bce12fc5585d3fe694d4dbce"
-  integrity sha512-LISuG0/TmmoDoCRmV5XAqYkd3UCBNM0ML3gGBndze65WITcsExCD3DTvXXTLyNcOC0heFQZzluW88bN/oC1DQQ==
-  dependencies:
-    use-sync-external-store "^1.2.0"
-
-use-sync-external-store@^1.0.0, use-sync-external-store@^1.2.0:
+use-sync-external-store@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
   integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==


### PR DESCRIPTION
Builds on #72 and does the following to get Android happier:

- add implementations of useful NativeBase components:
  - VStack/HStack
  - Center
  - Divider
- replace use of Alert
- memoize core components
- fix for forecast cards not receiving touches on Android

Android build is still not zippy yet, but it is much better.