### PR TITLE
Fix some submission TODOs

### DIFF
--- a/components/content/carousel/ImageList.tsx
+++ b/components/content/carousel/ImageList.tsx
@@ -59,7 +59,7 @@ export const ImageList: React.FC<PropsWithChildren<ImageListProps>> = ({
             setLoadingState(loadingState);
           }}
         />
-        {displayCaptions && (
+        {displayCaptions && item.caption && (
           <View flex={1} px={32}>
             <ScrollView bounces={false}>
               <HTML source={{html: item.caption}} />

--- a/components/observations/ObservationFormData.ts
+++ b/components/observations/ObservationFormData.ts
@@ -1,12 +1,11 @@
 import {merge} from 'lodash';
-import {Activity, InstabilityDistribution, Observation, PartnerType} from 'types/nationalAvalancheCenter';
+import {Activity, InstabilityDistribution, MediaUsage, Observation, PartnerType} from 'types/nationalAvalancheCenter';
 import {z} from 'zod';
 
 export const defaultObservationFormData = (initialValues: Partial<Observation> | null = null): ObservationFormData =>
   merge(
     {
       activity: [],
-      center_id: 'NWAC',
       instability: {
         avalanches_observed: false,
         avalanches_triggered: false,
@@ -16,7 +15,7 @@ export const defaultObservationFormData = (initialValues: Partial<Observation> |
       },
       media: [],
       observer_type: PartnerType.Public,
-      photoUsage: 'anonymous',
+      photoUsage: MediaUsage.Credit,
       private: false,
       start_date: new Date(),
       status: 'published',
@@ -53,6 +52,7 @@ export const simpleObservationFormSchema = z
     ),
     name: z.string({required_error: required}).min(2, tooShort).max(50, tooLong),
     observation_summary: z.string({required_error: required}).min(8, tooShort).max(1024, tooLong),
+    photoUsage: z.nativeEnum(MediaUsage, {required_error: required}),
     private: z.boolean(),
     start_date: z.date({required_error: required}),
   })
@@ -82,6 +82,7 @@ export const simpleObservationFormSchema = z
         });
       }
     }
+
     // if instability.cracking, then we'll want cracking_description to be set
     if (arg.instability?.cracking) {
       const {cracking_description} = arg.instability;

--- a/components/observations/SimpleForm.tsx
+++ b/components/observations/SimpleForm.tsx
@@ -7,7 +7,7 @@ import {AxiosError} from 'axios';
 import * as ImagePicker from 'expo-image-picker';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {FormProvider, useForm, useWatch} from 'react-hook-form';
-import {Keyboard, KeyboardAvoidingView, Platform, ScrollView, TouchableWithoutFeedback, View as RNView} from 'react-native';
+import {ActivityIndicator, Keyboard, KeyboardAvoidingView, Platform, ScrollView, TouchableWithoutFeedback, View as RNView} from 'react-native';
 import Toast from 'react-native-root-toast';
 import {SafeAreaView} from 'react-native-safe-area-context';
 
@@ -103,11 +103,15 @@ export const SimpleForm: React.FC<{
   });
 
   const onSubmitHandler = async (data: ObservationFormData) => {
+    // Submit button turns into a cancel button
+    if (mutation.isLoading) {
+      mutation.reset();
+      return;
+    }
     // TODO: plumb through additional data: private vs public, photo credit value
     // TODO: add the zone, based on whichever lat/lng have been selected
     // TODO: add a spinner to the submit button so it's clearer that something is happening
     data.uploadPaths = images.map(image => image.uri);
-    mutation.reset();
     mutation.mutate(data);
   };
 
@@ -453,17 +457,26 @@ export const SimpleForm: React.FC<{
                   <Button
                     mx={16}
                     mt={16}
-                    mb={32}
                     buttonStyle="primary"
+                    disabled={mutation.isSuccess}
                     onPress={async () => {
                       // Force validation errors to show up on fields that haven't been visited yet
                       await formContext.trigger();
                       // Then try to submit the form
                       formContext.handleSubmit(onSubmitHandler, onSubmitErrorHandler)();
                     }}>
-                    <BodySemibold>Submit your observation</BodySemibold>
-                    {/* TODO add an activity spinner here and disable the button while we're working */}
+                    {mutation.isLoading && (
+                      <HStack space={8} alignItems="center" pt={3}>
+                        <ActivityIndicator size="small" />
+                        <BodySemibold color={colorLookup('white')}>Cancel submission</BodySemibold>
+                      </HStack>
+                    )}
+                    {!mutation.isLoading && <BodySemibold>Submit your observation</BodySemibold>}
                   </Button>
+                  <VStack mx={16} mt={16} mb={32}>
+                    {mutation.isSuccess && <Body>Thanks for your observation!</Body>}
+                    {mutation.isError && <Body color={colorLookup('error.900')}>There was an error submitting your observation.</Body>}
+                  </VStack>
                 </VStack>
               </ScrollView>
             </VStack>

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "@testing-library/react-native": "^11.5.0",
     "@types/color": "^3.0.3",
     "@types/jest": "^29.2.4",
+    "@types/md5": "^2.3.2",
     "@types/polylabel": "^1.0.5",
     "@types/react": "~18.0.24",
     "@types/react-native": "~0.70.6",

--- a/types/nationalAvalancheCenter/enums.ts
+++ b/types/nationalAvalancheCenter/enums.ts
@@ -103,6 +103,12 @@ export enum MediaType {
   // TODO(skuznets): more exist, no idea what they are
 }
 
+export enum MediaUsage {
+  Anonymous = 'anonymous', // can be re-used, but keep author anonymous
+  Credit = 'credit', // can be re-used, but give credit
+  Private = 'private', // do not re-use, for forecasters only
+}
+
 export enum AvalancheCenterType {
   Nonprofit = 'nonprofit',
   State = 'state',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3599,6 +3599,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/md5@^2.3.2":
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@types/md5/-/md5-2.3.2.tgz#529bb3f8a7e9e9f621094eb76a443f585d882528"
+  integrity sha512-v+JFDu96+UYJ3/UWzB0mEglIS//MZXgRaJ4ubUPwOM0gvLc/kcQ3TWNYwENEK7/EcXGQVrW8h/XqednSjBd/Og==
+
 "@types/node@*":
   version "18.14.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.14.0.tgz#94c47b9217bbac49d4a67a967fdcdeed89ebb7d0"


### PR DESCRIPTION
- Disable the submit button after successful submission, to prevent multiple uploads
- Fix bug with cache of uploaded media
- Add TS types for `md5` package
- Fix bug in image viewer that complains when photos don't have captions
- Plumb through setting from submit form about how photos can be re-used