### PR TITLE
hooks: include host in all query keys

### DIFF
--- a/hooks/useAvalancheCenterMetadata.ts
+++ b/hooks/useAvalancheCenterMetadata.ts
@@ -22,7 +22,7 @@ export const useAvalancheCenterMetadata = (center_id: AvalancheCenterID) => {
 };
 
 function queryKey(nationalAvalancheCenterHost: string, center_id: string) {
-  return ['host', nationalAvalancheCenterHost, 'avalanche-center', center_id];
+  return ['center-metadata', 'host', nationalAvalancheCenterHost, 'avalanche-center', center_id];
 }
 
 export const prefetchAvalancheCenterMetadata = async (queryClient: QueryClient, nationalAvalancheCenterHost: string, center_id: AvalancheCenterID) => {

--- a/hooks/useAvalancheCenterMetadata.ts
+++ b/hooks/useAvalancheCenterMetadata.ts
@@ -14,20 +14,20 @@ import {ZodError} from 'zod';
 export const useAvalancheCenterMetadata = (center_id: AvalancheCenterID) => {
   const {nationalAvalancheCenterHost} = React.useContext<ClientProps>(ClientContext);
   return useQuery<AvalancheCenter, AxiosError | ZodError>({
-    queryKey: queryKey(center_id),
+    queryKey: queryKey(nationalAvalancheCenterHost, center_id),
     queryFn: async () => fetchAvalancheCenterMetadata(nationalAvalancheCenterHost, center_id),
     staleTime: 24 * 60 * 60 * 1000, // don't bother re-fetching for one day (in milliseconds)
     cacheTime: Infinity, // hold on to this cached data forever
   });
 };
 
-function queryKey(center_id: string) {
-  return ['avalanche-center', center_id];
+function queryKey(nationalAvalancheCenterHost: string, center_id: string) {
+  return ['host', nationalAvalancheCenterHost, 'avalanche-center', center_id];
 }
 
 export const prefetchAvalancheCenterMetadata = async (queryClient: QueryClient, nationalAvalancheCenterHost: string, center_id: AvalancheCenterID) => {
   await queryClient.prefetchQuery({
-    queryKey: queryKey(center_id),
+    queryKey: queryKey(nationalAvalancheCenterHost, center_id),
     queryFn: async () => {
       Log.prefetch('starting metadata prefetch');
       const result = await fetchAvalancheCenterMetadata(nationalAvalancheCenterHost, center_id);

--- a/hooks/useAvalancheForecast.ts
+++ b/hooks/useAvalancheForecast.ts
@@ -27,7 +27,7 @@ export const useAvalancheForecast = (center_id: AvalancheCenterID, forecast_zone
 };
 
 function queryKey(nationalAvalancheCenterHost: string, forecastId: number) {
-  return ['host', nationalAvalancheCenterHost, 'product', forecastId];
+  return ['avalanche-forecast', 'host', nationalAvalancheCenterHost, 'product', forecastId];
 }
 
 export const prefetchAvalancheForecast = async (queryClient: QueryClient, nationalAvalancheCenterHost: string, forecastId: number) => {

--- a/hooks/useAvalancheForecastFragments.ts
+++ b/hooks/useAvalancheForecastFragments.ts
@@ -16,18 +16,18 @@ import {apiDateString} from 'utils/date';
 export const useAvalancheForecastFragments = (center_id: AvalancheCenterID, date: Date) => {
   const {nationalAvalancheCenterHost} = React.useContext<ClientProps>(ClientContext);
   return useQuery<Product[] | undefined, AxiosError | ZodError>({
-    queryKey: queryKey(center_id, date),
+    queryKey: queryKey(nationalAvalancheCenterHost, center_id, date),
     queryFn: async () => fetchAvalancheForecastFragments(nationalAvalancheCenterHost, center_id, date),
   });
 };
 
-function queryKey(center_id: string, date: Date) {
-  return ['products', center_id, apiDateString(date)];
+function queryKey(nationalAvalancheCenterHost: string, center_id: string, date: Date) {
+  return ['host', nationalAvalancheCenterHost, 'products', center_id, apiDateString(date)];
 }
 
 const prefetchAvalancheForecastFragments = async (queryClient: QueryClient, nationalAvalancheCenterHost: string, center_id: string, date: Date) => {
   await queryClient.prefetchQuery({
-    queryKey: queryKey(center_id, date),
+    queryKey: queryKey(nationalAvalancheCenterHost, center_id, date),
     queryFn: async () => {
       Log.prefetch('starting fragment prefetch');
       const result = await fetchAvalancheForecastFragments(nationalAvalancheCenterHost, center_id, date);

--- a/hooks/useAvalancheForecastFragments.ts
+++ b/hooks/useAvalancheForecastFragments.ts
@@ -22,7 +22,7 @@ export const useAvalancheForecastFragments = (center_id: AvalancheCenterID, date
 };
 
 function queryKey(nationalAvalancheCenterHost: string, center_id: string, date: Date) {
-  return ['host', nationalAvalancheCenterHost, 'products', center_id, apiDateString(date)];
+  return ['forecast-fragments', 'host', nationalAvalancheCenterHost, 'products', center_id, apiDateString(date)];
 }
 
 const prefetchAvalancheForecastFragments = async (queryClient: QueryClient, nationalAvalancheCenterHost: string, center_id: string, date: Date) => {

--- a/hooks/useMapLayer.ts
+++ b/hooks/useMapLayer.ts
@@ -1,40 +1,65 @@
 import React from 'react';
 
 import axios, {AxiosError} from 'axios';
-import {useQuery} from 'react-query';
+import {QueryClient, useQuery} from 'react-query';
 
 import * as Sentry from 'sentry-expo';
+
+import Log from 'network/log';
 
 import {ClientContext, ClientProps} from 'clientContext';
 import {AvalancheCenterID, MapLayer, mapLayerSchema} from 'types/nationalAvalancheCenter';
 import {ZodError} from 'zod';
 
 export const useMapLayer = (center_id: AvalancheCenterID) => {
-  const clientProps = React.useContext<ClientProps>(ClientContext);
-  return useQuery<MapLayer, AxiosError | ZodError>(
-    ['map-layer', center_id],
-    async () => {
-      const url = `${clientProps.nationalAvalancheCenterHost}/v2/public/products/map-layer/${center_id}`;
-      const {data} = await axios.get(url);
+  const {nationalAvalancheCenterHost} = React.useContext<ClientProps>(ClientContext);
+  return useQuery<MapLayer, AxiosError | ZodError>({
+    queryKey: queryKey(nationalAvalancheCenterHost, center_id),
+    queryFn: async () => fetchMapLayer(nationalAvalancheCenterHost, center_id),
+    staleTime: 24 * 60 * 60 * 1000, // don't bother re-fetching for one day (in milliseconds)
+    cacheTime: Infinity, // hold on to this cached data forever
+  });
+};
 
-      const parseResult = mapLayerSchema.safeParse(data);
-      if (parseResult.success === false) {
-        console.warn('unparsable map layer', url, parseResult.error, JSON.stringify(data, null, 2));
-        Sentry.Native.captureException(parseResult.error, {
-          tags: {
-            zod_error: true,
-            center_id,
-          },
-        });
-        throw parseResult.error;
-      } else {
-        return parseResult.data;
-      }
+function queryKey(nationalAvalancheCenterHost: string, center_id: string) {
+  return ['host', nationalAvalancheCenterHost, 'avalanche-center', center_id];
+}
+
+export const prefetchMapLayer = async (queryClient: QueryClient, nationalAvalancheCenterHost: string, center_id: AvalancheCenterID) => {
+  await queryClient.prefetchQuery({
+    queryKey: queryKey(nationalAvalancheCenterHost, center_id),
+    queryFn: async () => {
+      Log.prefetch('starting map layer prefetch');
+      const result = await fetchMapLayer(nationalAvalancheCenterHost, center_id);
+      Log.prefetch('map layer request finished');
+      return result;
     },
-    {
-      enabled: !!center_id,
-      staleTime: 24 * 60 * 60 * 1000, // don't bother re-fetching for one day (in milliseconds)
-      cacheTime: Infinity, // hold on to this cached data forever
-    },
-  );
+  });
+  Log.prefetch('avalanche center map layer is cached with react-query');
+};
+
+export const fetchMapLayer = async (nationalAvalancheCenterHost: string, center_id: AvalancheCenterID) => {
+  const url = `${nationalAvalancheCenterHost}/v2/public/products/map-layer/${center_id}`;
+  const {data} = await axios.get(url);
+
+  const parseResult = mapLayerSchema.safeParse(data);
+  if (parseResult.success === false) {
+    console.warn(`unparsable map layer for avalanche center ${center_id}`, url, parseResult.error, JSON.stringify(data, null, 2));
+    Sentry.Native.captureException(parseResult.error, {
+      tags: {
+        zod_error: true,
+        center_id,
+        url,
+      },
+    });
+    throw parseResult.error;
+  } else {
+    return parseResult.data;
+  }
+};
+
+export default {
+  queryKey,
+  fetch: fetchMapLayer,
+  prefetch: prefetchMapLayer,
 };

--- a/hooks/useMapLayer.ts
+++ b/hooks/useMapLayer.ts
@@ -22,7 +22,7 @@ export const useMapLayer = (center_id: AvalancheCenterID) => {
 };
 
 function queryKey(nationalAvalancheCenterHost: string, center_id: string) {
-  return ['host', nationalAvalancheCenterHost, 'avalanche-center', center_id];
+  return ['map-layer', 'host', nationalAvalancheCenterHost, 'avalanche-center', center_id];
 }
 
 export const prefetchMapLayer = async (queryClient: QueryClient, nationalAvalancheCenterHost: string, center_id: AvalancheCenterID) => {

--- a/network/prefetchAllActiveForecasts.ts
+++ b/network/prefetchAllActiveForecasts.ts
@@ -5,6 +5,7 @@ import {QueryClient} from 'react-query';
 import Log from 'network/log';
 
 import {AvalancheCenterID, MediaType, Product} from 'types/nationalAvalancheCenter';
+import AvalancheCenterMapLayerQuery from 'hooks/useMapLayer';
 import AvalancheCenterMetadataQuery from 'hooks/useAvalancheCenterMetadata';
 import ForecastFragmentsQuery from 'hooks/useAvalancheForecastFragments';
 import ForecastQuery from 'hooks/useAvalancheForecast';
@@ -13,6 +14,7 @@ import ForecastQuery from 'hooks/useAvalancheForecast';
 // Note: you can enable preload logging by setting ENABLE_PREFETCH_LOGGING in network/log
 //
 export const prefetchAllActiveForecasts = async (queryClient: QueryClient, center_id: AvalancheCenterID, prefetchDate: Date, nationalAvalancheCenterHost: string) => {
+  await AvalancheCenterMapLayerQuery.prefetch(queryClient, nationalAvalancheCenterHost, center_id);
   await AvalancheCenterMetadataQuery.prefetch(queryClient, nationalAvalancheCenterHost, center_id);
   await ForecastFragmentsQuery.prefetch(queryClient, nationalAvalancheCenterHost, center_id, prefetchDate);
 

--- a/network/prefetchAllActiveForecasts.ts
+++ b/network/prefetchAllActiveForecasts.ts
@@ -16,7 +16,7 @@ export const prefetchAllActiveForecasts = async (queryClient: QueryClient, cente
   await AvalancheCenterMetadataQuery.prefetch(queryClient, nationalAvalancheCenterHost, center_id);
   await ForecastFragmentsQuery.prefetch(queryClient, nationalAvalancheCenterHost, center_id, prefetchDate);
 
-  const fragments = queryClient.getQueryData<Product[] | undefined>(ForecastFragmentsQuery.queryKey(center_id, prefetchDate));
+  const fragments = queryClient.getQueryData<Product[] | undefined>(ForecastFragmentsQuery.queryKey(nationalAvalancheCenterHost, center_id, prefetchDate));
   fragments?.forEach(async f => {
     await ForecastQuery.prefetch(queryClient, nationalAvalancheCenterHost, f.id);
     const forecastData = queryClient.getQueryData<Product>(ForecastQuery.queryKey(nationalAvalancheCenterHost, f.id));


### PR DESCRIPTION
Now that we support asking the staging or production API for this data, we need to include the host in our query keys so that our caches are separate.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>