### PR TITLE
Fix error handling in chained hooks

### DIFF
--- a/hooks/useAvalancheForecastFragment.ts
+++ b/hooks/useAvalancheForecastFragment.ts
@@ -1,20 +1,24 @@
-import {useQuery} from 'react-query';
+import {useContext} from 'react';
+
+import {useQuery, useQueryClient} from 'react-query';
 import {add, areIntervalsOverlapping} from 'date-fns';
 
 import {AvalancheCenterID, Product} from 'types/nationalAvalancheCenter';
-import {useAvalancheForecastFragments} from './useAvalancheForecastFragments';
 import {apiDateString} from 'utils/date';
+import {ClientContext, ClientProps} from 'clientContext';
+import AvalancheForecastFragments from 'hooks/useAvalancheForecastFragments';
 
 export const useAvalancheForecastFragment = (center_id: AvalancheCenterID, forecast_zone_id: number, date: Date) => {
-  const {data: fragments} = useAvalancheForecastFragments(center_id, date);
+  const queryClient = useQueryClient();
+  const {nationalAvalancheCenterHost} = useContext<ClientProps>(ClientContext);
 
   return useQuery<Product, Error>(
     ['products', center_id, forecast_zone_id, apiDateString(date)],
     async () => {
+      const fragments = await AvalancheForecastFragments.fetchQuery(queryClient, nationalAvalancheCenterHost, center_id, date);
       return fragments?.find(forecast => isBetween(forecast.published_time, forecast.expires_time, date) && forecast.forecast_zone.find(zone => zone.id === forecast_zone_id));
     },
     {
-      enabled: !!fragments,
       staleTime: 60 * 60 * 1000, // re-fetch in the background once an hour (in milliseconds)
       cacheTime: 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)
     },

--- a/hooks/useAvalancheForecastFragments.ts
+++ b/hooks/useAvalancheForecastFragments.ts
@@ -38,6 +38,15 @@ const prefetchAvalancheForecastFragments = async (queryClient: QueryClient, nati
   Log.prefetch('avalanche fragment data is cached with react-query');
 };
 
+const fetchAvalancheForecastFragmentsQuery = async (queryClient: QueryClient, nationalAvalancheCenterHost: string, center_id: string, date: Date) =>
+  await queryClient.fetchQuery({
+    queryKey: queryKey(nationalAvalancheCenterHost, center_id, date),
+    queryFn: async () => {
+      const result = await fetchAvalancheForecastFragments(nationalAvalancheCenterHost, center_id, date);
+      return result;
+    },
+  });
+
 const fetchAvalancheForecastFragments = async (nationalAvalancheCenterHost: string, center_id: string, date: Date) => {
   const url = `${nationalAvalancheCenterHost}/v2/public/products`;
   const {data} = await axios.get(url, {
@@ -68,6 +77,6 @@ const fetchAvalancheForecastFragments = async (nationalAvalancheCenterHost: stri
 
 export default {
   queryKey,
-  fetch: fetchAvalancheForecastFragments,
   prefetch: prefetchAvalancheForecastFragments,
+  fetchQuery: fetchAvalancheForecastFragmentsQuery,
 };

--- a/hooks/useLatestWeatherForecast.ts
+++ b/hooks/useLatestWeatherForecast.ts
@@ -1,16 +1,18 @@
-import {useLatestWeatherForecasts, WeatherForecast} from 'hooks/useLatestWeatherForecasts';
-import {useQuery} from 'react-query';
+import {fetchWeatherQuery, WeatherForecast} from 'hooks/useLatestWeatherForecasts';
+import {useQuery, useQueryClient} from 'react-query';
 import {AvalancheCenterID, AvalancheForecastZone} from 'types/nationalAvalancheCenter';
 
 export const useLatestWeatherForecast = (center_id: AvalancheCenterID, zone: AvalancheForecastZone) => {
   if (center_id !== 'NWAC') {
     throw new Error(`can't fetch weather for ${center_id}: useWeatherForecast hook only supports NWAC`);
   }
-  const {data: forecasts} = useLatestWeatherForecasts(center_id);
+
+  const queryClient = useQueryClient();
 
   return useQuery<WeatherForecast, Error>(
     ['products', center_id, zone.id],
-    () => {
+    async () => {
+      const forecasts = await fetchWeatherQuery(queryClient);
       const zoneData = forecasts.zones[zone.name];
       if (!zoneData) {
         throw new Error(`can't fetch weather for ${zone.id} (${zone.name}): can't find matching forecast`);
@@ -24,7 +26,6 @@ export const useLatestWeatherForecast = (center_id: AvalancheCenterID, zone: Ava
       };
     },
     {
-      enabled: !!forecasts,
       staleTime: 60 * 60 * 1000, // re-fetch in the background once an hour (in milliseconds)
       cacheTime: 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)
     },

--- a/hooks/useLatestWeatherForecasts.ts
+++ b/hooks/useLatestWeatherForecasts.ts
@@ -114,8 +114,17 @@ export const prefetchWeather = async (queryClient: QueryClient) => {
       return result;
     },
   });
-  Log.prefetch('avalanche center map layer is cached with react-query');
+  Log.prefetch('avalanche center weather is cached with react-query');
 };
+
+export const fetchWeatherQuery = async (queryClient: QueryClient) =>
+  await queryClient.fetchQuery({
+    queryKey: queryKey(),
+    queryFn: async () => {
+      const result = await fetchWeather();
+      return result;
+    },
+  });
 
 const toArray = (elements: HTMLCollection) => Array.prototype.slice.call(elements);
 
@@ -361,6 +370,6 @@ export const fetchWeather = async () => {
 
 export default {
   queryKey,
-  fetch: fetchWeather,
   prefetch: prefetchWeather,
+  fetchQuery: fetchWeatherQuery,
 };


### PR DESCRIPTION
Realized that our singular hooks (`useAvalancheForecastFragment`, `useLatestWeatherForecast`) would never raise an error if the plural hook (`useAvalancheForecastFragments`, `useLatestWeatherForecasts`) failed.

Your first question is going to be "can't you just take the `isError` etc" off the plural hook and return it from the singular hook, and you theoretically *can* but it's super-messy. The return value from useQuery has ~30 fields and a few different states that have to be managed, and the mapping of the singular result (e.g. `UseQueryType<Product, Error>`) to the plural result (e.g. `UseQueryType<Product[] | undefined, AxiosError | ZodError>`) isn't clean.

This way, we await the result of the first query, and if it fails then the error is automatically bubbled up. It's very similar to what we do for prefetching queries.