### PR TITLE
hooks: use a broader range for fetching forecasts

### DIFF
--- a/hooks/useAvalancheForecastFragments.ts
+++ b/hooks/useAvalancheForecastFragments.ts
@@ -43,8 +43,8 @@ const fetchAvalancheForecastFragments = async (nationalAvalancheCenterHost: stri
   const {data} = await axios.get(url, {
     params: {
       avalanche_center_id: center_id,
-      date_start: apiDateString(sub(date, {days: 1})),
-      date_end: apiDateString(add(date, {days: 1})),
+      date_start: apiDateString(sub(date, {days: 2})),
+      date_end: apiDateString(add(date, {days: 2})),
     },
   });
 


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Fixes #91 
