### PR TITLE
Fix display dates for avalanche danger tables

### DIFF
--- a/components/forecast/AvalancheTab.tsx
+++ b/components/forecast/AvalancheTab.tsx
@@ -92,10 +92,10 @@ export const AvalancheTab: React.FunctionComponent<AvalancheTabProps> = React.me
         <HTML source={{html: forecast.bottom_line}} />
       </Card>
       <Card borderRadius={0} borderColor="white" header={<HeaderWithTooltip title="Avalanche Danger" content={helpStrings.avalancheDanger} />}>
-        <AvalancheDangerTable date={forecast.published_time} forecast={currentDanger} elevation_band_names={elevationBandNames} size={'main'} />
+        <AvalancheDangerTable date={addDays(forecast.published_time, 1)} forecast={currentDanger} elevation_band_names={elevationBandNames} size={'main'} />
       </Card>
       <CollapsibleCard startsCollapsed borderRadius={0} borderColor="white" header={<HeaderWithTooltip title="Outlook" content={helpStrings.avalancheDangerOutlook} />}>
-        <AvalancheDangerTable date={addDays(forecast.published_time, 1)} forecast={outlookDanger} elevation_band_names={elevationBandNames} size={'outlook'} />
+        <AvalancheDangerTable date={addDays(forecast.published_time, 2)} forecast={outlookDanger} elevation_band_names={elevationBandNames} size={'outlook'} />
       </CollapsibleCard>
       {forecast.forecast_avalanche_problems.map((problem, index) => (
         <CollapsibleCard


### PR DESCRIPTION
A forecast published on Sunday should show forecast danger for Monday and Tuesday, not for Sunday and Monday

<img width="343" alt="image" src="https://user-images.githubusercontent.com/101196/215603032-20dce9ca-0634-422a-855a-8f7e5cd7a7ae.png">
