### PR TITLE
*: pass around actual date-times, not dates

### DIFF
--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -27,7 +27,7 @@ import {HomeStackNavigationProps} from 'routes';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {Body, BodySmSemibold, Caption1, Caption1Black, Title3Black} from 'components/text';
 import {colorFor} from './AvalancheDangerPyramid';
-import {apiDateString, utcDateToLocalTimeString} from 'utils/date';
+import {toISOStringUTC, utcDateToLocalTimeString} from 'utils/date';
 import {TravelAdvice} from './helpers/travelAdvice';
 import {COLORS} from 'theme/colors';
 import {FontAwesome5} from '@expo/vector-icons';
@@ -54,7 +54,7 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
           zoneName: zone.name,
           center_id: zone.center_id,
           forecast_zone_id: zone.zone_id,
-          dateString: apiDateString(date),
+          dateString: toISOStringUTC(date),
         });
       } else {
         setSelectedZone(zone);
@@ -465,7 +465,7 @@ const AvalancheForecastZoneCard: React.FunctionComponent<{
           zoneName: zone.name,
           center_id: zone.center_id,
           forecast_zone_id: zone.zone_id,
-          dateString: apiDateString(date),
+          dateString: toISOStringUTC(date),
         });
       }}>
       <VStack borderRadius={8} bg="white" width={width * CARD_WIDTH} mx={CARD_MARGIN * width} height={200}>

--- a/components/TelemetryStationMap.tsx
+++ b/components/TelemetryStationMap.tsx
@@ -10,7 +10,7 @@ import {CARD_MARGIN, CARD_SPACING, CARD_WIDTH} from './AvalancheForecastZoneMap'
 import {useNavigation} from '@react-navigation/native';
 import {TelemetryStackNavigationProps} from 'routes';
 import {AvalancheCenterID} from '../types/nationalAvalancheCenter';
-import {apiDateString} from 'utils/date';
+import {toISOStringUTC} from 'utils/date';
 import {regionFromBounds, updateBoundsToContain} from './helpers/geographicCoordinates';
 
 export const TelemetryStationMap: React.FunctionComponent<{
@@ -153,7 +153,7 @@ export const TelemetryStationCard: React.FunctionComponent<{
           source: station.source,
           station_id: station.stid,
           name: station.name,
-          dateString: apiDateString(date),
+          dateString: toISOStringUTC(date),
         });
       }}
       style={{

--- a/components/forecast/AvalancheForecast.tsx
+++ b/components/forecast/AvalancheForecast.tsx
@@ -2,10 +2,10 @@ import React, {useCallback, useEffect} from 'react';
 
 import {uniq} from 'lodash';
 
-import {ActivityIndicator, Alert, RefreshControl, ScrollView, StyleSheet, TouchableOpacity} from 'react-native';
+import {ActivityIndicator, RefreshControl, ScrollView, StyleSheet, TouchableOpacity} from 'react-native';
 import {useNavigation} from '@react-navigation/native';
 
-import {HStack, View} from 'components/core';
+import {HStack, View, VStack} from 'components/core';
 
 import {AvalancheCenterID, AvalancheForecastZone, AvalancheForecastZoneSummary} from 'types/nationalAvalancheCenter';
 import {Tab, TabControl} from 'components/TabControl';
@@ -79,31 +79,61 @@ export const AvalancheForecast: React.FunctionComponent<AvalancheForecastProps> 
     navigation.popToTop();
   }, [navigation]);
 
-  if (isForecastLoading || isCenterLoading || !center || !forecast) {
-    return <ActivityIndicator />;
-  }
-  if (isForecastError || isCenterError) {
+  if (isForecastLoading || isCenterLoading) {
     return (
-      <View>
-        {isCenterError && <Body>{`Could not fetch ${center_id} properties: ${centerError?.message}.`}</Body>}
-        {isForecastError && <Body>{`Could not fetch forecast for ${center_id} zone ${forecast_zone_id}: ${forecastError?.message}.`}</Body>}
-        {/* TODO(brian): we should add a "Try again" button and have that invoke `refetchByUser` */}
-      </View>
+      <HStack space={8} style={{flex: 1}}>
+        <VStack space={8} style={{flex: 1}} alignItems={'center'}>
+          <Body>
+            Loading current {center_id} avalanche forecast for zone {forecast_zone_id}...
+          </Body>
+          <ActivityIndicator />
+        </VStack>
+      </HStack>
+    );
+  }
+  if (!center) {
+    return (
+      <HStack space={8} style={{flex: 1}}>
+        <VStack space={8} style={{flex: 1}} alignItems={'center'}>
+          <Body>Could not fetch {center_id} properties: avalanche center not found.</Body>
+        </VStack>
+      </HStack>
     );
   }
 
   const zone: AvalancheForecastZone | undefined = center.zones.find(item => item.id === forecast_zone_id);
   if (!zone) {
-    const message = `No such zone ${forecast_zone_id} for center ${center_id}.`;
-    Alert.alert('Avalanche forecast zone not found', message, [
-      {
-        text: 'OK',
-      },
-    ]);
     return (
-      <View>
-        <Body>{message}</Body>
-      </View>
+      <HStack space={8} style={{flex: 1}}>
+        <VStack space={8} style={{flex: 1}} alignItems={'center'}>
+          <Body>
+            Could not find zone {forecast_zone_id} for center {center_id}.
+          </Body>
+        </VStack>
+      </HStack>
+    );
+  }
+
+  if (!forecast) {
+    return (
+      <HStack space={8} style={{flex: 1}}>
+        <VStack space={8} style={{flex: 1}} alignItems={'center'}>
+          <Body>
+            No current {center_id} avalanche forecast found for the {zone.name} zone.
+          </Body>
+        </VStack>
+      </HStack>
+    );
+  }
+  if (isForecastError || isCenterError) {
+    return (
+      <HStack space={8} style={{flex: 1}}>
+        <VStack space={8} style={{flex: 1}} alignItems={'center'}>
+          {isCenterError && <Body>{`Could not fetch ${center_id} properties: ${centerError?.message}.`}</Body>}
+          {isForecastError && <Body>{`Could not fetch forecast for ${center_id} zone ${forecast_zone_id}: ${forecastError?.message}.`}</Body>}
+          {/* TODO(brian): we should add a "Try again" button and have that invoke `refetchByUser` */}
+        </VStack>
+      </HStack>
     );
   }
 

--- a/components/forecast/AvalancheForecast.tsx
+++ b/components/forecast/AvalancheForecast.tsx
@@ -16,7 +16,7 @@ import {useRefreshByUser} from 'hooks/useRefreshByUser';
 import {AvalancheTab} from './AvalancheTab';
 import {Body, FeatureTitleBlack} from 'components/text';
 import {Dropdown} from 'components/content/Dropdown';
-import {apiDateString} from 'utils/date';
+import {toISOStringUTC} from 'utils/date';
 import {HomeStackNavigationProps} from 'routes';
 import {AvalancheCenterLogo} from '../AvalancheCenterLogo';
 import {WeatherTab} from 'components/forecast/WeatherTab';
@@ -68,7 +68,7 @@ export const AvalancheForecast: React.FunctionComponent<AvalancheForecastProps> 
           zoneName: zone.name,
           center_id: center_id,
           forecast_zone_id: zone.id,
-          dateString: apiDateString(date),
+          dateString: toISOStringUTC(date),
         });
       }
     },

--- a/components/forecast/WeatherTab.tsx
+++ b/components/forecast/WeatherTab.tsx
@@ -6,7 +6,7 @@ import {HTML} from 'components/text/HTML';
 import {ActivityIndicator, StyleSheet} from 'react-native';
 import {colorLookup} from 'theme';
 import {AvalancheCenterID, AvalancheForecastZone} from 'types/nationalAvalancheCenter';
-import {apiDateString, utcDateToLocalTimeString} from 'utils/date';
+import {toISOStringUTC, utcDateToLocalTimeString} from 'utils/date';
 import {InfoTooltip} from 'components/content/InfoTooltip';
 import helpStrings from 'content/helpStrings';
 import {useWeatherStations} from 'hooks/useWeatherStations';
@@ -161,7 +161,7 @@ export const WeatherTab: React.FC<WeatherTabProps> = ({zone, center_id, date}) =
                 data: stations,
                 action: () => {
                   // Nested navigation to the stationDetail page of the Weather Data stack
-                  const dateString = apiDateString(date);
+                  const dateString = toISOStringUTC(date);
                   navigation.navigate('Weather Data', {
                     center_id,
                     dateString,

--- a/components/observations/ObservationSubmit.tsx
+++ b/components/observations/ObservationSubmit.tsx
@@ -81,7 +81,7 @@ export const ObservationSubmit: React.FC<{
               <ScrollView style={{height: '100%', width: '100%', backgroundColor: 'white'}}>
                 <VStack width="100%" justifyContent="flex-start" alignItems="stretch" space={8} pt={8} pb={8}>
                   <View px={16}>
-                    <Body>Help keep the NWAC community informed by submitting your observation.</Body>
+                    <Body>Help keep the {center_id} community informed by submitting your observation.</Body>
                   </View>
                   <CollapsibleCard borderRadius={0} borderColor="white" startsCollapsed={false} header={<Title3Semibold>Privacy</Title3Semibold>}>
                     <VStack space={8}>

--- a/components/observations/ObservationsPortal.tsx
+++ b/components/observations/ObservationsPortal.tsx
@@ -21,7 +21,7 @@ export const ObservationsPortal: React.FC<{
         {/* these magic numbers are yanked out of Figma. They could probably be converted to percentages */}
         <Topo width={887.0152587890625} height={456.3430480957031} style={{position: 'absolute', left: -306.15625, bottom: -60}} />
         <VStack height="100%" width="100%" justifyContent="center" alignItems="stretch" space={16} px={32} pb={200}>
-          <Body textAlign="center">Help keep the NWAC community informed by submitting your observation.</Body>
+          <Body textAlign="center">Help keep the {center_id} community informed by submitting your observation.</Body>
           <Button buttonStyle="primary" onPress={() => navigation.navigate('observationSubmit', {center_id})}>
             <BodySemibold>Submit an observation</BodySemibold>
           </Button>

--- a/components/observations/ObservationsPortal.tsx
+++ b/components/observations/ObservationsPortal.tsx
@@ -7,7 +7,7 @@ import Topo from 'assets/topo.svg';
 import {Button} from 'components/content/Button';
 import {useNavigation} from '@react-navigation/native';
 import {ObservationsStackNavigationProps} from 'routes';
-import {apiDateString} from 'utils/date';
+import {toISOStringUTC} from 'utils/date';
 
 export const ObservationsPortal: React.FC<{
   center_id: AvalancheCenterID;
@@ -25,7 +25,7 @@ export const ObservationsPortal: React.FC<{
           <Button buttonStyle="primary" onPress={() => navigation.navigate('observationSubmit', {center_id})}>
             <BodySemibold>Submit an observation</BodySemibold>
           </Button>
-          <Button onPress={() => navigation.navigate('observationsList', {center_id, dateString: apiDateString(date)})}>
+          <Button onPress={() => navigation.navigate('observationsList', {center_id, dateString: toISOStringUTC(date)})}>
             <BodySemibold>View all observations</BodySemibold>
           </Button>
         </VStack>


### PR DESCRIPTION
observations: use the center ID in text

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

*: pass around actual date-times, not dates

Our hooks expect to get actual date-times for their fetches, since we
will return different data from them based on what time of day it is and
when the avalanche centers roll over their forecast products. We need to
pass real date-times for that precision.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

forecast: slightly clean up error states

This is certainly not the final pass, likely we want to do the fetches
inside of the tab so that we can render the rest of the screen correctly
around these errors.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

