### PR TITLE
Tap on a selected polygon should open forecast

### DIFF
--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -52,10 +52,26 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
 
   const {isLoading, isError, data: zones} = useMapViewZones(center, date);
 
+  const navigation = useNavigation<HomeStackNavigationProps>();
   const [selectedZone, setSelectedZone] = useState<MapViewZone | null>(null);
-  const onPress = useCallback(() => {
+  const onPressMapView = useCallback(() => {
     setSelectedZone(null);
   }, []);
+  const onPressPolygon = useCallback(
+    (zone: MapViewZone) => {
+      if (selectedZone === zone) {
+        navigation.navigate('forecast', {
+          zoneName: zone.name,
+          center_id: zone.center_id,
+          forecast_zone_id: zone.zone_id,
+          dateString: apiDateString(date),
+        });
+      } else {
+        setSelectedZone(zone);
+      }
+    },
+    [navigation, selectedZone, date],
+  );
 
   const avalancheCenterMapRegionBounds: RegionBounds = zones
     ? zones.reduce((accumulator, currentValue) => updateBoundsToContain(accumulator, toLatLngList(currentValue.geometry)), defaultAvalancheCenterMapRegionBounds)
@@ -94,8 +110,8 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
         zoomEnabled={true}
         scrollEnabled={true}
         provider={'google'}
-        onPress={onPress}>
-        {isReady && zones?.map(zone => <AvalancheForecastZonePolygon key={zone.zone_id} zone={zone} setSelectedZone={setSelectedZone} />)}
+        onPress={onPressMapView}>
+        {isReady && zones?.map(zone => <AvalancheForecastZonePolygon key={zone.zone_id} zone={zone} onPress={onPressPolygon} />)}
       </MapView.Animated>
       <SafeAreaView onLayout={(event: LayoutChangeEvent) => controller.animateUsingUpdatedTopElementsHeight(event.nativeEvent.layout.y + event.nativeEvent.layout.height)}>
         <View flex={1}>

--- a/components/AvalancheForecastZonePolygon.tsx
+++ b/components/AvalancheForecastZonePolygon.tsx
@@ -25,10 +25,10 @@ export const toLatLngList = (geometry: FeatureComponent): LatLng[] => {
 
 export interface AvalancheForecastZonePolygonProps {
   zone: MapViewZone;
-  setSelectedZone: (zone: MapViewZone) => void;
+  onPress: (zone: MapViewZone) => void;
 }
 
-export const AvalancheForecastZonePolygon: React.FunctionComponent<AvalancheForecastZonePolygonProps> = ({zone, setSelectedZone}: AvalancheForecastZonePolygonProps) => {
+export const AvalancheForecastZonePolygon: React.FunctionComponent<AvalancheForecastZonePolygonProps> = ({zone, onPress}: AvalancheForecastZonePolygonProps) => {
   return (
     <Polygon
       coordinates={toLatLngList(zone.geometry)}
@@ -37,7 +37,7 @@ export const AvalancheForecastZonePolygon: React.FunctionComponent<AvalancheFore
       strokeWidth={2}
       tappable={true}
       onPress={event => {
-        setSelectedZone(zone);
+        onPress(zone);
         // By calling stopPropagation, we prevent this event from getting passed to the MapView's onPress handler,
         // which would then clear the selection
         // https://github.com/react-native-maps/react-native-maps/issues/1132


### PR DESCRIPTION
does what it says on the tin. overall this seems like the right/expected behavior from a user perspective - we can see if the animations prevent anyone from using this successfully, but that doesn't seem like a reason *not* to allow this behavior.

(I guess we could only allow it when the drawer is visible? feels kinda arbitrary though)