### PR TITLE
components/observations: show the media in the card

### DIFF
--- a/components/observations/ObservationsListView.tsx
+++ b/components/observations/ObservationsListView.tsx
@@ -8,6 +8,7 @@ import {FlatList} from 'react-native';
 import {ObservationsStackNavigationProps} from 'routes';
 
 import {Card} from 'components/content/Card';
+import {Carousel} from 'components/content/carousel';
 import {incompleteQueryState, NotFound, QueryState} from 'components/content/QueryState';
 import {HStack, VStack} from 'components/core';
 import {NACIcon} from 'components/icons/nac-icons';
@@ -163,6 +164,7 @@ export const ObservationSummaryCard: React.FunctionComponent<{
           <HTML source={{html: observation.observationSummary}} />
         </VStack>
       )}
+      {observation.media && observation.media.length > 0 && <Carousel thumbnailHeight={160} thumbnailAspectRatio={1.3} media={observation.media} displayCaptions={false} />}
     </Card>
   );
 };

--- a/hooks/useNWACObservations.ts
+++ b/hooks/useNWACObservations.ts
@@ -91,6 +91,7 @@ export const fetchNWACObservations = async (nwacHost: string, center_id: Avalanc
         instability: object.content.instability,
         observationSummary: object.content.observation_summary,
         locationPoint: object.content.location_point,
+        media: object.content.media,
       })),
     };
   }

--- a/hooks/useObservations.ts
+++ b/hooks/useObservations.ts
@@ -212,6 +212,7 @@ export type ObservationsQuery = {
     locationName: string;
     instability: any;
     observationSummary: string;
+    media?: any | null;
     locationPoint: {__typename?: 'CoordinatesGraph'; lat?: number | null; lng?: number | null};
   }>;
 };
@@ -225,6 +226,7 @@ export type OverviewFragment = {
   locationName: string;
   instability: any;
   observationSummary: string;
+  media?: any | null;
   locationPoint: {__typename?: 'CoordinatesGraph'; lat?: number | null; lng?: number | null};
 };
 
@@ -310,6 +312,7 @@ export const OverviewFragmentDoc = `
   locationName
   instability
   observationSummary
+  media
 }
     `;
 export const EverythingFragmentDoc = `

--- a/types/nationalAvalancheCenter/observations-queries.graphql
+++ b/types/nationalAvalancheCenter/observations-queries.graphql
@@ -22,6 +22,7 @@ fragment overview on ObservationGraphPublic {
   locationName
   instability
   observationSummary
+  media
 }
 
 fragment everything on ObservationGraphPublic {


### PR DESCRIPTION
For a quick overview of what's going on (and to help me know I did the NWAC API correctly, let's be honest) we add media to the card overviews for observations.