### PR TITLE
*: close over query state in hooks

### DIFF
--- a/components/AvalancheCenterSelector.tsx
+++ b/components/AvalancheCenterSelector.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
 import {useNavigation} from '@react-navigation/native';
-import {ActivityIndicator, SectionList, SectionListData, StyleSheet, Text, TouchableOpacity, useWindowDimensions} from 'react-native';
+import {SectionList, SectionListData, StyleSheet, Text, TouchableOpacity, useWindowDimensions} from 'react-native';
 
 import {AvalancheCenterLogo} from 'components/AvalancheCenterLogo';
+import {incompleteQueryState, QueryState} from 'components/content/QueryState';
 import {HStack, View, VStack} from 'components/core';
 import {Body} from 'components/text';
 import {useAvalancheCenterMetadata} from 'hooks/useAvalancheCenterMetadata';
@@ -53,36 +54,11 @@ interface AvalancheCenterCardProps {
 
 export const AvalancheCenterCard: React.FunctionComponent<AvalancheCenterCardProps> = ({avalancheCenterId, selected, onPress}: AvalancheCenterCardProps) => {
   const {width} = useWindowDimensions();
-  const {isLoading, isError, data: avalancheCenter, error} = useAvalancheCenterMetadata(avalancheCenterId);
-  if (isLoading) {
-    return <ActivityIndicator style={styles.item} />;
+  const centerResult = useAvalancheCenterMetadata(avalancheCenterId);
+  if (incompleteQueryState(centerResult)) {
+    return <QueryState results={[centerResult]} />;
   }
-  if (isError) {
-    return (
-      <View>
-        <View bg="light.100">
-          <VStack>
-            <HStack justifyContent="flex-start" alignItems="center">
-              <Body color="light.400">{`Could not fetch data for ${avalancheCenterId}: ${error?.message}.`}</Body>
-            </HStack>
-          </VStack>
-        </View>
-      </View>
-    );
-  }
-  if (!avalancheCenter) {
-    return (
-      <View>
-        <View bg="light.100">
-          <VStack>
-            <HStack justifyContent="flex-start" alignItems="center">
-              <Body color="light.400">{`No metadata found for ${avalancheCenterId}.`}</Body>
-            </HStack>
-          </VStack>
-        </View>
-      </View>
-    );
-  }
+  const avalancheCenter = centerResult.data;
 
   return (
     <View>

--- a/components/content/QueryState.tsx
+++ b/components/content/QueryState.tsx
@@ -1,0 +1,59 @@
+import {UseQueryResult} from '@tanstack/react-query';
+import {HStack} from 'components/core';
+import {Body} from 'components/text';
+import React from 'react';
+import {ActivityIndicator} from 'react-native';
+import * as Sentry from 'sentry-expo';
+
+export const QueryState: React.FunctionComponent<{results: UseQueryResult[]}> = ({results}) => {
+  const errors = results.filter(result => result.isError).map(result => result.error as Error);
+  if (errors.length > 0) {
+    errors.forEach(error => {
+      Sentry.Native.captureException(error);
+    });
+    return <InternalError />;
+  }
+
+  if (results.map(result => result.isLoading).reduce((accumulator, value) => accumulator || value)) {
+    return <Loading />;
+  }
+
+  if (results.map(result => result.isSuccess && !result.data).reduce((accumulator, value) => accumulator || value)) {
+    return <NotFound />;
+  }
+
+  Sentry.Native.captureException(new Error(`QueryState called with a set of queries that were loaded and had no errors: ${JSON.stringify(results)}`));
+  return <InternalError />;
+};
+
+export const InternalError: React.FunctionComponent = () => {
+  return (
+    <HStack width={'100%'} space={8} style={{flex: 1}} justifyContent={'center'} alignItems={'center'}>
+      <Body>An internal error occurred.</Body>
+    </HStack>
+  );
+};
+
+export const Loading: React.FunctionComponent = () => {
+  return (
+    <HStack width={'100%'} space={8} style={{flex: 1}} justifyContent={'center'} alignItems={'center'}>
+      <ActivityIndicator />
+    </HStack>
+  );
+};
+
+export const NotFound: React.FunctionComponent = () => {
+  return (
+    <HStack width={'100%'} space={8} style={{flex: 1}} justifyContent={'center'} alignItems={'center'}>
+      <Body>Could not find the requested resource.</Body>
+    </HStack>
+  );
+};
+
+// incompleteQueryState checks to see if any of the queries are not yet complete - if so, render a <QueryState/>.
+export const incompleteQueryState = (...results: UseQueryResult[]): boolean => {
+  return results
+    .map(result => [result.isError, result.isLoading, result.isSuccess && !result.data])
+    .flat()
+    .reduce((accumulator, value) => accumulator || value);
+};

--- a/components/form/LocationField.tsx
+++ b/components/form/LocationField.tsx
@@ -1,11 +1,12 @@
 import {AntDesign, FontAwesome} from '@expo/vector-icons';
+import {incompleteQueryState, QueryState} from 'components/content/QueryState';
 import {defaultMapRegionForZones, ZoneMap} from 'components/content/ZoneMap';
 import {Center, HStack, View, VStack} from 'components/core';
 import {Body, bodySize, BodyXSm, BodyXSmBlack, Title3Black} from 'components/text';
 import {useMapViewZones} from 'hooks/useMapViewZones';
 import React, {useCallback, useEffect, useState} from 'react';
 import {useController} from 'react-hook-form';
-import {ActivityIndicator, Image, Modal, TouchableOpacity} from 'react-native';
+import {Image, Modal, TouchableOpacity} from 'react-native';
 import {Region} from 'react-native-maps';
 import {SafeAreaProvider, SafeAreaView} from 'react-native-safe-area-context';
 import {colorLookup} from 'theme';
@@ -22,7 +23,8 @@ export const LocationField: React.FC<LocationFieldProps> = ({name, label}) => {
   } = useController({name});
   const [modalVisible, setModalVisible] = useState(false);
 
-  const {isLoading, isError, data: zones} = useMapViewZones('NWAC', new Date());
+  const zonesResult = useMapViewZones('NWAC', new Date());
+  const zones = zonesResult.data;
   const [initialRegion, setInitialRegion] = useState<Region>(defaultMapRegionForZones([]));
   const [mapReady, setMapReady] = useState<boolean>(false);
 
@@ -83,8 +85,7 @@ export const LocationField: React.FC<LocationFieldProps> = ({name, label}) => {
                   />
                 </HStack>
                 <Center width="100%" height="100%">
-                  {isLoading && <ActivityIndicator size="large" />}
-                  {isError && <Body>Error loading map. Please try again.</Body>}
+                  {incompleteQueryState(zonesResult) && <QueryState results={[zonesResult]} />}
                   {mapReady && (
                     <>
                       <ZoneMap

--- a/hooks/useAvalancheForecast.ts
+++ b/hooks/useAvalancheForecast.ts
@@ -8,13 +8,11 @@ import * as Sentry from 'sentry-expo';
 import Log from 'network/log';
 
 import {ClientContext, ClientProps} from 'clientContext';
-import {useAvalancheForecastFragment} from 'hooks/useAvalancheForecastFragment';
-import {AvalancheCenterID, Product, productSchema} from 'types/nationalAvalancheCenter';
+import {Product, productSchema} from 'types/nationalAvalancheCenter';
 import {ZodError} from 'zod';
 
-export const useAvalancheForecast = (center_id: AvalancheCenterID, forecast_zone_id: number, date: Date) => {
+export const useAvalancheForecast = (fragment: Product) => {
   const {nationalAvalancheCenterHost} = React.useContext<ClientProps>(ClientContext);
-  const {data: fragment} = useAvalancheForecastFragment(center_id, forecast_zone_id, date);
   const forecastId = fragment?.id;
 
   return useQuery<Product, AxiosError | ZodError>({

--- a/hooks/useLatestAvalancheForecast.ts
+++ b/hooks/useLatestAvalancheForecast.ts
@@ -8,13 +8,11 @@ import * as Sentry from 'sentry-expo';
 import Log from 'network/log';
 
 import {ClientContext, ClientProps} from 'clientContext';
-import {useAvalancheCenterMetadata} from 'hooks/useAvalancheCenterMetadata';
-import {AvalancheCenterID, Product, productSchema} from 'types/nationalAvalancheCenter';
+import {AvalancheCenter, AvalancheCenterID, Product, productSchema} from 'types/nationalAvalancheCenter';
 import {nominalForecastDate} from 'utils/date';
 import {ZodError} from 'zod';
 
-export const useLatestAvalancheForecast = (center_id: AvalancheCenterID, zone_id: number, requestedTime: Date) => {
-  const {data: metadata} = useAvalancheCenterMetadata(center_id);
+export const useLatestAvalancheForecast = (center_id: AvalancheCenterID, metadata: AvalancheCenter, zone_id: number, requestedTime: Date) => {
   const expiryTimeHours = metadata?.config.expires_time;
   const expiryTimeZone = metadata?.timezone;
 


### PR DESCRIPTION
We have a couple of similar issues coming to a head here:

 - you can't nest hooks inside of hooks, so you can't cleanly close over a hook that needs some ancillary data for its inner workings
 - when a screen needs data from a number of sources, say, when one of the hooks being used has further data requirements, the handling logic for any of those hooks still loading or having an error gets annoying, quick

In this commit I move the handling logic to a central component, which makes it much less onerous for a hook to simply ask for the data it needs as input.