### PR TITLE
Allow the subsection header text to flex

### DIFF
--- a/components/forecast/WeatherTab.tsx
+++ b/components/forecast/WeatherTab.tsx
@@ -35,7 +35,7 @@ const SmallHeaderWithTooltip = ({title, content, dialogTitle}) => (
   // the icon style is designed to make the circle "i" look natural next to the
   // text - neither `center` nor `baseline` alignment look good on their own
   <HStack space={6} alignItems="center">
-    <BodySemibold>{title}</BodySemibold>
+    <BodySemibold style={{flex: 1}}>{title}</BodySemibold>
     <InfoTooltip size={bodySize} title={dialogTitle || title} content={content} style={{paddingBottom: 0, paddingTop: 1}} />
   </HStack>
 );


### PR DESCRIPTION
Bug reported by @yuliadub in Slack. Repros on iPhone 11 when setting dynamic text size to 110%.

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/101196/216713923-c3379448-73e3-4b6a-b4b7-ba14bea5d14d.png) | ![image](https://user-images.githubusercontent.com/101196/216713950-7ecb7d9f-28d5-4cca-8de7-afc7a50ce00b.png)


