### PR TITLE
*: fetch forecasts using the latest product API

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -36,7 +36,7 @@ import {TelemetryTabScreen} from 'components/screens/TelemetryScreen';
 import {AvalancheCenterID} from './types/nationalAvalancheCenter';
 import {prefetchAllActiveForecasts} from './network/prefetchAllActiveForecasts';
 import {HTMLRendererConfig} from 'components/text/HTML';
-import {apiDateString} from 'utils/date';
+import {formatInTimeZone} from 'date-fns-tz';
 
 // The SplashScreen stays up until we've loaded all of our fonts and other assets
 SplashScreen.preventAutoHideAsync();
@@ -110,7 +110,7 @@ const BaseApp: React.FunctionComponent<{
 }> = ({staging, setStaging}) => {
   const [avalancheCenterId, setAvalancheCenterId] = React.useState(Constants.expoConfig.extra.avalanche_center as AvalancheCenterID);
   const [date] = React.useState<Date>(defaultDate);
-  const dateString = apiDateString(date);
+  const dateString = formatInTimeZone(date, 'UTC', 'yyyy-MM-dd HH:mm:ssXXX');
 
   const {nationalAvalancheCenterHost} = React.useContext<ClientProps>(ClientContext);
   const queryClient = useQueryClient();

--- a/App.tsx
+++ b/App.tsx
@@ -1,7 +1,7 @@
 import React, {useCallback, useEffect} from 'react';
 
 import {AppStateStatus, Platform, StyleSheet, View} from 'react-native';
-import {NavigationContainer} from '@react-navigation/native';
+import {NavigationContainer, ParamListBase, RouteProp} from '@react-navigation/native';
 import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
 import {SafeAreaProvider} from 'react-native-safe-area-context';
 import {AntDesign} from '@expo/vector-icons';
@@ -186,7 +186,11 @@ const BaseApp: React.FunctionComponent<{
   );
 };
 
-const withParams = (state, params) => {
+/* eslint-disable @typescript-eslint/no-explicit-any */
+function withParams<U extends ParamListBase, V extends keyof U>(
+  state: {route: RouteProp<U, V>; navigation: any},
+  params: Readonly<U[V]>,
+): {route: RouteProp<U, V>; navigation: any} {
   return {
     ...state,
     route: {
@@ -197,6 +201,6 @@ const withParams = (state, params) => {
       },
     },
   };
-};
+}
 
 export default App;

--- a/App.tsx
+++ b/App.tsx
@@ -36,7 +36,7 @@ import {TelemetryTabScreen} from 'components/screens/TelemetryScreen';
 import {AvalancheCenterID} from './types/nationalAvalancheCenter';
 import {prefetchAllActiveForecasts} from './network/prefetchAllActiveForecasts';
 import {HTMLRendererConfig} from 'components/text/HTML';
-import {formatInTimeZone} from 'date-fns-tz';
+import {toISOStringUTC} from './utils/date';
 
 // The SplashScreen stays up until we've loaded all of our fonts and other assets
 SplashScreen.preventAutoHideAsync();
@@ -110,7 +110,7 @@ const BaseApp: React.FunctionComponent<{
 }> = ({staging, setStaging}) => {
   const [avalancheCenterId, setAvalancheCenterId] = React.useState(Constants.expoConfig.extra.avalanche_center as AvalancheCenterID);
   const [date] = React.useState<Date>(defaultDate);
-  const dateString = formatInTimeZone(date, 'UTC', 'yyyy-MM-dd HH:mm:ssXXX');
+  const dateString = toISOStringUTC(date);
 
   const {nationalAvalancheCenterHost} = React.useContext<ClientProps>(ClientContext);
   const queryClient = useQueryClient();

--- a/App.tsx
+++ b/App.tsx
@@ -166,14 +166,14 @@ const BaseApp: React.FunctionComponent<{
                   }
                 },
               })}>
-              <TabNavigator.Screen name="Home" initialParams={{center_id: avalancheCenterId, dateString}}>
-                {state => HomeTabScreen(withParams(state, {center_id: avalancheCenterId, date: date}))}
+              <TabNavigator.Screen name="Home" initialParams={{center_id: avalancheCenterId, dateString: dateString}}>
+                {state => HomeTabScreen(withParams(state, {center_id: avalancheCenterId, dateString: dateString}))}
               </TabNavigator.Screen>
-              <TabNavigator.Screen name="Observations" initialParams={{center_id: avalancheCenterId, dateString}}>
-                {state => ObservationsTabScreen(withParams(state, {center_id: avalancheCenterId, date: date}))}
+              <TabNavigator.Screen name="Observations" initialParams={{center_id: avalancheCenterId, dateString: dateString}}>
+                {state => ObservationsTabScreen(withParams(state, {center_id: avalancheCenterId, dateString: dateString}))}
               </TabNavigator.Screen>
-              <TabNavigator.Screen name="Weather Data" initialParams={{center_id: avalancheCenterId, dateString}}>
-                {state => TelemetryTabScreen(withParams(state, {center_id: avalancheCenterId, date: date}))}
+              <TabNavigator.Screen name="Weather Data" initialParams={{center_id: avalancheCenterId, dateString: dateString}}>
+                {state => TelemetryTabScreen(withParams(state, {center_id: avalancheCenterId, dateString: dateString}))}
               </TabNavigator.Screen>
               <TabNavigator.Screen name="Menu" initialParams={{center_id: avalancheCenterId}}>
                 {() => MenuStackScreen(avalancheCenterId, setAvalancheCenterId, staging, setStaging)}

--- a/components/forecast/AvalancheForecast.tsx
+++ b/components/forecast/AvalancheForecast.tsx
@@ -9,7 +9,7 @@ import {HStack, View} from 'components/core';
 
 import {AvalancheCenterID, AvalancheForecastZone, AvalancheForecastZoneSummary} from 'types/nationalAvalancheCenter';
 import {Tab, TabControl} from 'components/TabControl';
-import {useAvalancheForecast} from 'hooks/useAvalancheForecast';
+import {useLatestAvalancheForecast} from 'hooks/useLatestAvalancheForecast';
 import {useAvalancheCenterMetadata} from 'hooks/useAvalancheCenterMetadata';
 import {useRefreshByUser} from 'hooks/useRefreshByUser';
 
@@ -42,7 +42,7 @@ export const AvalancheForecast: React.FunctionComponent<AvalancheForecastProps> 
     data: forecast,
     error: forecastError,
     refetch: refetchForecast,
-  } = useAvalancheForecast(center_id, forecast_zone_id, date);
+  } = useLatestAvalancheForecast(center_id, forecast_zone_id, date); // TODO(skuznets): when we refactor to show previous forecasts, we will need two wrappers for the logic under the fetching, choosing either to fetch the latest, or for a specific date
   const {isRefetchingByUser, refetchByUser} = useRefreshByUser(refetchCenter, refetchForecast);
 
   // When navigating from elsewhere in the app, the screen title should already

--- a/components/screens/HomeScreen.tsx
+++ b/components/screens/HomeScreen.tsx
@@ -9,8 +9,18 @@ export const HomeTabScreen = ({route}: NativeStackScreenProps<TabNavigatorParamL
   const {center_id, dateString} = route.params;
   return (
     <AvalancheCenterStack.Navigator initialRouteName="avalancheCenter">
-      <AvalancheCenterStack.Screen name="avalancheCenter" component={MapScreen} initialParams={{center_id: center_id, dateString}} options={() => ({headerShown: false})} />
-      <AvalancheCenterStack.Screen name="forecast" component={ForecastScreen} initialParams={{center_id: center_id, dateString}} options={() => ({headerShown: false})} />
+      <AvalancheCenterStack.Screen
+        name="avalancheCenter"
+        component={MapScreen}
+        initialParams={{center_id: center_id, dateString: dateString}}
+        options={() => ({headerShown: false})}
+      />
+      <AvalancheCenterStack.Screen
+        name="forecast"
+        component={ForecastScreen}
+        initialParams={{center_id: center_id, dateString: dateString}}
+        options={() => ({headerShown: false})}
+      />
     </AvalancheCenterStack.Navigator>
   );
 };

--- a/hooks/useAvalancheCenterMetadata.ts
+++ b/hooks/useAvalancheCenterMetadata.ts
@@ -22,7 +22,7 @@ export const useAvalancheCenterMetadata = (center_id: AvalancheCenterID) => {
 };
 
 function queryKey(nationalAvalancheCenterHost: string, center_id: string) {
-  return ['center-metadata', 'host', nationalAvalancheCenterHost, 'avalanche-center', center_id];
+  return ['center-metadata', {host: nationalAvalancheCenterHost, center: center_id}];
 }
 
 export const prefetchAvalancheCenterMetadata = async (queryClient: QueryClient, nationalAvalancheCenterHost: string, center_id: AvalancheCenterID) => {

--- a/hooks/useAvalancheForecast.ts
+++ b/hooks/useAvalancheForecast.ts
@@ -27,7 +27,7 @@ export const useAvalancheForecast = (center_id: AvalancheCenterID, forecast_zone
 };
 
 function queryKey(nationalAvalancheCenterHost: string, forecastId: number) {
-  return ['avalanche-forecast', 'host', nationalAvalancheCenterHost, 'product', forecastId];
+  return ['avalanche-forecast', {host: nationalAvalancheCenterHost, forecast: forecastId}];
 }
 
 export const prefetchAvalancheForecast = async (queryClient: QueryClient, nationalAvalancheCenterHost: string, forecastId: number) => {

--- a/hooks/useAvalancheForecastFragments.ts
+++ b/hooks/useAvalancheForecastFragments.ts
@@ -22,7 +22,7 @@ export const useAvalancheForecastFragments = (center_id: AvalancheCenterID, date
 };
 
 function queryKey(nationalAvalancheCenterHost: string, center_id: string, date: Date) {
-  return ['forecast-fragments', 'host', nationalAvalancheCenterHost, 'products', center_id, apiDateString(date)];
+  return ['forecast-fragments', {host: nationalAvalancheCenterHost, center: center_id, date: apiDateString(date)}];
 }
 
 const prefetchAvalancheForecastFragments = async (queryClient: QueryClient, nationalAvalancheCenterHost: string, center_id: string, date: Date) => {

--- a/hooks/useLatestAvalancheForecast.ts
+++ b/hooks/useLatestAvalancheForecast.ts
@@ -1,0 +1,99 @@
+import React from 'react';
+
+import axios, {AxiosError} from 'axios';
+import {QueryClient, useQuery} from 'react-query';
+
+import * as Sentry from 'sentry-expo';
+
+import Log from 'network/log';
+
+import {ClientContext, ClientProps} from 'clientContext';
+import {AvalancheCenterID, Product, productSchema} from 'types/nationalAvalancheCenter';
+import {ZodError} from 'zod';
+import {nominalForecastDate} from 'utils/date';
+import {useAvalancheCenterMetadata} from './useAvalancheCenterMetadata';
+
+export const useLatestAvalancheForecast = (center_id: AvalancheCenterID, zone_id: number, requestedTime: Date) => {
+  const {data: metadata} = useAvalancheCenterMetadata(center_id);
+  const expiryTimeHours = metadata?.config.expires_time;
+  const expiryTimeZone = metadata?.timezone;
+
+  const {nationalAvalancheCenterHost} = React.useContext<ClientProps>(ClientContext);
+  return useQuery<Product, AxiosError | ZodError>({
+    queryKey: queryKey(nationalAvalancheCenterHost, center_id, zone_id, requestedTime, expiryTimeZone, expiryTimeHours),
+    queryFn: async () => fetchLatestAvalancheForecast(nationalAvalancheCenterHost, center_id, zone_id),
+    enabled: !!expiryTimeHours,
+    cacheTime: 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)
+  });
+};
+
+// the query we make to the NAC API does not make use of the nominal date for which we're asking, but we want a good
+// user experience around the cut-over moment between nominal dates. Consider a user that has loaded this query before
+// the cut-over, and has a cached version of the previous day's forecasts. When they refresh their view after the
+// cut-over, we want to render only once we've done a fresh load, since we expect to have new data, instead of using
+// the cache. By adding the nominal date to the query key, we get this behavior.
+function queryKey(nationalAvalancheCenterHost: string, center_id: string, zone_id: number, requestedTime: Date, expiryTimeZone: string, expiryTimeHours: number) {
+  return [
+    'latest-forecast',
+    {
+      host: nationalAvalancheCenterHost,
+      center: center_id,
+      zone_id: zone_id,
+      requestedTime: nominalForecastDate(requestedTime, expiryTimeZone, expiryTimeHours),
+    },
+  ];
+}
+
+const prefetchLatestAvalancheForecast = async (
+  queryClient: QueryClient,
+  nationalAvalancheCenterHost: string,
+  center_id: string,
+  zone_id: number,
+  requestedTime: Date,
+  expiryTimeZone: string,
+  expiryTimeHours: number,
+) => {
+  await queryClient.prefetchQuery({
+    queryKey: queryKey(nationalAvalancheCenterHost, center_id, zone_id, requestedTime, expiryTimeZone, expiryTimeHours),
+    queryFn: async () => {
+      Log.prefetch('starting fragment prefetch');
+      const result = await fetchLatestAvalancheForecast(nationalAvalancheCenterHost, center_id, zone_id);
+      Log.prefetch('fragment request finished');
+      return result;
+    },
+  });
+  Log.prefetch('avalanche fragment data is cached with react-query');
+};
+
+const fetchLatestAvalancheForecast = async (nationalAvalancheCenterHost: string, center_id: string, zone_id: number) => {
+  const url = `${nationalAvalancheCenterHost}/v2/public/product`;
+  const {data} = await axios.get(url, {
+    params: {
+      center_id: center_id,
+      type: 'forecast',
+      zone_id: zone_id,
+    },
+  });
+
+  const parseResult = productSchema.safeParse(data);
+  if (parseResult.success === false) {
+    console.warn('unparsable forecast', url, parseResult.error, JSON.stringify(data, null, 2));
+    Sentry.Native.captureException(parseResult.error, {
+      tags: {
+        zod_error: true,
+        center_id,
+        zone_id,
+        url,
+      },
+    });
+    throw parseResult.error;
+  } else {
+    return parseResult.data;
+  }
+};
+
+export default {
+  queryKey,
+  fetch: fetchLatestAvalancheForecast,
+  prefetch: prefetchLatestAvalancheForecast,
+};

--- a/hooks/useMapLayer.ts
+++ b/hooks/useMapLayer.ts
@@ -22,7 +22,7 @@ export const useMapLayer = (center_id: AvalancheCenterID) => {
 };
 
 function queryKey(nationalAvalancheCenterHost: string, center_id: string) {
-  return ['map-layer', 'host', nationalAvalancheCenterHost, 'avalanche-center', center_id];
+  return ['map-layer', {host: nationalAvalancheCenterHost, center: center_id}];
 }
 
 export const prefetchMapLayer = async (queryClient: QueryClient, nationalAvalancheCenterHost: string, center_id: AvalancheCenterID) => {

--- a/hooks/useMapViewZones.ts
+++ b/hooks/useMapViewZones.ts
@@ -1,10 +1,13 @@
-import {useQuery} from 'react-query';
+import React from 'react';
+import {useQueries, useQuery} from 'react-query';
 
 import {useMapLayer} from './useMapLayer';
-import {useAvalancheForecastFragments} from './useAvalancheForecastFragments';
+import LatestAvalancheForecastQuery from 'hooks/useLatestAvalancheForecast';
 
 import {AvalancheCenterID, DangerLevel, FeatureComponent} from 'types/nationalAvalancheCenter';
 import {apiDateString} from 'utils/date';
+import {useAvalancheCenterMetadata} from './useAvalancheCenterMetadata';
+import {ClientContext, ClientProps} from '../clientContext';
 
 export type MapViewZone = {
   center_id: AvalancheCenterID;
@@ -19,8 +22,24 @@ export type MapViewZone = {
 };
 
 export const useMapViewZones = (center_id: AvalancheCenterID, date: Date) => {
+  const {nationalAvalancheCenterHost} = React.useContext<ClientProps>(ClientContext);
   const {data: mapLayer} = useMapLayer(center_id);
-  const {data: fragments} = useAvalancheForecastFragments(center_id, date);
+  const {data: metadata} = useAvalancheCenterMetadata(center_id);
+  const expiryTimeHours = metadata?.config.expires_time;
+  const expiryTimeZone = metadata?.timezone;
+
+  const forecastResults = useQueries(
+    mapLayer
+      ? mapLayer.features.map(feature => {
+          return {
+            queryKey: LatestAvalancheForecastQuery.queryKey(nationalAvalancheCenterHost, center_id, feature.id, date, expiryTimeZone, expiryTimeHours),
+            queryFn: async () => LatestAvalancheForecastQuery.fetch(nationalAvalancheCenterHost, center_id, feature.id),
+            enabled: !!expiryTimeHours,
+            cacheTime: 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)
+          };
+        })
+      : [],
+  );
 
   // This query executes as soon as `useMapLayer` finishes, but then tries to augment
   // data with anything found in `useAvalancheForecastFragments`.
@@ -43,18 +62,21 @@ export const useMapViewZones = (center_id: AvalancheCenterID, date: Date) => {
       }, {});
 
       // Freshen up the data with values from useAvalancheForecastFragments, if available
-      if (fragments != null) {
-        fragments.forEach(forecast => {
-          forecast.forecast_zone?.forEach(({zone_id}) => {
-            const mapViewZoneData = featureMap[zone_id];
-            if (mapViewZoneData) {
-              mapViewZoneData.dangerLevel = forecast.danger?.filter(d => d.valid_day === 'current').map(d => Math.max(d.lower, d.middle, d.upper)) ?? mapViewZoneData.dangerLevel;
-              mapViewZoneData.danger = forecast.danger_level_text ?? mapViewZoneData.danger;
-              mapViewZoneData.startDate = forecast.published_time ?? mapViewZoneData.startDate;
-              mapViewZoneData.endDate = forecast.expires_time ?? mapViewZoneData.endDate;
-            }
+      if (forecastResults != null) {
+        forecastResults
+          .map(result => result.data) // get data from the results
+          .filter(data => data) // only operate on results that have succeeded
+          .forEach(forecast => {
+            forecast.forecast_zone?.forEach(({zone_id}) => {
+              const mapViewZoneData = featureMap[zone_id];
+              if (mapViewZoneData) {
+                mapViewZoneData.dangerLevel = forecast.danger?.filter(d => d.valid_day === 'current').map(d => Math.max(d.lower, d.middle, d.upper)) ?? mapViewZoneData.dangerLevel;
+                mapViewZoneData.danger = forecast.danger_level_text ?? mapViewZoneData.danger;
+                mapViewZoneData.startDate = forecast.published_time ?? mapViewZoneData.startDate;
+                mapViewZoneData.endDate = forecast.expires_time ?? mapViewZoneData.endDate;
+              }
+            });
           });
-        });
       }
 
       return Object.keys(featureMap).map(k => featureMap[k]);

--- a/utils/date.test.tsx
+++ b/utils/date.test.tsx
@@ -1,4 +1,4 @@
-import {apiDateString, fixMalformedISO8601DateString, utcDateToLocalDateString, utcDateToLocalTimeString} from 'utils/date';
+import {apiDateString, fixMalformedISO8601DateString, nominalForecastDate, utcDateToLocalDateString, utcDateToLocalTimeString} from 'utils/date';
 import * as TimezoneMock from 'timezone-mock';
 
 describe('Dates', () => {
@@ -80,6 +80,24 @@ describe('Dates', () => {
 
     afterEach(() => {
       TimezoneMock.unregister();
+    });
+  });
+
+  describe('nominalForecastDate', () => {
+    it('returns the current day when requesting before the expiry time', () => {
+      expect(nominalForecastDate(new Date('2023-01-24T09:44:27-08:00'), 'America/Los_Angeles', 18)).toBe('2023-01-24');
+    });
+    it('returns the next day when requesting after the expiry time', () => {
+      expect(nominalForecastDate(new Date('2023-01-24T19:44:27-08:00'), 'America/Los_Angeles', 18)).toBe('2023-01-25');
+    });
+    it('returns the current day when requesting before the expiry time using UTC', () => {
+      expect(nominalForecastDate(new Date('2023-01-24T17:44:27-00:00'), 'America/Los_Angeles', 18)).toBe('2023-01-24');
+    });
+    it('returns the next day when requesting after the expiry time using UTC', () => {
+      expect(nominalForecastDate(new Date('2023-01-25T03:44:27-00:00'), 'America/Los_Angeles', 18)).toBe('2023-01-25');
+    });
+    it('handles single-digit expiry hours', () => {
+      expect(nominalForecastDate(new Date('2023-01-24T19:44:27-08:00'), 'America/Los_Angeles', 1)).toBe('2023-01-25');
     });
   });
 });

--- a/utils/date.tsx
+++ b/utils/date.tsx
@@ -6,6 +6,8 @@ const MISSING_TIMEZONE = /^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(\.\d+)?$/;
 // Some avalanche.org endpoints return dates without timezone information! This method is used to detect and fix them, by assuming they're UTC.
 export const fixMalformedISO8601DateString = (date: string) => (MISSING_TIMEZONE.test(date) ? `${date}Z` : date);
 
+export const toISOStringUTC = (date: Date) => formatInTimeZone(date, 'UTC', 'yyyy-MM-dd HH:mm:ssXXX');
+
 // The National Avalanche Center API expects 'YYYY-MM-DD' date-strings in query parameters, and it operates in UTC.
 export const apiDateString = (date: Date) => formatInTimeZone(date, 'UTC', 'yyyy-MM-dd');
 

--- a/utils/date.tsx
+++ b/utils/date.tsx
@@ -1,5 +1,5 @@
-import {format} from 'date-fns';
-import {formatInTimeZone} from 'date-fns-tz';
+import {add, format, isAfter} from 'date-fns';
+import {formatInTimeZone, toDate} from 'date-fns-tz';
 
 const MISSING_TIMEZONE = /^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(\.\d+)?$/;
 
@@ -8,6 +8,26 @@ export const fixMalformedISO8601DateString = (date: string) => (MISSING_TIMEZONE
 
 // The National Avalanche Center API expects 'YYYY-MM-DD' date-strings in query parameters, and it operates in UTC.
 export const apiDateString = (date: Date) => formatInTimeZone(date, 'UTC', 'yyyy-MM-dd');
+
+// Forecasts expire in the middle of a calendar day, so the forecast that we expect to be valid at any given time during
+// the day changes based on the relationship of that time to the expected expiry time, as recorded for the avalanche
+// center. For example:
+// | requestedTime | expiryTimeHours | nominalForecastDate |
+// | ------------- | --------------- | ------------------- |
+// |  01/01 09:00  |   18 (hours)    |  01/01              |
+// |  01/01 18:00  |   18 (hours)    |  01/02              |
+// |  01/01 20:00  |   18 (hours)    |  01/02              |
+export const nominalForecastDate = (requestedTime: Date, expiryTimeZone: string, expiryTimeHours: number): string => {
+  // requestedTime is in UTC, expiryTimeHours is relative to the locale-specific start of day
+  const expiryTimeString = `${formatInTimeZone(requestedTime, expiryTimeZone, 'yyyy-MM-dd')} ${String(expiryTimeHours).padStart(2, '0')}:00:00`;
+  const expiryTime = toDate(expiryTimeString, {timeZone: expiryTimeZone});
+  if (isAfter(expiryTime, requestedTime)) {
+    return formatInTimeZone(requestedTime, expiryTimeZone, 'yyyy-MM-dd');
+  } else {
+    const tomorrow = add(requestedTime, {days: 1});
+    return formatInTimeZone(tomorrow, expiryTimeZone, 'yyyy-MM-dd');
+  }
+};
 
 export const utcDateToLocalTimeString = (date: Date | string | undefined): string => {
   if (date == null) {


### PR DESCRIPTION
hooks: use a mapping custom for options

This is common in all of the react-query documentation for capturing
options passed to a query. No reason we should buck the trend.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

*: fetch forecasts using the latest product API

Ultimately, we will need two types of views:

1. "show me the currently-valid products for a zone"
2. "show me the valid products for a zone at some point in the past"

Due to quirks of how the date filtering works on the products API from
the NAC (filtering on the publication date, not the date for which the
product is valid), we need to split these cases up. This PR does the
first pass to allow us to fetch the currently-valid forecast.
Follow-up PRs will:

1. update our routes to not contain a date, and resolve "now" when we're
   in the component
2. add a new route for a particular time in history
3. add warnings & synopses to the data we fetch for a forecast date

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

