### PR TITLE
move avy problem icons, adjust sizing of problem cards

### DIFF
--- a/components/AvalancheProblemCard.tsx
+++ b/components/AvalancheProblemCard.tsx
@@ -7,7 +7,7 @@ import {AvalancheProblemLikelihoodLine} from './AvalancheProblemLikelihoodLine';
 import {AvalancheProblemSizeLine} from './AvalancheProblemSizeLine';
 import {HTML} from 'components/text/HTML';
 import {Center, HStack, VStack} from 'components/core';
-import {AllCapsSm, Caption1Semibold} from 'components/text';
+import {AllCapsSm, allCapsSmLineHeight, Caption1Semibold} from 'components/text';
 import {Card, CardProps} from 'components/content/Card';
 import {colorLookup} from 'theme';
 import {Carousel} from 'components/content/carousel';
@@ -17,13 +17,23 @@ export interface AvalancheProblemCardProps {
   names: ElevationBandNames;
 }
 
-const AspectCard: React.FC<CardProps> = ({...props}) => <Card flex={1} flexBasis={'35%'} flexGrow={1} borderColor={colorLookup('light.200')} borderRadius={8} mb={8} {...props} />;
+interface AspectCardProps extends Omit<CardProps, 'children'> {
+  caption: string;
+}
+const AspectCard: React.FC<AspectCardProps> = ({caption, ...props}) => (
+  <Card flex={1} flexBasis={'35%'} flexGrow={1} borderColor={colorLookup('light.200')} borderRadius={8} mb={8} {...props}>
+    {/* Always force the caption to take the space of two lines - this makes things line up on narrow screens,
+        where "Aspect/Elevation" doesn't fit on a single line */}
+    <Center height={2 * allCapsSmLineHeight}>
+      <AllCapsSm textAlign="center">{caption}</AllCapsSm>
+    </Center>
+  </Card>
+);
 
 export const AvalancheProblemCard: React.FunctionComponent<AvalancheProblemCardProps> = ({problem, names}: AvalancheProblemCardProps) => {
   const [cardWidth, setCardWidth] = useState<number | null>(null);
   return (
     <VStack space={8} onLayout={event => setCardWidth(event.nativeEvent.layout.width)}>
-      <HTML source={{html: problem.discussion}} />
       <HStack flexWrap="wrap" justifyContent="space-evenly" alignItems="stretch">
         <AspectCard
           mr={16}
@@ -33,36 +43,37 @@ export const AvalancheProblemCard: React.FunctionComponent<AvalancheProblemCardP
               <AvalancheProblemIcon problem={problem.avalanche_problem_id} />
               <Caption1Semibold textAlign="center">{problem.name}</Caption1Semibold>
             </VStack>
-          }>
-          <AllCapsSm textAlign="center">Problem Type</AllCapsSm>
-        </AspectCard>
+          }
+          caption="Problem Type"
+        />
         <AspectCard
           header={
             // The height is repeated here so that the first two items have the same height
             <Center style={{height: 150}}>
               <AnnotatedDangerRose rose={{style: {}, locations: problem.location}} elevationBandNames={names} />
             </Center>
-          }>
-          <AllCapsSm textAlign="center">Aspect/Elevation</AllCapsSm>
-        </AspectCard>
+          }
+          caption="Aspect/Elevation"
+        />
         <AspectCard
           mr={16}
           header={
             <Center>
               <AvalancheProblemLikelihoodLine likelihood={problem.likelihood} />
             </Center>
-          }>
-          <AllCapsSm textAlign="center">Likelihood</AllCapsSm>
-        </AspectCard>
+          }
+          caption="Likelihood"
+        />
         <AspectCard
           header={
             <Center>
               <AvalancheProblemSizeLine size={problem.size} />
             </Center>
-          }>
-          <AllCapsSm textAlign="center">Size</AllCapsSm>
-        </AspectCard>
+          }
+          caption="Size"
+        />
       </HStack>
+      <HTML source={{html: problem.discussion}} />
       {problem.media.type === MediaType.Image && problem.media.url !== null && cardWidth > 0 && (
         <Carousel media={[problem.media]} thumbnailAspectRatio={1.3} thumbnailHeight={cardWidth / 1.3} />
       )}

--- a/components/text/index.tsx
+++ b/components/text/index.tsx
@@ -64,8 +64,9 @@ export const BodyXSm: React.FunctionComponent<TextWrapperProps> = props => (
 export const BodyXSmMedium: React.FunctionComponent<TextWrapperProps> = props => <BodyXSm fontFamily="Lato_400Regular" {...props} />;
 export const BodyXSmBlack: React.FunctionComponent<TextWrapperProps> = props => <BodyXSm fontFamily="Lato_900Black" {...props} />;
 
+export const allCapsSmLineHeight = 18;
 export const AllCapsSm: React.FunctionComponent<TextWrapperProps> = props => (
-  <TextWrapper fontSize={13} lineHeight={18} fontFamily="Lato_400Regular" letterSpacing={-0.08} {...merge({style: {textTransform: 'uppercase'}}, props)} />
+  <TextWrapper fontSize={13} lineHeight={allCapsSmLineHeight} fontFamily="Lato_400Regular" letterSpacing={-0.08} {...merge({style: {textTransform: 'uppercase'}}, props)} />
 );
 export const AllCapsSmBlack: React.FunctionComponent<TextWrapperProps> = props => <AllCapsSm fontFamily="Lato_900Black" {...props} />;
 


### PR DESCRIPTION
1) per @charlotteguard 's request, move the icons back to the top of the avalanche problem discussion
2) noticed that "Aspect/Elevation" wraps to two lines on my Android device; made the 2 line space consistent so that card elements line up visually (see screenshot)

![Screenshot_20230120-074751_Expo Go](https://user-images.githubusercontent.com/101196/213743707-e1206fed-fdd1-467d-bb94-3bc95f50ef40.jpg)
