### PR TITLE
More weather cleanups

### DIFF
--- a/components/forecast/WeatherTab.tsx
+++ b/components/forecast/WeatherTab.tsx
@@ -1,6 +1,6 @@
 import {Card, CollapsibleCard} from 'components/content/Card';
 import {Center, HStack, View, VStack} from 'components/core';
-import {useWeatherForecasts} from 'hooks/useWeatherForecasts';
+import {useLatestWeatherForecast} from 'hooks/useLatestWeatherForecast';
 import {AllCapsSm, AllCapsSmBlack, Body, BodyBlack, BodySemibold, Title3Black} from 'components/text';
 import {HTML} from 'components/text/HTML';
 import {ActivityIndicator, StyleSheet} from 'react-native';
@@ -21,7 +21,7 @@ const timeOfDayString = (period: 'day' | 'night', subperiod: 'early' | 'late') =
 };
 
 export const WeatherTab: React.FC<WeatherTabProps> = ({zone}) => {
-  const {isLoading, isError, data: forecast} = useWeatherForecasts();
+  const {isLoading, isError, data: forecast} = useLatestWeatherForecast('NWAC', zone);
 
   if (isLoading) {
     return (
@@ -62,7 +62,7 @@ export const WeatherTab: React.FC<WeatherTabProps> = ({zone}) => {
           </VStack>
         </HStack>
         <VStack alignItems="stretch" pt={4}>
-          {forecast.zones[zone.name].slice(0, 2).map((forecast, index) => {
+          {forecast.data.slice(0, 2).map((forecast, index) => {
             return (
               <VStack space={2} key={index} py={12} borderBottomWidth={1} borderColor={index === 0 ? colorLookup('light.200') : 'white'}>
                 <BodyBlack>{forecast.label}</BodyBlack>

--- a/components/forecast/WeatherTab.tsx
+++ b/components/forecast/WeatherTab.tsx
@@ -21,9 +21,9 @@ const timeOfDayString = (period: 'day' | 'night', subperiod: 'early' | 'late') =
 };
 
 export const WeatherTab: React.FC<WeatherTabProps> = ({zone}) => {
-  const {isLoading, isError, data: forecast} = useLatestWeatherForecast('NWAC', zone);
+  const {isLoading, isError, isIdle, data: forecast} = useLatestWeatherForecast('NWAC', zone);
 
-  if (isLoading) {
+  if (isLoading || (isIdle && !forecast)) {
     return (
       <Center style={StyleSheet.absoluteFillObject}>
         <ActivityIndicator />
@@ -88,7 +88,7 @@ export const WeatherTab: React.FC<WeatherTabProps> = ({zone}) => {
                     <BodySemibold>Precipitation (in)</BodySemibold>
                     {Object.entries(forecast.precipitation).map(([zone, value]) => (
                       <HStack key={zone} justifyContent="space-between" alignItems="flex-start" alignSelf="stretch">
-                        <View flex={1} flexGrow={3} pr={12}>
+                        <View flex={1} flexGrow={2} pr={12}>
                           <Body style={{flex: 1, flexBasis: 0.75}}>{zone}</Body>
                         </View>
                         <View flex={1} flexGrow={1}>

--- a/hooks/useLatestWeatherForecast.ts
+++ b/hooks/useLatestWeatherForecast.ts
@@ -1,0 +1,32 @@
+import {useLatestWeatherForecasts, WeatherForecast} from 'hooks/useLatestWeatherForecasts';
+import {useQuery} from 'react-query';
+import {AvalancheCenterID, AvalancheForecastZone} from 'types/nationalAvalancheCenter';
+
+export const useLatestWeatherForecast = (center_id: AvalancheCenterID, zone: AvalancheForecastZone) => {
+  if (center_id !== 'NWAC') {
+    throw new Error(`can't fetch weather for ${center_id}: useWeatherForecast hook only supports NWAC`);
+  }
+  const {data: forecasts} = useLatestWeatherForecasts(center_id);
+
+  return useQuery<WeatherForecast, Error>(
+    ['products', center_id, zone.id],
+    () => {
+      const zoneData = forecasts.zones[zone.name];
+      if (!zoneData) {
+        throw new Error(`can't fetch weather for ${zone.id} (${zone.name}): can't find matching forecast`);
+      }
+      return {
+        author: forecasts.author,
+        published_time: forecasts.published_time,
+        expires_time: forecasts.expires_time,
+        synopsis: forecasts.synopsis,
+        data: zoneData,
+      };
+    },
+    {
+      enabled: !!forecasts,
+      staleTime: 60 * 60 * 1000, // re-fetch in the background once an hour (in milliseconds)
+      cacheTime: 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)
+    },
+  );
+};

--- a/hooks/useLatestWeatherForecasts.test.tsx
+++ b/hooks/useLatestWeatherForecasts.test.tsx
@@ -1,7 +1,7 @@
-import {fetchWeather} from './useWeatherForecasts';
+import {fetchWeather} from './useLatestWeatherForecasts';
 
 // Tests are skipped by default; not sure we want to let this constantly hit the server
-describe.skip('useNWACWeatherForecast', () => {
+describe.skip('useLatestWeatherForecasts', () => {
   it('scrapes the HTML into a reasonable format', async () => {
     const data = await fetchWeather();
 

--- a/hooks/useLatestWeatherForecasts.ts
+++ b/hooks/useLatestWeatherForecasts.ts
@@ -9,6 +9,8 @@ import {getTimezoneOffset} from 'date-fns-tz';
 import {add, parse} from 'date-fns';
 import {AvalancheCenterID} from 'types/nationalAvalancheCenter';
 
+const LOG_LEVEL = 0;
+
 const precipZoneToForecastZone = {
   'Hurricane Ridge': 'Olympics',
   'Mt Baker Ski Area': 'West Slopes North',
@@ -133,8 +135,14 @@ const findNextSiblingByTag = (node, tag: string) => {
 };
 
 const periodInfo = (input: string) => {
+  if (!input || input.length === 0) {
+    return null;
+  }
   const parts = input.split(' ');
   const day = parts[0];
+  if (!day || day.length === 0) {
+    return null;
+  }
   switch (parts[1]) {
     case 'Morning':
       return {label: day, day, period: 'day', subperiod: 'early'};
@@ -195,36 +203,43 @@ export const fetchWeather = async () => {
     const zoneName = mwrIdToName[mwrId];
     const periods = toArray(node.getElementsByTagName('th'))
       .filter(n => n.getAttribute('class') === 'row-header')
-      .map(n => periodInfo(str(n)));
+      .map(n => periodInfo(str(n)))
+      .filter(n => n != null);
     const forecasts = toArray(node.getElementsByTagName('td'))
       .filter(n => n.getAttribute('class') === 'description')
       .map(n => str(n));
     merge(zones, {[zoneName]: periods.map((p, idx) => ({label: p.label, forecast: forecasts[idx], precipitation: {}}))});
   });
 
-  // console.log('step 1', JSON.stringify(zones, null, 2));
+  LOG_LEVEL > 0 && console.log('step 1', JSON.stringify(zones, null, 2));
 
   // Zone snow level predictions
   const snowLevel = doc.getElementsByClassName('desktop snow-level')[0];
   const snowLevelRows = toArray(snowLevel.getElementsByTagName('tr'));
   const snowLevelPeriods = toArray(snowLevelRows[0].getElementsByTagName('th'))
     .slice(1)
-    .map(n => periodInfo(str(n)));
+    .map(n => str(n))
+    .filter(x => x.length > 0)
+    .map(n => periodInfo(n))
+    .filter(n => n != null);
   snowLevelRows.slice(1).forEach(row => {
     const zoneName = canonicalZoneName(row.getElementsByTagName('th')[0]);
     const cells = toArray(row.getElementsByTagName('td')).map(cell => str(cell));
     cells.forEach((cell, idx) => {
+      if (idx >= snowLevelPeriods.length) {
+        return;
+      }
       const period = snowLevelPeriods[idx];
       const forecast = zones[zoneName].find(f => f.label === period.label);
       if (forecast) {
         forecast['snowLevel'] = forecast['snowLevel'] || [];
         forecast['snowLevel'].push({period: period.period, subperiod: period.subperiod, level: Number(cell.replace(/\D/g, ''))});
       } else {
-        // console.warn(`Snow level: could not find forecast for ${period.label}`, zones);
+        LOG_LEVEL > 1 && console.warn(`Snow level: could not find forecast for ${period.label}`, zones);
       }
     });
   });
-  // console.log('step 2', JSON.stringify(zones, null, 2));
+  LOG_LEVEL > 0 && console.log('step 2', JSON.stringify(zones, null, 2));
 
   const precip = doc.getElementsByClassName('desktop precipitation')[0];
   const precipRows = toArray(precip.getElementsByTagName('tr'));
@@ -232,7 +247,8 @@ export const fetchWeather = async () => {
     .slice(1)
     .map(n => str(n))
     .filter(x => x.length > 0)
-    .map(x => periodInfo(x));
+    .map(x => periodInfo(x))
+    .filter(n => n != null);
   precipRows.slice(2).forEach(row => {
     const precipZone = canonicalZoneName(row.getElementsByTagName('th')[0]);
     const zoneName = precipZoneToForecastZone[precipZone];
@@ -241,17 +257,20 @@ export const fetchWeather = async () => {
         .map(cell => str(cell))
         .filter(x => x.length > 0);
       cells.forEach((cell, idx) => {
+        if (idx >= precipPeriods.length) {
+          return;
+        }
         const period = precipPeriods[idx];
         const forecast = zones[zoneName].find(f => f.label === period.label);
         if (forecast) {
           forecast.precipitation[precipZone] = cell;
         } else {
-          // console.warn(`Precipitation: could not find forecast for ${period.label}`, zones);
+          LOG_LEVEL > 1 && console.warn(`Precipitation: could not find forecast for ${period.label}`, zones);
         }
       });
     }
   });
-  // console.log('step 3', JSON.stringify(zones, null, 2));
+  LOG_LEVEL > 0 && console.log('step 3', JSON.stringify(zones, null, 2));
 
   const temps = doc.getElementsByClassName('desktop temperatures')[0];
   const tempsRows = toArray(temps.getElementsByTagName('tr'));
@@ -259,24 +278,28 @@ export const fetchWeather = async () => {
     .slice(1)
     .map(n => str(n))
     .filter(x => x.length > 0)
-    .map(n => periodInfo(n));
+    .map(n => periodInfo(n))
+    .filter(n => n != null);
   tempsRows.slice(2).forEach(row => {
     const zoneName = canonicalZoneName(row.getElementsByTagName('td')[0]);
     const cells = toArray(row.getElementsByTagName('td'))
       .slice(1)
       .map(cell => str(cell));
     cells.forEach((cell, idx) => {
+      if (idx >= tempsPeriods.length) {
+        return;
+      }
       const period = tempsPeriods[idx];
       const forecast = zones[zoneName].find(f => f.label === period.label);
       if (forecast) {
         const [_temp, high, low] = cell.match(/(\d+)\s*\/\s*(\d+)/);
         forecast['temperatures'] = {low: Number(low), high: Number(high)};
       } else {
-        // console.warn(`Temps: could not find forecast for ${period.label}`, zones);
+        LOG_LEVEL > 1 && console.warn(`Temps: could not find forecast for ${period.label}`, zones);
       }
     });
   });
-  // console.log('step 4', JSON.stringify(zones, null, 2));
+  LOG_LEVEL > 0 && console.log('step 4', JSON.stringify(zones, null, 2));
 
   // Ridgeline winds table doesn't have a sensible classname :(
   const windsHeader = doc.getElementById('free-winds-5k');
@@ -286,22 +309,26 @@ export const fetchWeather = async () => {
     .slice(1)
     .map(n => str(n))
     .filter(x => x.length > 0)
-    .map(n => periodInfo(n));
+    .map(n => periodInfo(n))
+    .filter(n => n != null);
   windsRows.slice(1).forEach(row => {
     const zoneName = canonicalZoneName(row.getElementsByTagName('th')[0]);
     const cells = toArray(row.getElementsByTagName('td')).map(cell => str(cell));
     cells.forEach((cell, idx) => {
+      if (idx >= windsPeriods.length) {
+        return;
+      }
       const period = windsPeriods[idx];
       const forecast = zones[zoneName].find(f => f.label === period.label);
       if (forecast) {
         forecast['winds'] = forecast['winds'] || [];
         forecast['winds'].push({period: period.period, subperiod: period.subperiod, speed: cell});
       } else {
-        // console.log(`Winds: could not find forecast for ${period.label}`, zones);
+        LOG_LEVEL > 1 && console.warn(`Winds: could not find forecast for ${period.label}`, zones);
       }
     });
   });
-  // console.log('step 5', JSON.stringify(zones, null, 2));
+  LOG_LEVEL > 0 && console.log('step 5', JSON.stringify(zones, null, 2));
 
   // Date hacking - convert a string like `Issued: 2:00 PM PST Wednesday, January 25, 2023`
   const publishedTimeComponents = str(doc.getElementsByClassName('forecast-date')[0]).split(' ');

--- a/utils/date.tsx
+++ b/utils/date.tsx
@@ -36,7 +36,7 @@ export const utcDateToLocalTimeString = (date: Date | string | undefined): strin
     return 'Unknown';
   }
   const d = typeof date === 'string' ? new Date(date) : date;
-  return format(d, `EEE, MMM d, yyyy h:mm a`);
+  return format(d, `EEE, MMM d, yyyy \nh:mm a`);
 };
 
 export const utcDateToLocalDateString = (date: Date | string | undefined): string => {


### PR DESCRIPTION
- `useWeatherForecasts` -> `useLatestWeatherForecasts`
- add a `useLatestWeatherForecast` hook to get weather for a particular zone
- make parser a little more robust when handling table entries like `Saturday Afternoon*`
- make a little more room for precipitation amounts so they don't wrap as easily, but it's still quite a tight squeeze in that space: 
<img width="167" alt="image" src="https://user-images.githubusercontent.com/101196/214984634-ec035be8-0619-4a83-a4ea-aef976ac3bbc.png">
