### PR TITLE
map: improve the calculations for the top elements height

### DIFF
--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -97,9 +97,21 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
         selectedZone={selectedZone}
         onPressPolygon={onPressPolygon}
       />
-      <SafeAreaView onLayout={(event: LayoutChangeEvent) => controller.animateUsingUpdatedTopElementsHeight(event.nativeEvent.layout.y + event.nativeEvent.layout.height)}>
-        <View flex={1}>
-          <DangerScale px={4} width="100%" position="absolute" top={12} />
+      <SafeAreaView>
+        <View>
+          <VStack
+            width="100%"
+            position="absolute"
+            flex={1}
+            onLayout={(event: LayoutChangeEvent) => {
+              // onLayout returns position relative to parent - we need position relative to screen
+              event.currentTarget.measureInWindow((x, y, width, height) => {
+                controller.animateUsingUpdatedTopElementsHeight(y + height);
+              });
+            }}>
+            <View height={12} />
+            <DangerScale px={4} width="100%" />
+          </VStack>
         </View>
       </SafeAreaView>
 


### PR DESCRIPTION
Calculate the real, relative-to-window (not parent) height of the top elements using a container that we can add the search bar to in the future. Moved the `top={12}` into a separate view in the column since for whatever reason the layout calculations could not handle the former, but are fine with the latter.

cc @floatplane 
Fixes the Android layout issues.