### PR TITLE
Add new header to forecast screen with dropdown and home button

### DIFF
--- a/components/content/Dropdown.tsx
+++ b/components/content/Dropdown.tsx
@@ -31,7 +31,6 @@ export const Dropdown: React.FC<DropdownProps> = ({items, selectedItem, onSelect
         <TouchableOpacity
           onPress={() => {
             setDropdownVisible(!dropdownVisible);
-            console.log('press');
           }}>
           <HStack justifyContent="space-between" alignItems="center">
             <Body>{selectedItem}</Body>

--- a/components/content/Dropdown.tsx
+++ b/components/content/Dropdown.tsx
@@ -1,0 +1,77 @@
+import {HStack, View, ViewProps, VStack} from 'components/core';
+import React, {useState} from 'react';
+import {LayoutChangeEvent, LayoutRectangle, Modal, StyleSheet, TouchableOpacity, TouchableWithoutFeedback} from 'react-native';
+import {Body, bodySize} from 'components/text';
+import {colorLookup} from 'theme';
+import tinycolor from 'tinycolor2';
+import {AntDesign} from '@expo/vector-icons';
+
+export interface DropdownProps extends ViewProps {
+  items: string[];
+  selectedItem: string;
+  onSelectionChange?: (item: string) => void;
+}
+
+const borderColor = 'rgba(0, 0, 0, 0.15)';
+
+export const Dropdown: React.FC<DropdownProps> = ({items, selectedItem, onSelectionChange, ...props}) => {
+  const [dropdownVisible, setDropdownVisible] = useState<boolean>(false);
+  const [layout, setLayout] = useState<LayoutRectangle>({x: 0, y: 0, width: 0, height: 0});
+
+  const onLayout = (event: LayoutChangeEvent) => {
+    // onLayout returns position relative to parent - we need position relative to screen
+    event.currentTarget.measureInWindow((x, y, width, height) => {
+      setLayout({x, y, width, height});
+    });
+  };
+
+  return (
+    <>
+      <View borderColor={borderColor} borderWidth={2} borderRadius={4} p={8} flexDirection="column" justifyContent="center" onLayout={onLayout} {...props}>
+        <TouchableOpacity
+          onPress={() => {
+            setDropdownVisible(!dropdownVisible);
+            console.log('press');
+          }}>
+          <HStack justifyContent="space-between" alignItems="center">
+            <Body>{selectedItem}</Body>
+            <AntDesign name={dropdownVisible ? 'up' : 'down'} size={bodySize} color={colorLookup('darkText')} />
+          </HStack>
+        </TouchableOpacity>
+      </View>
+      <Modal visible={dropdownVisible} transparent animationType="fade">
+        <TouchableWithoutFeedback onPress={() => setDropdownVisible(false)}>
+          <View style={{...StyleSheet.absoluteFillObject}}>
+            <VStack
+              bg="white"
+              position="absolute"
+              top={layout.y + layout.height}
+              left={layout.x}
+              width={layout.width}
+              pb={2}
+              borderColor={borderColor}
+              borderWidth={2}
+              borderTopWidth={0}
+              borderBottomLeftRadius={4}
+              borderBottomRightRadius={4}>
+              {items.sort().map((item, index) => (
+                <TouchableOpacity
+                  key={item}
+                  onPress={() => {
+                    setDropdownVisible(false);
+                    onSelectionChange?.(item);
+                  }}>
+                  <View px={8} key={item} bg={item === selectedItem ? tinycolor(colorLookup('color-primary')).setAlpha(0.1).toRgbString() : undefined}>
+                    <View py={8} borderTopWidth={index > 0 ? 2 : 0} borderColor={borderColor}>
+                      <Body key={item}>{item}</Body>
+                    </View>
+                  </View>
+                </TouchableOpacity>
+              ))}
+            </VStack>
+          </View>
+        </TouchableWithoutFeedback>
+      </Modal>
+    </>
+  );
+};

--- a/components/screens/ForecastScreen.tsx
+++ b/components/screens/ForecastScreen.tsx
@@ -6,19 +6,16 @@ import {NativeStackScreenProps} from '@react-navigation/native-stack';
 
 import {AvalancheForecast} from 'components/forecast/AvalancheForecast';
 import {HomeStackParamList} from 'routes';
+import {View} from 'components/core';
 
 export const ForecastScreen = ({route}: NativeStackScreenProps<HomeStackParamList, 'forecast'>) => {
   const {center_id, forecast_zone_id, dateString, zoneName} = route.params;
   return (
-    <SafeAreaView style={styles.container}>
-      <AvalancheForecast center_id={center_id} forecast_zone_id={forecast_zone_id} date={new Date(dateString)} zoneName={zoneName} />
+    // hat tip to https://github.com/react-navigation/react-navigation/issues/8694 for the use of `edges`
+    <SafeAreaView style={StyleSheet.absoluteFillObject} edges={['top', 'left', 'right']}>
+      <View width="100%" height="100%">
+        <AvalancheForecast center_id={center_id} forecast_zone_id={forecast_zone_id} date={new Date(dateString)} zoneName={zoneName} />
+      </View>
     </SafeAreaView>
   );
 };
-
-const styles = StyleSheet.create({
-  container: {
-    ...StyleSheet.absoluteFillObject,
-    flex: 1,
-  },
-});

--- a/components/screens/HomeScreen.tsx
+++ b/components/screens/HomeScreen.tsx
@@ -10,12 +10,7 @@ export const HomeTabScreen = ({route}: NativeStackScreenProps<TabNavigatorParamL
   return (
     <AvalancheCenterStack.Navigator initialRouteName="avalancheCenter">
       <AvalancheCenterStack.Screen name="avalancheCenter" component={MapScreen} initialParams={{center_id: center_id, dateString}} options={() => ({headerShown: false})} />
-      <AvalancheCenterStack.Screen
-        name="forecast"
-        component={ForecastScreen}
-        initialParams={{center_id: center_id, dateString}}
-        options={({route}) => ({title: String(route.params.zoneName)})}
-      />
+      <AvalancheCenterStack.Screen name="forecast" component={ForecastScreen} initialParams={{center_id: center_id, dateString}} options={() => ({headerShown: false})} />
     </AvalancheCenterStack.Navigator>
   );
 };


### PR DESCRIPTION
Implements the new forecast header as defined in [Figma](https://www.figma.com/file/Bai2w7x0vUakL5WRjPGRg7/App---V3?node-id=97%3A89887&t=1cwZ9viaFawVGBng-0)

1) Add the active zones to a dropdown
2) Add an icon for navigating back to the map

https://user-images.githubusercontent.com/101196/214113696-ce9e04d7-217c-4206-b70d-ed84e075a620.mov

