### PR TITLE
Keep the weather scraper from crashing on asterisks in column headers

### DIFF
--- a/hooks/useLatestWeatherForecasts.ts
+++ b/hooks/useLatestWeatherForecasts.ts
@@ -143,7 +143,8 @@ const periodInfo = (input: string) => {
   if (!day || day.length === 0) {
     return null;
   }
-  switch (parts[1]) {
+  // Not dealing with asterisks here - https://github.com/stevekuznetsov/avalanche-forecast/issues/109 tracks doing this for the real API
+  switch (parts[1]?.trim()?.replace('*', '')) {
     case 'Morning':
       return {label: day, day, period: 'day', subperiod: 'early'};
     case 'Afternoon':


### PR DESCRIPTION
Most region forecasts for today are crashing because of this - just making a quick patch