### PR TITLE
Weather station list in weather forecast tab

### DIFF
--- a/components/helpers/geographicCoordinates.test.ts
+++ b/components/helpers/geographicCoordinates.test.ts
@@ -1,7 +1,7 @@
 // useAvalancheForecastFragments pulls in Sentry, which makes Jest blow up
 jest.mock('@sentry/react-native', () => ({init: () => jest.fn()}));
 
-import {updateBoundsToContain, RegionBounds, regionFromBounds} from 'components/helpers/geographicCoordinates';
+import {updateBoundsToContain, RegionBounds, regionFromBounds, boundsForRegions} from 'components/helpers/geographicCoordinates';
 import {LatLng} from 'react-native-maps';
 
 describe('AvalancheForecastZonePolygon', () => {
@@ -93,6 +93,25 @@ describe('AvalancheForecastZonePolygon', () => {
         longitude: 1,
         latitudeDelta: 2,
         longitudeDelta: 2,
+      });
+    });
+  });
+
+  describe('boundsForRegions', () => {
+    it('calculates the total bounding box for multiple regions', () => {
+      const regions = [
+        {
+          topLeft: {latitude: 20, longitude: -100},
+          bottomRight: {latitude: 10, longitude: -50},
+        },
+        {
+          topLeft: {latitude: 40, longitude: -110},
+          bottomRight: {latitude: 15, longitude: -75},
+        },
+      ];
+      expect(boundsForRegions(regions)).toStrictEqual({
+        topLeft: {latitude: 40, longitude: -110},
+        bottomRight: {latitude: 10, longitude: -50},
       });
     });
   });

--- a/hooks/useAvalancheCenterMetadata.ts
+++ b/hooks/useAvalancheCenterMetadata.ts
@@ -38,7 +38,16 @@ export const prefetchAvalancheCenterMetadata = async (queryClient: QueryClient, 
   Log.prefetch('avalanche center metadata is cached with react-query');
 };
 
-export const fetchAvalancheCenterMetadata = async (nationalAvalancheCenterHost: string, center_id: AvalancheCenterID) => {
+export const fetchAvalancheCenterMetadataQuery = async (queryClient: QueryClient, nationalAvalancheCenterHost: string, center_id: AvalancheCenterID) =>
+  await queryClient.fetchQuery({
+    queryKey: queryKey(nationalAvalancheCenterHost, center_id),
+    queryFn: async () => {
+      const result = await fetchAvalancheCenterMetadata(nationalAvalancheCenterHost, center_id);
+      return result;
+    },
+  });
+
+const fetchAvalancheCenterMetadata = async (nationalAvalancheCenterHost: string, center_id: AvalancheCenterID) => {
   const url = `${nationalAvalancheCenterHost}/v2/public/avalanche-center/${center_id}`;
   const {data} = await axios.get(url);
 
@@ -60,6 +69,6 @@ export const fetchAvalancheCenterMetadata = async (nationalAvalancheCenterHost: 
 
 export default {
   queryKey,
-  fetch: fetchAvalancheCenterMetadata,
+  fetchQuery: fetchAvalancheCenterMetadataQuery,
   prefetch: prefetchAvalancheCenterMetadata,
 };

--- a/hooks/useMapLayer.ts
+++ b/hooks/useMapLayer.ts
@@ -38,7 +38,16 @@ export const prefetchMapLayer = async (queryClient: QueryClient, nationalAvalanc
   Log.prefetch('avalanche center map layer is cached with react-query');
 };
 
-export const fetchMapLayer = async (nationalAvalancheCenterHost: string, center_id: AvalancheCenterID) => {
+const fetchMapLayerQuery = async (queryClient: QueryClient, nationalAvalancheCenterHost: string, center_id: AvalancheCenterID) =>
+  await queryClient.fetchQuery({
+    queryKey: queryKey(nationalAvalancheCenterHost, center_id),
+    queryFn: async () => {
+      const result = await fetchMapLayer(nationalAvalancheCenterHost, center_id);
+      return result;
+    },
+  });
+
+const fetchMapLayer = async (nationalAvalancheCenterHost: string, center_id: AvalancheCenterID) => {
   const url = `${nationalAvalancheCenterHost}/v2/public/products/map-layer/${center_id}`;
   const {data} = await axios.get(url);
 
@@ -60,6 +69,6 @@ export const fetchMapLayer = async (nationalAvalancheCenterHost: string, center_
 
 export default {
   queryKey,
-  fetch: fetchMapLayer,
+  fetchQuery: fetchMapLayerQuery,
   prefetch: prefetchMapLayer,
 };

--- a/hooks/useWeatherStations.ts
+++ b/hooks/useWeatherStations.ts
@@ -41,7 +41,7 @@ const stationGroupMapping = {
   'Mount Rainier - Paradise': ['35', '36'],
   'Mount Rainier - Camp Muir': ['34'],
   'Chinook Pass': ['32', '33'],
-  'White Pass': ['37', '39'],
+  'White Pass': ['37', '39', '49'],
   'Mt St Helens': ['40'],
 
   // West Central
@@ -63,9 +63,7 @@ const stationGroupMapping = {
   'Mt. Hood Meadows Cascade Express': ['41'],
 };
 
-// TODO
 const decommissionedStations = [
-  '49', // White Pass - Pigtail Peak
   '15', // Stevens Pass - Brooks Wind (Retired 2019)
 ];
 

--- a/hooks/useWeatherStations.ts
+++ b/hooks/useWeatherStations.ts
@@ -1,0 +1,131 @@
+import {useContext} from 'react';
+
+import {useQuery, useQueryClient} from 'react-query';
+
+import {ClientContext, ClientProps} from 'clientContext';
+import {ApiError, OpenAPI, StationMetadata, StationMetadataService} from 'types/generated/snowbound';
+import {AvalancheCenterID, Feature} from 'types/nationalAvalancheCenter';
+import AvalancheCenterMetadata from 'hooks/useAvalancheCenterMetadata';
+import MapLayer from 'hooks/useMapLayer';
+import {boundsForRegions, featureBounds, pointInFeature} from 'components/helpers/geographicCoordinates';
+
+type Source = 'nwac' | 'snotel' | 'mesowest';
+
+interface Props {
+  center: AvalancheCenterID;
+  sources: Source[];
+}
+
+interface ZoneResult {
+  zoneId: number;
+  name: string;
+  stationGroups: Record<string, StationMetadata[]>;
+}
+
+const stationGroupMapping = {
+  // Snoqualmie Pass
+  'Alpental Ski Area': ['1', '2', '3'],
+  'Snoqualmie Pass': ['21', '22', '23'],
+
+  // Stevens Pass
+  'Stevens Pass Ski Area - Tye Mill Chair, Skyline Chair': ['17', '18'],
+  'Stevens Pass - WSDOT Schmidt Haus': ['13'],
+  'Grace Lakes & Old Faithful': ['14', '51'],
+  'Stevens Pass Ski Area - Brooks Chair': ['50'],
+
+  // West South
+  'Crystal Mt Ski Area': ['28', '29'],
+  'Crystal Mt. - Green Valley & Campbell Basin': ['27', '54'],
+  'Mt Baker Ski Area': ['5', '6'],
+  'Mount Rainier - Sunrise': ['30', '31'],
+  'Mount Rainier - Paradise': ['35', '36'],
+  'Mount Rainier - Camp Muir': ['34'],
+  'Chinook Pass': ['32', '33'],
+  'White Pass': ['37', '39'],
+  'Mt St Helens': ['40'],
+
+  // West Central
+  'White Chuck': ['57'],
+
+  // East Central
+  'Mission Ridge Ski Area': ['24', '25', '26'],
+  'Tumwater Mt. & Leavenworth': ['19', '53'],
+  'Dirtyface Mt': ['10'],
+
+  // East North
+  'Washington Pass': ['8', '9'],
+
+  // Mt Hood
+  'Skibowl Ski Area - Government Camp': ['46', '47'],
+  'Timberline Lodge': ['44', '56'],
+  'Timberline Ski Area - Magic Mile Chair': ['45'],
+  'Mt Hood Meadows Ski Area': ['42', '43'],
+  'Mt. Hood Meadows Cascade Express': ['41'],
+};
+
+// TODO
+const decommissionedStations = [
+  '49', // White Pass - Pigtail Peak
+  '15', // Stevens Pass - Brooks Wind (Retired 2019)
+];
+
+export const useWeatherStations = ({center, sources}: Props) => {
+  if (center !== 'NWAC') {
+    throw new Error(`can't fetch weather for ${center}: useWeatherStations hook only supports NWAC`);
+  }
+
+  const queryClient = useQueryClient();
+  const clientProps = useContext<ClientProps>(ClientContext);
+  const sourceString = sources.join(',');
+
+  return useQuery<ZoneResult[], ApiError | Error>(
+    ['stations', sourceString],
+    async () => {
+      // Get the snowbound API token for the center
+      const metadata = await AvalancheCenterMetadata.fetchQuery(queryClient, clientProps.nationalAvalancheCenterHost, center);
+      const token = metadata.widget_config.stations.token;
+
+      // get list of zones for the center
+      const mapLayer = await MapLayer.fetchQuery(queryClient, clientProps.nationalAvalancheCenterHost, center);
+      const mapLayerZones: Feature[] = mapLayer.features;
+      const dataByZone = mapLayerZones.map(f => ({feature: f, bounds: featureBounds(f), stationGroups: {}}));
+
+      // get the overall bounding box for the center
+      const centerBounds = boundsForRegions(Object.values(dataByZone).map(v => v.bounds));
+
+      OpenAPI.BASE = clientProps.snowboundHost;
+      const stations: StationMetadata[] = await StationMetadataService.readStationMetadataWxV1StationMetadataGet({
+        source: sourceString,
+        token,
+        limit: 250,
+        // bbox: Bounding box, comma separated list from lower left to upper right. For example, '-116,45,-115,47'
+        bbox: [centerBounds.topLeft.longitude, centerBounds.bottomRight.latitude, centerBounds.bottomRight.longitude, centerBounds.topLeft.latitude].map(x => String(x)).join(','),
+      });
+
+      // Take the list of returned stations, and figure out which zone in the center they belong to
+      stations
+        .filter(s => !decommissionedStations.includes(s.stid))
+        .forEach(s => {
+          const {lat: latitude, lng: longitude} = s.coordinates;
+          const matchingZones = dataByZone.filter(zoneData => pointInFeature({latitude, longitude}, zoneData.feature));
+          if (matchingZones.length === 0) {
+            console.warn(`Unable to find matching zone for weather station ${s.id}, ${s.name}, ${s.coordinates}`);
+          } else if (matchingZones.length > 1) {
+            console.warn(`Found multiple matching zones for weather station ${s.id}, ${s.name}, ${s.coordinates}: ${matchingZones.map(z => z.feature.properties.name).join(',')}`);
+          } else {
+            // Mapped station to a single zone. Now, should it appear in the UI as part of a group?
+            const groupMapping = Object.entries(stationGroupMapping).find(([_name, stids]) => stids.includes(s.stid));
+            const name = groupMapping ? groupMapping[0] : s.name;
+            matchingZones[0].stationGroups[name] = matchingZones[0].stationGroups[name] || [];
+            matchingZones[0].stationGroups[name].push(s);
+          }
+        });
+
+      return dataByZone.map(dz => ({zoneId: dz.feature.id, name: dz.feature.properties.name, stationGroups: dz.stationGroups}));
+    },
+    {
+      staleTime: 24 * 60 * 60 * 1000, // don't bother re-fetching for one day (in milliseconds)
+      cacheTime: Infinity, // hold on to this cached data forever
+    },
+  );
+};

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   "jest": {
     "preset": "jest-expo",
     "transformIgnorePatterns": [
-      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)"
+      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|d3(-?[a-z]+)?|internmap)"
     ],
     "setupFilesAfterEnv": [
       "@testing-library/jest-native/extend-expect"

--- a/types/nationalAvalancheCenter/schemas.ts
+++ b/types/nationalAvalancheCenter/schemas.ts
@@ -49,14 +49,24 @@ export const dangerLevelSchema = z.nativeEnum(DangerLevel);
 // coordinates encodes a list of points, each as a two-member array [longitude,latitude]
 // for a type=Polygon, this a three-dimensional array number[][][]
 // for a type=MultiPolygon, this a four-dimensional array number[][][][]
+// See https://stevage.github.io/geojson-spec/#section-3.1.6 for the definition of Polygon/MultiPolygon
+const point = z.number().array().length(2);
+const lineString = point.array().min(4);
+const polygon = lineString.array().min(1);
+const multiPolygon = polygon.array().min(1);
+export type Point = z.infer<typeof point>;
+export type LineString = z.infer<typeof lineString>;
+export type Polygon = z.infer<typeof polygon>;
+export type MultiPolygon = z.infer<typeof multiPolygon>;
+
 export const polygonSchema = z.object({
   type: z.literal('Polygon'),
-  coordinates: z.array(z.array(z.array(z.number()))),
+  coordinates: polygon,
 });
 
 export const multiPolygonSchema = z.object({
   type: z.literal('MultiPolygon'),
-  coordinates: z.array(z.array(z.array(z.array(z.number())))),
+  coordinates: multiPolygon,
 });
 
 export const featureComponentSchema = z.union([polygonSchema, multiPolygonSchema]);


### PR DESCRIPTION
This PR adds the list of weather stations to the end of the weather forecast. Like the overall weather forecast, this has only been tested with NWAC data and may need more work to function for other avalanche centers.

The flow in `useWeatherStations` is as follows:
- take the input avalanche center
- get the overall bounding box for all zones in the center
- ask Snowbound for all weather stations in the center's bounding box
- take the list of weather stations and break it down by zone, by testing station location against the zone polygon boundary
- apply any additional grouping to the weather stations, if defined (only defined for NWAC)
- return the map of zone => weather station groups

## screenshots

loading state | error state | loaded state
--- | --- | ---
![image](https://user-images.githubusercontent.com/101196/215836384-04dfa3a8-d1b4-4984-9d80-4ea70eec0fe1.png) | ![image](https://user-images.githubusercontent.com/101196/215836412-8cd50210-ed82-4ca6-83e7-74e5c8b9b931.png) | ![i](https://user-images.githubusercontent.com/101196/215836594-643037b5-00c2-4fbd-8c8e-75d67936b49f.png)
