### PR TITLE
Create common setup action

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -1,0 +1,31 @@
+name: 'setup'
+description: 'Check out the repo, install node, Expo, node_modules'
+inputs:
+  install_expo:
+    required: false
+    default: false
+    type: boolean
+    description: 'Run the expo install action'
+  expo_token:
+    required: false
+    type: string
+    description: 'The Expo auth token'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 🏗 Setup Node
+      uses: actions/setup-node@v2
+      with:
+        node-version: 16.x
+        cache: yarn
+    - name: 🏗 Setup Expo
+      uses: expo/expo-github-action@v7
+      if: inputs.install_expo && inputs.EXPO_TOKEN != ''
+      with:
+        expo-version: latest
+        eas-version: latest
+        token: ${{ inputs.EXPO_TOKEN }}
+    - name: 📦 Install dependencies
+      run: yarn install
+      shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,16 +12,8 @@ jobs:
     steps:
       - name: 🏗 Setup repo
         uses: actions/checkout@v2
-
-      - name: 🏗 Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 16.x
-          cache: yarn
-
-      - name: 📦 Install dependencies
-        run: yarn install
-
+      - name: 🏗 Setup build environment
+        uses: ./.github/actions/setup
       - name: 🎨 Run prettier
         run: yarn ci:prettier
 
@@ -31,16 +23,8 @@ jobs:
     steps:
       - name: 🏗 Setup repo
         uses: actions/checkout@v2
-
-      - name: 🏗 Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 16.x
-          cache: yarn
-
-      - name: 📦 Install dependencies
-        run: yarn install
-
+      - name: 🏗 Setup build environment
+        uses: ./.github/actions/setup
       - name: 🧹 Run eslint
         run: yarn ci:eslint
 
@@ -50,16 +34,8 @@ jobs:
     steps:
       - name: 🏗 Setup repo
         uses: actions/checkout@v2
-
-      - name: 🏗 Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 16.x
-          cache: yarn
-
-      - name: 📦 Install dependencies
-        run: yarn install
-
+      - name: 🏗 Setup build environment
+        uses: ./.github/actions/setup
       - name: 🎨 Run typescript compiler (tsc)
         run: yarn ci:tsc
 
@@ -69,15 +45,7 @@ jobs:
     steps:
       - name: 🏗 Setup repo
         uses: actions/checkout@v2
-
-      - name: 🏗 Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 16.x
-          cache: yarn
-
-      - name: 📦 Install dependencies
-        run: yarn install
-
+      - name: 🏗 Setup build environment
+        uses: ./.github/actions/setup
       - name: 🕵️‍♀️  Run tests
         run: yarn test

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -23,21 +23,11 @@ jobs:
       - name: 🏗 Setup repo
         uses: actions/checkout@v2
 
-      - name: 🏗 Setup Node
-        uses: actions/setup-node@v2
+      - name: 🏗 Setup build environment
+        uses: ./.github/actions/setup
         with:
-          node-version: 16.x
-          cache: yarn
-
-      - name: 🏗 Setup Expo
-        uses: expo/expo-github-action@v7
-        with:
-          expo-version: latest
-          eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
-
-      - name: 📦 Install dependencies
-        run: yarn install
+          install_expo: true
+          expo_token: ${{ secrets.EXPO_TOKEN }}
 
       - name: 🚀 Publish preview
         id: eas-update

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,21 +20,11 @@ jobs:
       - name: 🏗 Setup repo
         uses: actions/checkout@v2
 
-      - name: 🏗 Setup Node
-        uses: actions/setup-node@v2
+      - name: 🏗 Setup build environment
+        uses: ./.github/actions/setup
         with:
-          node-version: 16.x
-          cache: yarn
-
-      - name: 🏗 Setup Expo and EAS
-        uses: expo/expo-github-action@v7
-        with:
-          expo-version: latest
-          eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
-
-      - name: 📦 Install dependencies
-        run: yarn install
+          install_expo: true
+          expo_token: ${{ secrets.EXPO_TOKEN }}
 
       - name: 🚀 Publish update bundle
         shell: bash
@@ -48,21 +38,11 @@ jobs:
       - name: 🏗 Setup repo
         uses: actions/checkout@v2
 
-      - name: 🏗 Setup Node
-        uses: actions/setup-node@v2
+      - name: 🏗 Setup build environment
+        uses: ./.github/actions/setup
         with:
-          node-version: 16.x
-          cache: yarn
-
-      - name: 🏗 Setup Expo and EAS
-        uses: expo/expo-github-action@v7
-        with:
-          expo-version: latest
-          eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
-
-      - name: 📦 Install dependencies
-        run: yarn install
+          install_expo: true
+          expo_token: ${{ secrets.EXPO_TOKEN }}
 
       - name: 🚀 Build Android app
         run: eas build --non-interactive --platform android --profile preview
@@ -77,21 +57,11 @@ jobs:
       - name: 🏗 Setup repo
         uses: actions/checkout@v2
 
-      - name: 🏗 Setup Node
-        uses: actions/setup-node@v2
+      - name: 🏗 Setup build environment
+        uses: ./.github/actions/setup
         with:
-          node-version: 16.x
-          cache: yarn
-
-      - name: 🏗 Setup Expo and EAS
-        uses: expo/expo-github-action@v7
-        with:
-          expo-version: latest
-          eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
-
-      - name: 📦 Install dependencies
-        run: yarn install
+          install_expo: true
+          expo_token: ${{ secrets.EXPO_TOKEN }}
 
       - name: 🚀 Build iOS app
         run: eas build --non-interactive --platform ios --profile preview


### PR DESCRIPTION
This extracts the "install Node - maybe install Expo - run `yarn install`" dance into a single reusable action, and updates the existing workflows to use it. 

Doesn't fix anything broken, doesn't break anything new. Just trying to get a better understanding of how to extract common code!