### PR TITLE
Weather tab style

### DIFF
--- a/components/forecast/WeatherTab.tsx
+++ b/components/forecast/WeatherTab.tsx
@@ -1,7 +1,7 @@
 import {Card, CollapsibleCard} from 'components/content/Card';
 import {Center, HStack, View, VStack} from 'components/core';
 import {useLatestWeatherForecast} from 'hooks/useLatestWeatherForecast';
-import {AllCapsSm, AllCapsSmBlack, Body, BodyBlack, BodySemibold, bodySize, Title3Black} from 'components/text';
+import {AllCapsSm, AllCapsSmBlack, Body, BodyBlack, BodyXSmBlack, bodyXSmSize, Title3Black} from 'components/text';
 import {HTML} from 'components/text/HTML';
 import {ActivityIndicator, StyleSheet} from 'react-native';
 import {colorLookup} from 'theme';
@@ -35,8 +35,8 @@ const SmallHeaderWithTooltip = ({title, content, dialogTitle}) => (
   // the icon style is designed to make the circle "i" look natural next to the
   // text - neither `center` nor `baseline` alignment look good on their own
   <HStack space={6} alignItems="center">
-    <BodySemibold style={{flex: 1}}>{title}</BodySemibold>
-    <InfoTooltip size={bodySize} title={dialogTitle || title} content={content} style={{paddingBottom: 0, paddingTop: 1}} />
+    <BodyXSmBlack style={{flex: 1}}>{title}</BodyXSmBlack>
+    <InfoTooltip size={bodyXSmSize} title={dialogTitle || title} content={content} style={{paddingBottom: 0, paddingTop: 1}} />
   </HStack>
 );
 
@@ -94,45 +94,49 @@ export const WeatherTab: React.FC<WeatherTabProps> = ({zone, center_id, date}) =
               <VStack space={2} key={index} py={12} borderBottomWidth={1} borderColor={index === 0 ? colorLookup('light.200') : 'white'}>
                 <BodyBlack>{forecast.label}</BodyBlack>
                 <Body>{forecast.forecast}</Body>
-                <HStack justifyContent="space-between" alignItems="flex-start" pt={12} space={12}>
-                  <VStack flexBasis={0.5} flex={1}>
-                    <SmallHeaderWithTooltip title="5K ft Temps (°F)" dialogTitle="Temperature" content={helpStrings.weather.temperature} />
-                    <Body>
-                      {forecast.temperatures.high} (max) / {forecast.temperatures.low} (min)
-                    </Body>
-                  </VStack>
-                  <VStack flexBasis={0.5} flex={1}>
-                    <SmallHeaderWithTooltip title="Snow Level (ft)" dialogTitle="Snow Level" content={helpStrings.weather.snowLevelNoAsterisk} />
-                    {forecast.snowLevel.map(level => (
-                      <Body key={level.subperiod}>
-                        {Intl.NumberFormat().format(level.level)} {timeOfDayString(level.period, level.subperiod)}
+                <View borderWidth={1} borderColor={colorLookup('light.200')} mt={12}>
+                  <HStack justifyContent="space-between" alignItems="stretch" borderBottomWidth={1} borderColor={colorLookup('light.200')}>
+                    <VStack flexBasis={0.5} flex={1} m={12}>
+                      <SmallHeaderWithTooltip title="5K ft Temps (°F)" dialogTitle="Temperature" content={helpStrings.weather.temperature} />
+                      <Body>
+                        {forecast.temperatures.high} (max) / {forecast.temperatures.low} (min)
                       </Body>
-                    ))}
-                  </VStack>
-                </HStack>
-                <HStack justifyContent="space-between" alignItems="flex-start" pt={12} space={12}>
-                  <VStack flexBasis={0.5} flex={1}>
-                    <SmallHeaderWithTooltip title="Precipitation (in)" dialogTitle="Precipitation" content={helpStrings.weather.precipitation} />
-                    {Object.entries(forecast.precipitation).map(([zone, value]) => (
-                      <HStack key={zone} justifyContent="space-between" alignItems="flex-start" alignSelf="stretch">
-                        <View flex={1} flexGrow={2} pr={12}>
-                          <Body style={{flex: 1, flexBasis: 0.75}}>{zone}</Body>
-                        </View>
-                        <View flex={1} flexGrow={1}>
-                          <Body>{value}</Body>
-                        </View>
-                      </HStack>
-                    ))}
-                  </VStack>
-                  <VStack flexBasis={0.5} flex={1}>
-                    <SmallHeaderWithTooltip title="Ridgeline Winds (mph)" dialogTitle="Ridgeline Winds" content={helpStrings.weather.wind} />
-                    {forecast.winds.map(level => (
-                      <Body key={level.subperiod}>
-                        {level.speed} {timeOfDayString(level.period, level.subperiod)}
-                      </Body>
-                    ))}
-                  </VStack>
-                </HStack>
+                    </VStack>
+                    <View width={1} height="100%" bg={colorLookup('light.200')} flex={0} />
+                    <VStack flexBasis={0.5} flex={1} m={12}>
+                      <SmallHeaderWithTooltip title="Snow Level (ft)" dialogTitle="Snow Level" content={helpStrings.weather.snowLevelNoAsterisk} />
+                      {forecast.snowLevel.map(level => (
+                        <Body key={level.subperiod}>
+                          {Intl.NumberFormat().format(level.level)} {timeOfDayString(level.period, level.subperiod)}
+                        </Body>
+                      ))}
+                    </VStack>
+                  </HStack>
+                  <HStack justifyContent="space-between" alignItems="flex-start">
+                    <VStack flexBasis={0.5} flex={1} m={12}>
+                      <SmallHeaderWithTooltip title="Precipitation (in)" dialogTitle="Precipitation" content={helpStrings.weather.precipitation} />
+                      {Object.entries(forecast.precipitation).map(([zone, value]) => (
+                        <HStack key={zone} justifyContent="space-between" alignItems="flex-start" alignSelf="stretch">
+                          <View flex={1} flexGrow={2} pr={12}>
+                            <Body style={{flex: 1, flexBasis: 0.75}}>{zone}</Body>
+                          </View>
+                          <View flex={1} flexGrow={1}>
+                            <Body textAlign="right">{value}</Body>
+                          </View>
+                        </HStack>
+                      ))}
+                    </VStack>
+                    <View width={1} height="100%" bg={colorLookup('light.200')} flex={0} />
+                    <VStack flexBasis={0.5} flex={1} m={12}>
+                      <SmallHeaderWithTooltip title="Ridgeline Winds (mph)" dialogTitle="Ridgeline Winds" content={helpStrings.weather.wind} />
+                      {forecast.winds.map(level => (
+                        <Body key={level.subperiod}>
+                          {level.speed} {timeOfDayString(level.period, level.subperiod)}
+                        </Body>
+                      ))}
+                    </VStack>
+                  </HStack>
+                </View>
               </VStack>
             );
           })}

--- a/components/text/index.tsx
+++ b/components/text/index.tsx
@@ -61,8 +61,9 @@ export const BodySm: React.FunctionComponent<TextWrapperProps> = props => (
 export const BodySmSemibold: React.FunctionComponent<TextWrapperProps> = props => <BodySm fontFamily="Lato_700Bold" {...props} />;
 export const BodySmBlack: React.FunctionComponent<TextWrapperProps> = props => <BodySm fontFamily="Lato_900Black" {...props} />;
 
+export const bodyXSmSize = 12;
 export const BodyXSm: React.FunctionComponent<TextWrapperProps> = props => (
-  <TextWrapper fontSize={12} lineHeight={18} fontFamily="Lato_400Regular" letterSpacing={-0.31} {...props} />
+  <TextWrapper fontSize={bodyXSmSize} lineHeight={18} fontFamily="Lato_400Regular" letterSpacing={-0.31} {...props} />
 );
 export const BodyXSmMedium: React.FunctionComponent<TextWrapperProps> = props => <BodyXSm fontFamily="Lato_400Regular" {...props} />;
 export const BodyXSmBlack: React.FunctionComponent<TextWrapperProps> = props => <BodyXSm fontFamily="Lato_900Black" {...props} />;

--- a/components/weather_data/WeatherStationDetail.tsx
+++ b/components/weather_data/WeatherStationDetail.tsx
@@ -61,7 +61,7 @@ const shortFieldMap = {
   equip_temperature: 'EqTemp',
   snow_depth_24h: '24Sno',
   intermittent_snow: 'intermittent_snow',
-  net_solar: 'net_solar',
+  net_solar: 'SR',
   solar_radiation: 'SR',
 };
 
@@ -95,6 +95,10 @@ const TimeSeriesTable: React.FC<{timeSeries: TimeSeries}> = ({timeSeries}) => {
       }
       if (values.findIndex(v => v !== null) === -1) {
         // skip empty columns: when all values are null
+        return;
+      }
+      if (field === 'solar_radiation') {
+        // we don't display solar_radiation, only net_solar
         return;
       }
       const columnIndex = tableColumns.push({field, elevation}) - 1;

--- a/components/weather_data/WeatherStationDetail.tsx
+++ b/components/weather_data/WeatherStationDetail.tsx
@@ -111,8 +111,8 @@ const TimeSeriesTable: React.FC<{timeSeries: TimeSeries}> = ({timeSeries}) => {
   });
 
   // With the columns we have, what should the preferred ordering be?
-  const sortedColumns = range(tableColumns.length);
-  sortedColumns.sort((a, b) => {
+  const sortedColIndices = range(tableColumns.length);
+  sortedColIndices.sort((a, b) => {
     // Column sorting rules:
     // 1. time first
     // 2. preferred column sort after that
@@ -131,7 +131,7 @@ const TimeSeriesTable: React.FC<{timeSeries: TimeSeries}> = ({timeSeries}) => {
   });
 
   // With the rows we have, what should the preferred ordering be?
-  const sortedRows = range(tableRows.length - 1, -1, -1); // descending by time
+  const sortedRowIndices = range(tableRows.length - 1, -1, -1); // descending by time
 
   const columnPadding = 3;
   const rowPadding = 2;
@@ -140,7 +140,7 @@ const TimeSeriesTable: React.FC<{timeSeries: TimeSeries}> = ({timeSeries}) => {
     <ScrollView>
       <ScrollView horizontal>
         <HStack padding={8} justifyContent="space-between" alignItems="center" bg="white">
-          {sortedColumns
+          {sortedColIndices
             .map(i => ({...tableColumns[i], columnIndex: i}))
             .map(({field, elevation, columnIndex}) => (
               <VStack key={columnIndex} justifyContent="flex-start" alignItems="stretch">
@@ -149,7 +149,7 @@ const TimeSeriesTable: React.FC<{timeSeries: TimeSeries}> = ({timeSeries}) => {
                   <BodyXSmBlack>{field === 'date_time' ? 'PST' : shortUnits(timeSeries.UNITS[field])}</BodyXSmBlack>
                   <BodyXSmBlack>{field !== 'date_time' ? `${elevation}'` : ' '}</BodyXSmBlack>
                 </VStack>
-                {sortedRows
+                {sortedRowIndices
                   .map(i => tableRows[i])
                   .map((row, index) => (
                     <Center flex={1} key={index} bg={colorLookup(index % 2 ? 'light.100' : 'light.300')} py={rowPadding} px={columnPadding}>


### PR DESCRIPTION
Change weather tab detail to reflect Kaitlin's latest changes. Looks like a big change, but only because a new View got added to the hierarchy - view the diff with whitespace changes ignored. 

Also, some _very_ light refactoring on the weather data table.

![image](https://user-images.githubusercontent.com/101196/217058191-44c2ca79-8dac-4c40-83cc-a43693b6499b.png)
