### PR TITLE
Fix navigation weirdness around weather data tables

### DIFF
--- a/components/forecast/WeatherTab.tsx
+++ b/components/forecast/WeatherTab.tsx
@@ -155,21 +155,13 @@ export const WeatherTab: React.FC<WeatherTabProps> = ({zone, center_id, date}) =
                 label: name,
                 data: stations,
                 action: () => {
-                  // Nested navigation to the stationDetail page of the Weather Data stack
                   const dateString = toISOStringUTC(date);
-                  navigation.navigate('Weather Data', {
+                  navigation.navigate('stationDetail', {
                     center_id,
+                    station_stids: stations.map(s => s.stid),
+                    name,
                     dateString,
-                    screen: 'stationDetail',
-                    // Treat this as the first screen in the Weather Data stack - don't show a back button going to the stationList
-                    initial: true,
-                    params: {
-                      center_id,
-                      station_stids: stations.map(s => s.stid),
-                      name,
-                      dateString,
-                      zoneName: zone.name,
-                    },
+                    zoneName: zone.name,
                   });
                 },
               }))}

--- a/components/screens/HomeScreen.tsx
+++ b/components/screens/HomeScreen.tsx
@@ -2,25 +2,17 @@ import {createNativeStackNavigator, NativeStackScreenProps} from '@react-navigat
 
 import {ForecastScreen} from 'components/screens/ForecastScreen';
 import {MapScreen} from 'components/screens/MapScreen';
+import {StationDetailScreen} from 'components/screens/WeatherScreen';
 import {HomeStackParamList, TabNavigatorParamList} from 'routes';
 
 const AvalancheCenterStack = createNativeStackNavigator<HomeStackParamList>();
 export const HomeTabScreen = ({route}: NativeStackScreenProps<TabNavigatorParamList, 'Home'>) => {
   const {center_id, dateString} = route.params;
   return (
-    <AvalancheCenterStack.Navigator initialRouteName="avalancheCenter">
-      <AvalancheCenterStack.Screen
-        name="avalancheCenter"
-        component={MapScreen}
-        initialParams={{center_id: center_id, dateString: dateString}}
-        options={() => ({headerShown: false})}
-      />
-      <AvalancheCenterStack.Screen
-        name="forecast"
-        component={ForecastScreen}
-        initialParams={{center_id: center_id, dateString: dateString}}
-        options={() => ({headerShown: false})}
-      />
+    <AvalancheCenterStack.Navigator initialRouteName="avalancheCenter" screenOptions={{headerShown: false}}>
+      <AvalancheCenterStack.Screen name="avalancheCenter" component={MapScreen} initialParams={{center_id: center_id, dateString: dateString}} />
+      <AvalancheCenterStack.Screen name="forecast" component={ForecastScreen} initialParams={{center_id: center_id, dateString: dateString}} />
+      <AvalancheCenterStack.Screen name="stationDetail" component={StationDetailScreen} />
     </AvalancheCenterStack.Navigator>
   );
 };

--- a/components/screens/WeatherScreen.tsx
+++ b/components/screens/WeatherScreen.tsx
@@ -21,6 +21,6 @@ const StationListScreen = ({route}: NativeStackScreenProps<WeatherStackParamList
   return <WeatherStationList {...route.params} />;
 };
 
-const StationDetailScreen = ({route}: NativeStackScreenProps<WeatherStackParamList, 'stationDetail'>) => {
+export const StationDetailScreen = ({route}: NativeStackScreenProps<WeatherStackParamList, 'stationDetail'>) => {
   return <WeatherStationDetail {...route.params} />;
 };

--- a/routes.ts
+++ b/routes.ts
@@ -11,6 +11,14 @@ export type TabNavigatorParamList = {
 };
 export type TabNavigationProps = BottomTabNavigationProp<TabNavigatorParamList>;
 
+type WeatherStationDetailPageProps = {
+  center_id: AvalancheCenterID;
+  station_stids: string[];
+  zoneName: string;
+  name: string;
+  dateString: string;
+};
+
 export type HomeStackParamList = {
   avalancheCenter: {
     center_id: AvalancheCenterID;
@@ -22,6 +30,7 @@ export type HomeStackParamList = {
     forecast_zone_id: number;
     dateString: string;
   };
+  stationDetail: WeatherStationDetailPageProps;
 };
 export type HomeStackNavigationProps = NativeStackNavigationProp<HomeStackParamList>;
 
@@ -30,13 +39,7 @@ export type WeatherStackParamList = {
     center_id: AvalancheCenterID;
     dateString: string;
   };
-  stationDetail: {
-    center_id: AvalancheCenterID;
-    station_stids: string[];
-    zoneName: string;
-    name: string;
-    dateString: string;
-  };
+  stationDetail: WeatherStationDetailPageProps;
 };
 export type WeatherStackNavigationProps = NativeStackNavigationProp<WeatherStackParamList>;
 


### PR DESCRIPTION
This resolves #159. When navigating to weather station detail from the forecast tab, we push the weather data screen onto the Home tab's navigation stack. This keeps it from getting tangled with the Weather Data tab's stack, which was causing all kinds of weirdness. 

It also maps to the way Slack handles navigating to DMs with a particular user - you can get there from two different places in the Slack tab bar, and they are allowed to co-exist. So it seems like the right fix.