### PR TITLE
Add a script for cleaning up old PR channels in expo

### DIFF
--- a/scripts/eas-clean-pr-channels.sh
+++ b/scripts/eas-clean-pr-channels.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+eas branch:list --json --non-interactive \
+| jq '.[] | del(.updates)| select( .name | startswith("xxx-pr-")) | .name' -r \
+| xargs -n 1 -I {} sh -c "eas channel:delete --non-interactive {}; eas branch:delete --non-interactive {}"


### PR DESCRIPTION
I think we end up with stray PR channels when a PR is merged before the preview build finishes. This is a pretty dumb script to just go in and clean them all up. Feel free to use your shell-fu to make it massively better @stevekuznetsov 