### PR TITLE
Update some styles

### DIFF
--- a/components/TabControl.tsx
+++ b/components/TabControl.tsx
@@ -32,7 +32,24 @@ export const TabControl: React.FunctionComponent<TabControlProps> = ({children, 
 
   return (
     <VStack style={{width: '100%', backgroundColor}}>
-      <HStack justifyContent="space-evenly" alignItems="center" width="100%" backgroundColor={backgroundColor} paddingTop={8}>
+      <HStack
+        justifyContent="space-evenly"
+        alignItems="center"
+        width="100%"
+        backgroundColor={backgroundColor}
+        paddingTop={8}
+        style={{
+          shadowColor: '#000',
+          shadowOffset: {
+            width: 0,
+            height: 2,
+          },
+          shadowOpacity: 0.23,
+          shadowRadius: 2.62,
+
+          elevation: 4,
+          marginBottom: 8,
+        }}>
         {React.Children.map(children, (child, index) => {
           const selected = selectedIndex === index;
           return (

--- a/components/forecast/AvalancheTab.tsx
+++ b/components/forecast/AvalancheTab.tsx
@@ -105,7 +105,7 @@ export const AvalancheTab: React.FunctionComponent<AvalancheTabProps> = React.me
   return (
     <ScrollView refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={refresh} />}>
       <VStack space={8} backgroundColor={colorLookup('background.base')}>
-        <Card marginTop={1} borderRadius={0} borderColor="white" header={<Title3Black>Avalanche Forecast</Title3Black>}>
+        <Card borderRadius={0} borderColor="white" header={<Title3Black>Avalanche Forecast</Title3Black>}>
           <HStack justifyContent="space-evenly" space={8}>
             <VStack space={8} style={{flex: 1}}>
               <AllCapsSmBlack>Issued</AllCapsSmBlack>

--- a/components/forecast/WeatherTab.tsx
+++ b/components/forecast/WeatherTab.tsx
@@ -98,7 +98,7 @@ export const WeatherTab: React.FC<WeatherTabProps> = ({zone, center_id, requeste
   return (
     <ScrollView refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={refresh} />}>
       <VStack space={8} backgroundColor={colorLookup('background.base')}>
-        <Card marginTop={1} borderRadius={0} borderColor="white" header={<Title3Black>Weather Forecast</Title3Black>}>
+        <Card borderRadius={0} borderColor="white" header={<Title3Black>Weather Forecast</Title3Black>}>
           <HStack justifyContent="space-evenly" alignItems="flex-start" space={8}>
             <VStack space={8} style={{flex: 1}}>
               <AllCapsSmBlack>Issued</AllCapsSmBlack>

--- a/components/observations/ObservationDetailView.tsx
+++ b/components/observations/ObservationDetailView.tsx
@@ -1,18 +1,23 @@
-import {FontAwesome5, Fontisto, MaterialCommunityIcons} from '@expo/vector-icons';
+import React from 'react';
+import {ScrollView, StyleSheet} from 'react-native';
+
+import {AntDesign, FontAwesome5, Fontisto, MaterialCommunityIcons} from '@expo/vector-icons';
+import {useNavigation} from '@react-navigation/native';
+import {SafeAreaView} from 'react-native-safe-area-context';
+import * as Sentry from 'sentry-expo';
+
 import {Card, CollapsibleCard} from 'components/content/Card';
 import {Carousel} from 'components/content/carousel';
 import {incompleteQueryState, QueryState} from 'components/content/QueryState';
-import {HStack, VStack} from 'components/core';
+import {HStack, View, VStack} from 'components/core';
 import {NACIcon} from 'components/icons/nac-icons';
 import {zone} from 'components/observations/ObservationsListView';
-import {Body, BodyBlack, FeatureTitleBlack, Title1Black} from 'components/text';
+import {Body, BodyBlack, FeatureTitleBlack, Title1Black, Title3Black} from 'components/text';
 import {HTML} from 'components/text/HTML';
 import {useMapLayer} from 'hooks/useMapLayer';
 import {useNWACObservation} from 'hooks/useNWACObservation';
 import {useObservationQuery} from 'hooks/useObservations';
-import React from 'react';
-import {ScrollView, StyleSheet} from 'react-native';
-import * as Sentry from 'sentry-expo';
+import {ObservationsStackNavigationProps} from 'routes';
 import {colorLookup} from 'theme';
 import {
   Activity,
@@ -93,6 +98,8 @@ export const ObservationCard: React.FunctionComponent<{
   observation: Observation;
   mapLayer: MapLayer;
 }> = ({observation, mapLayer}) => {
+  const navigation = useNavigation<ObservationsStackNavigationProps>();
+
   const anySignsOfInstability =
     observation.instability.avalanches_caught ||
     observation.instability.avalanches_observed ||
@@ -101,242 +108,264 @@ export const ObservationCard: React.FunctionComponent<{
     observation.instability.cracking;
 
   return (
-    <ScrollView style={StyleSheet.absoluteFillObject}>
-      <VStack space={8} backgroundColor={colorLookup('background.base')}>
-        <Card
-          marginTop={2}
-          borderRadius={0}
-          borderColor="white"
-          header={<FeatureTitleBlack>{`${FormatPartnerType(observation.observer_type)} Field Observation`}</FeatureTitleBlack>}>
-          <VStack space={8}>
-            <HStack flexWrap="wrap" space={8} alignItems="flex-start">
-              <IdentifiedInformation header={'Submitted'} body={utcDateToLocalTimeString(observation.created_at)} />
-              {observation.end_date && <IdentifiedInformation header={'Expires'} body={utcDateToLocalTimeString(observation.end_date)} />}
-              <IdentifiedInformation header={'Author(s)'} body={observation.name || 'Unknown'} />
-              {observation.activity && <IdentifiedInformation header={'Activity'} body={activityDisplayName(observation.activity)} />}
-            </HStack>
-            <HStack flexWrap="wrap" space={8} alignItems="flex-start">
-              <IdentifiedInformation header={'Zone/Region'} body={zone(mapLayer, observation.location_point?.lat, observation.location_point?.lng)} />
-              <IdentifiedInformation header={'Location'} body={observation.location_name} />
-              <IdentifiedInformation header={'Route'} body={observation.route} />
-            </HStack>
-          </VStack>
-        </Card>
-        <CollapsibleCard
-          startsCollapsed={false}
-          borderRadius={0}
-          borderColor="white"
-          header={
-            <HStack space={8} alignItems="center">
-              <FontAwesome5 name="info-circle" size={24} color="black" />
-              <Title1Black>Observation Summary</Title1Black>
-            </HStack>
-          }>
-          <HTML source={{html: observation.observation_summary}} />
-          {anySignsOfInstability && (
-            <VStack space={8} style={{flex: 1}}>
-              <BodyBlack style={{textTransform: 'uppercase'}}>{'Signs Of Instability'}</BodyBlack>
-              {observation.instability.avalanches_caught && (
-                <HStack space={8} alignItems="center">
-                  <NACIcon name="avalanche" size={32} color="black" />
-                  <Body color="text.secondary">{'Caught in Avalanche(s)'}</Body>
-                </HStack>
-              )}
-              {observation.instability.avalanches_observed && (
-                <HStack space={8} alignItems="center">
-                  <NACIcon name="avalanche" size={32} color="black" />
-                  <Body color="text.secondary">{'Avalanche(s) Observed'}</Body>
-                </HStack>
-              )}
-              {observation.instability.avalanches_triggered && (
-                <HStack space={8} alignItems="center">
-                  <NACIcon name="avalanche" size={32} color="black" />
-                  <Body color="text.secondary">{'Avalanche(s) Triggered'}</Body>
-                </HStack>
-              )}
-              {observation.instability.collapsing && (
-                <HStack space={8} alignItems="center">
-                  <MaterialCommunityIcons name="arrow-collapse-vertical" size={24} color="black" />
-                  <Body color="text.secondary">
-                    {observation.instability.collapsing_description &&
-                      `${FormatInstabilityDistribution(observation.instability.collapsing_description as InstabilityDistribution)} `}
-                    {'Collapsing Observed'}
-                  </Body>
-                </HStack>
-              )}
-              {observation.instability.cracking && (
-                <HStack space={8} alignItems="center">
-                  <MaterialCommunityIcons name="lightning-bolt" size={24} color="black" />
-                  <Body color="text.secondary">
-                    {observation.instability.cracking_description && `${FormatInstabilityDistribution(observation.instability.cracking_description as InstabilityDistribution)} `}
-                    {'Cracking Observed'}
-                  </Body>
-                </HStack>
-              )}
-            </VStack>
-          )}
-          {observation.instability_summary && (
-            <VStack space={8} style={{flex: 1}}>
-              <BodyBlack style={{textTransform: 'uppercase'}}>{'Instability Comments'}</BodyBlack>
-              <HTML source={{html: observation.instability_summary}} />
-            </VStack>
-          )}
-        </CollapsibleCard>
-        {observation.media && observation.media.length > 0 && (
-          <CollapsibleCard
-            startsCollapsed={false}
-            borderRadius={0}
-            borderColor="white"
-            header={
-              <HStack space={8} alignItems="center">
-                <FontAwesome5 name="photo-video" size={24} color="black" />
-                <Title1Black>Observation Media</Title1Black>
-              </HStack>
-            }>
-            <Carousel thumbnailHeight={160} thumbnailAspectRatio={1.3} media={observation.media} displayCaptions={false} />
-          </CollapsibleCard>
-        )}
-        {((observation.avalanches && observation.avalanches.length > 0) || observation.avalanches_summary) && (
-          <CollapsibleCard
-            startsCollapsed={false}
-            borderRadius={0}
-            borderWidth={0}
-            borderColor="white"
-            header={
-              <HStack space={8} alignItems="center">
-                <NACIcon name="avalanche" size={48} color="black" />
-                <Title1Black>Avalanches</Title1Black>
-              </HStack>
-            }>
-            {observation.avalanches &&
-              observation.avalanches.length > 0 &&
-              observation.avalanches.map((item, index) => (
-                <VStack space={8} style={{flex: 1}} key={`avalanche-${index}`}>
-                  <HStack space={8} alignItems="center">
-                    <IdentifiedInformation
-                      header={'Date'}
-                      body={`${utcDateToLocalTimeString(item.date)} (${FormatAvalancheDateUncertainty(item.dateAccuracy as AvalancheDateUncertainty)})`}
-                    />
-                    <IdentifiedInformation header={'Location'} body={item.location} />
-                    <IdentifiedInformation header={'Size'} body={`D${item.dSize}-R${item.rSize}`} />
+    <View style={{...StyleSheet.absoluteFillObject, backgroundColor: 'white'}}>
+      <SafeAreaView edges={['top', 'left', 'right']} style={{height: '100%', width: '100%'}}>
+        <VStack space={8} backgroundColor="white" style={{height: '100%', width: '100%'}}>
+          <HStack justifyContent="flex-start" pb={8}>
+            <AntDesign.Button
+              size={24}
+              color={colorLookup('text')}
+              name="arrowleft"
+              backgroundColor="white"
+              iconStyle={{marginLeft: 0, marginRight: 8}}
+              style={{textAlign: 'center'}}
+              onPress={() => navigation.goBack()}
+            />
+            <Title3Black>{`${FormatPartnerType(observation.observer_type)} Field Observation`}</Title3Black>
+          </HStack>
+          <ScrollView style={{height: '100%', width: '100%'}}>
+            <VStack space={8} backgroundColor={colorLookup('background.base')}>
+              <Card
+                marginTop={2}
+                borderRadius={0}
+                borderColor="white"
+                header={<FeatureTitleBlack>{`${FormatPartnerType(observation.observer_type)} Field Observation`}</FeatureTitleBlack>}>
+                <VStack space={8}>
+                  <HStack flexWrap="wrap" space={8} alignItems="flex-start">
+                    <IdentifiedInformation header={'Submitted'} body={utcDateToLocalTimeString(observation.created_at)} />
+                    {observation.end_date && <IdentifiedInformation header={'Expires'} body={utcDateToLocalTimeString(observation.end_date)} />}
+                    <IdentifiedInformation header={'Author(s)'} body={observation.name || 'Unknown'} />
+                    {observation.activity && <IdentifiedInformation header={'Activity'} body={activityDisplayName(observation.activity)} />}
                   </HStack>
-                  <HStack space={8} alignItems="center">
-                    <IdentifiedInformation
-                      header={'Trigger'}
-                      body={`${FormatAvalancheTrigger(item.trigger as AvalancheTrigger)} - ${FormatAvalancheCause(item.cause as AvalancheCause)}`}
-                    />
-                    <IdentifiedInformation header={'Start Zone'} body={`${FormatAvalancheAspect(item.aspect as AvalancheAspect)}, ${item.slopeAngle}° at ${item.elevation}ft`} />
-                    <IdentifiedInformation header={'Vertical Fall'} body={`${item.verticalFall}ft`} />
+                  <HStack flexWrap="wrap" space={8} alignItems="flex-start">
+                    <IdentifiedInformation header={'Zone/Region'} body={zone(mapLayer, observation.location_point?.lat, observation.location_point?.lng)} />
+                    <IdentifiedInformation header={'Location'} body={observation.location_name} />
+                    <IdentifiedInformation header={'Route'} body={observation.route} />
                   </HStack>
-                  <HStack space={8} alignItems="center">
-                    <IdentifiedInformation header={'Crown Thickness'} body={`${item.avgCrownDepth}cm`} />
-                    <IdentifiedInformation header={'Width'} body={`${item.width}ft`} />
-                    <IdentifiedInformation header={'Type'} body={FormatAvalancheType(item.avalancheType as AvalancheType)} />
-                    <IdentifiedInformation header={'Bed Surface'} body={FormatAvalancheBedSurface(item.bedSfc as AvalancheBedSurface)} />
-                  </HStack>
-                  <>
-                    {item.media && item.media.length > 0 && (
-                      <VStack space={8} style={{flex: 1}}>
-                        <BodyBlack style={{textTransform: 'uppercase'}}>{'Avalanche Media'}</BodyBlack>
-                        <Carousel thumbnailHeight={160} thumbnailAspectRatio={1.3} media={item.media} displayCaptions={false} />
-                      </VStack>
-                    )}
-                  </>
-                  <>
-                    {item.comments && (
-                      <VStack space={8} style={{flex: 1}}>
-                        <BodyBlack style={{textTransform: 'uppercase'}}>{'Avalanche Comments'}</BodyBlack>
-                        <HTML source={{html: item.comments}} />
-                      </VStack>
-                    )}
-                  </>
                 </VStack>
-              ))}
-            {observation.avalanches_summary && (
-              <VStack space={8} style={{flex: 1}}>
-                <BodyBlack style={{textTransform: 'uppercase'}}>{'Avalanche Summary'}</BodyBlack>
-                <HTML source={{html: observation.avalanches_summary}} />
-              </VStack>
-            )}
-          </CollapsibleCard>
-        )}
-        {observation.advanced_fields && (observation.advanced_fields.weather || observation.advanced_fields.weather_summary) && (
-          <CollapsibleCard
-            startsCollapsed={false}
-            borderRadius={0}
-            borderColor="white"
-            header={
-              <HStack space={8} alignItems="center">
-                <MaterialCommunityIcons name="weather-snowy-heavy" size={24} color="black" />
-                <Title1Black>Weather</Title1Black>
-              </HStack>
-            }>
-            <>
-              {observation.advanced_fields.weather && (
-                <>
-                  <HStack flexWrap="wrap" space={8}>
-                    <IdentifiedWeatherInformation header={'Cloud Cover'} body={FormatCloudCover(observation.advanced_fields.weather.cloud_cover as CloudCover)} />
-                    <IdentifiedWeatherInformation header={'Temperature (F)'} body={observation.advanced_fields.weather.air_temp} />
-                    <IdentifiedWeatherInformation header={'New or Recent Snowfall'} body={observation.advanced_fields.weather.recent_snowfall} />
+              </Card>
+              <CollapsibleCard
+                startsCollapsed={false}
+                borderRadius={0}
+                borderColor="white"
+                header={
+                  <HStack space={8} alignItems="center">
+                    <FontAwesome5 name="info-circle" size={24} color="black" />
+                    <Title1Black>Observation Summary</Title1Black>
                   </HStack>
-                  <HStack flexWrap="wrap" space={8}>
-                    <IdentifiedWeatherInformation header={'Rain/Snow Line (ft)'} body={observation.advanced_fields.weather.rain_elevation} />
-                    <IdentifiedWeatherInformation
-                      header={'Snow Available For Transport'}
-                      body={FormatSnowAvailableForTransport(observation.advanced_fields.weather.snow_avail_for_transport as SnowAvailableForTransport)}
-                    />
-                    <IdentifiedWeatherInformation header={'Wind Loading'} body={FormatWindLoading(observation.advanced_fields.weather.wind_loading as WindLoading)} />
-                  </HStack>
-                </>
-              )}
-            </>
-            <>
-              {observation.advanced_fields.weather_summary && (
-                <VStack space={8} style={{flex: 1}}>
-                  <BodyBlack style={{textTransform: 'uppercase'}}>{'Weather Summary'}</BodyBlack>
-                  <HTML source={{html: observation.advanced_fields.weather_summary}} />
-                </VStack>
-              )}
-            </>
-          </CollapsibleCard>
-        )}
-        {observation.advanced_fields &&
-          (observation.advanced_fields.snowpack ||
-            (observation.advanced_fields.snowpack_media && observation.advanced_fields.snowpack_media.length > 0) ||
-            observation.advanced_fields.snowpack_summary) && (
-            <CollapsibleCard
-              startsCollapsed={false}
-              borderRadius={0}
-              borderColor="white"
-              header={
-                <HStack space={8} alignItems="center">
-                  <Fontisto name="snowflake" size={24} color="black" />
-                  <Title1Black>Snowpack Observations</Title1Black>
-                </HStack>
-              }>
-              <>{observation.advanced_fields.snowpack && <>{/* we don't know what fields could be in this thing ... */}</>}</>
-              <>
-                {observation.advanced_fields.snowpack_summary && (
+                }>
+                <HTML source={{html: observation.observation_summary}} />
+                {anySignsOfInstability && (
                   <VStack space={8} style={{flex: 1}}>
-                    <BodyBlack style={{textTransform: 'uppercase'}}>{'Snowpack Summary'}</BodyBlack>
-                    <HTML source={{html: observation.advanced_fields.snowpack_summary}} />
+                    <BodyBlack style={{textTransform: 'uppercase'}}>{'Signs Of Instability'}</BodyBlack>
+                    {observation.instability.avalanches_caught && (
+                      <HStack space={8} alignItems="center">
+                        <NACIcon name="avalanche" size={32} color="black" />
+                        <Body color="text.secondary">{'Caught in Avalanche(s)'}</Body>
+                      </HStack>
+                    )}
+                    {observation.instability.avalanches_observed && (
+                      <HStack space={8} alignItems="center">
+                        <NACIcon name="avalanche" size={32} color="black" />
+                        <Body color="text.secondary">{'Avalanche(s) Observed'}</Body>
+                      </HStack>
+                    )}
+                    {observation.instability.avalanches_triggered && (
+                      <HStack space={8} alignItems="center">
+                        <NACIcon name="avalanche" size={32} color="black" />
+                        <Body color="text.secondary">{'Avalanche(s) Triggered'}</Body>
+                      </HStack>
+                    )}
+                    {observation.instability.collapsing && (
+                      <HStack space={8} alignItems="center">
+                        <MaterialCommunityIcons name="arrow-collapse-vertical" size={24} color="black" />
+                        <Body color="text.secondary">
+                          {observation.instability.collapsing_description &&
+                            `${FormatInstabilityDistribution(observation.instability.collapsing_description as InstabilityDistribution)} `}
+                          {'Collapsing Observed'}
+                        </Body>
+                      </HStack>
+                    )}
+                    {observation.instability.cracking && (
+                      <HStack space={8} alignItems="center">
+                        <MaterialCommunityIcons name="lightning-bolt" size={24} color="black" />
+                        <Body color="text.secondary">
+                          {observation.instability.cracking_description &&
+                            `${FormatInstabilityDistribution(observation.instability.cracking_description as InstabilityDistribution)} `}
+                          {'Cracking Observed'}
+                        </Body>
+                      </HStack>
+                    )}
                   </VStack>
                 )}
-              </>
-              <>
-                {observation.advanced_fields.snowpack_media && observation.advanced_fields.snowpack_media.length > 0 && (
-                  <>
-                    <VStack space={8} style={{flex: 1}}>
-                      <BodyBlack style={{textTransform: 'uppercase'}}>{'Snowpack Media'}</BodyBlack>
-                      <Carousel thumbnailHeight={160} thumbnailAspectRatio={1.3} media={observation.advanced_fields.snowpack_media} displayCaptions={false} />
-                    </VStack>
-                  </>
+                {observation.instability_summary && (
+                  <VStack space={8} style={{flex: 1}}>
+                    <BodyBlack style={{textTransform: 'uppercase'}}>{'Instability Comments'}</BodyBlack>
+                    <HTML source={{html: observation.instability_summary}} />
+                  </VStack>
                 )}
-              </>
-            </CollapsibleCard>
-          )}
-      </VStack>
-    </ScrollView>
+              </CollapsibleCard>
+              {observation.media && observation.media.length > 0 && (
+                <CollapsibleCard
+                  startsCollapsed={false}
+                  borderRadius={0}
+                  borderColor="white"
+                  header={
+                    <HStack space={8} alignItems="center">
+                      <FontAwesome5 name="photo-video" size={24} color="black" />
+                      <Title1Black>Observation Media</Title1Black>
+                    </HStack>
+                  }>
+                  <Carousel thumbnailHeight={160} thumbnailAspectRatio={1.3} media={observation.media} displayCaptions={false} />
+                </CollapsibleCard>
+              )}
+              {((observation.avalanches && observation.avalanches.length > 0) || observation.avalanches_summary) && (
+                <CollapsibleCard
+                  startsCollapsed={false}
+                  borderRadius={0}
+                  borderWidth={0}
+                  borderColor="white"
+                  header={
+                    <HStack space={8} alignItems="center">
+                      <NACIcon name="avalanche" size={48} color="black" />
+                      <Title1Black>Avalanches</Title1Black>
+                    </HStack>
+                  }>
+                  {observation.avalanches &&
+                    observation.avalanches.length > 0 &&
+                    observation.avalanches.map((item, index) => (
+                      <VStack space={8} style={{flex: 1}} key={`avalanche-${index}`}>
+                        <HStack space={8} alignItems="center">
+                          <IdentifiedInformation
+                            header={'Date'}
+                            body={`${utcDateToLocalTimeString(item.date)} (${FormatAvalancheDateUncertainty(item.dateAccuracy as AvalancheDateUncertainty)})`}
+                          />
+                          <IdentifiedInformation header={'Location'} body={item.location} />
+                          <IdentifiedInformation header={'Size'} body={`D${item.dSize}-R${item.rSize}`} />
+                        </HStack>
+                        <HStack space={8} alignItems="center">
+                          <IdentifiedInformation
+                            header={'Trigger'}
+                            body={`${FormatAvalancheTrigger(item.trigger as AvalancheTrigger)} - ${FormatAvalancheCause(item.cause as AvalancheCause)}`}
+                          />
+                          <IdentifiedInformation
+                            header={'Start Zone'}
+                            body={`${FormatAvalancheAspect(item.aspect as AvalancheAspect)}, ${item.slopeAngle}° at ${item.elevation}ft`}
+                          />
+                          <IdentifiedInformation header={'Vertical Fall'} body={`${item.verticalFall}ft`} />
+                        </HStack>
+                        <HStack space={8} alignItems="center">
+                          <IdentifiedInformation header={'Crown Thickness'} body={`${item.avgCrownDepth}cm`} />
+                          <IdentifiedInformation header={'Width'} body={`${item.width}ft`} />
+                          <IdentifiedInformation header={'Type'} body={FormatAvalancheType(item.avalancheType as AvalancheType)} />
+                          <IdentifiedInformation header={'Bed Surface'} body={FormatAvalancheBedSurface(item.bedSfc as AvalancheBedSurface)} />
+                        </HStack>
+                        <>
+                          {item.media && item.media.length > 0 && (
+                            <VStack space={8} style={{flex: 1}}>
+                              <BodyBlack style={{textTransform: 'uppercase'}}>{'Avalanche Media'}</BodyBlack>
+                              <Carousel thumbnailHeight={160} thumbnailAspectRatio={1.3} media={item.media} displayCaptions={false} />
+                            </VStack>
+                          )}
+                        </>
+                        <>
+                          {item.comments && (
+                            <VStack space={8} style={{flex: 1}}>
+                              <BodyBlack style={{textTransform: 'uppercase'}}>{'Avalanche Comments'}</BodyBlack>
+                              <HTML source={{html: item.comments}} />
+                            </VStack>
+                          )}
+                        </>
+                      </VStack>
+                    ))}
+                  {observation.avalanches_summary && (
+                    <VStack space={8} style={{flex: 1}}>
+                      <BodyBlack style={{textTransform: 'uppercase'}}>{'Avalanche Summary'}</BodyBlack>
+                      <HTML source={{html: observation.avalanches_summary}} />
+                    </VStack>
+                  )}
+                </CollapsibleCard>
+              )}
+              {observation.advanced_fields && (observation.advanced_fields.weather || observation.advanced_fields.weather_summary) && (
+                <CollapsibleCard
+                  startsCollapsed={false}
+                  borderRadius={0}
+                  borderColor="white"
+                  header={
+                    <HStack space={8} alignItems="center">
+                      <MaterialCommunityIcons name="weather-snowy-heavy" size={24} color="black" />
+                      <Title1Black>Weather</Title1Black>
+                    </HStack>
+                  }>
+                  <>
+                    {observation.advanced_fields.weather && (
+                      <>
+                        <HStack flexWrap="wrap" space={8}>
+                          <IdentifiedWeatherInformation header={'Cloud Cover'} body={FormatCloudCover(observation.advanced_fields.weather.cloud_cover as CloudCover)} />
+                          <IdentifiedWeatherInformation header={'Temperature (F)'} body={observation.advanced_fields.weather.air_temp} />
+                          <IdentifiedWeatherInformation header={'New or Recent Snowfall'} body={observation.advanced_fields.weather.recent_snowfall} />
+                        </HStack>
+                        <HStack flexWrap="wrap" space={8}>
+                          <IdentifiedWeatherInformation header={'Rain/Snow Line (ft)'} body={observation.advanced_fields.weather.rain_elevation} />
+                          <IdentifiedWeatherInformation
+                            header={'Snow Available For Transport'}
+                            body={FormatSnowAvailableForTransport(observation.advanced_fields.weather.snow_avail_for_transport as SnowAvailableForTransport)}
+                          />
+                          <IdentifiedWeatherInformation header={'Wind Loading'} body={FormatWindLoading(observation.advanced_fields.weather.wind_loading as WindLoading)} />
+                        </HStack>
+                      </>
+                    )}
+                  </>
+                  <>
+                    {observation.advanced_fields.weather_summary && (
+                      <VStack space={8} style={{flex: 1}}>
+                        <BodyBlack style={{textTransform: 'uppercase'}}>{'Weather Summary'}</BodyBlack>
+                        <HTML source={{html: observation.advanced_fields.weather_summary}} />
+                      </VStack>
+                    )}
+                  </>
+                </CollapsibleCard>
+              )}
+              {observation.advanced_fields &&
+                (observation.advanced_fields.snowpack ||
+                  (observation.advanced_fields.snowpack_media && observation.advanced_fields.snowpack_media.length > 0) ||
+                  observation.advanced_fields.snowpack_summary) && (
+                  <CollapsibleCard
+                    startsCollapsed={false}
+                    borderRadius={0}
+                    borderColor="white"
+                    header={
+                      <HStack space={8} alignItems="center">
+                        <Fontisto name="snowflake" size={24} color="black" />
+                        <Title1Black>Snowpack Observations</Title1Black>
+                      </HStack>
+                    }>
+                    <>{observation.advanced_fields.snowpack && <>{/* we don't know what fields could be in this thing ... */}</>}</>
+                    <>
+                      {observation.advanced_fields.snowpack_summary && (
+                        <VStack space={8} style={{flex: 1}}>
+                          <BodyBlack style={{textTransform: 'uppercase'}}>{'Snowpack Summary'}</BodyBlack>
+                          <HTML source={{html: observation.advanced_fields.snowpack_summary}} />
+                        </VStack>
+                      )}
+                    </>
+                    <>
+                      {observation.advanced_fields.snowpack_media && observation.advanced_fields.snowpack_media.length > 0 && (
+                        <>
+                          <VStack space={8} style={{flex: 1}}>
+                            <BodyBlack style={{textTransform: 'uppercase'}}>{'Snowpack Media'}</BodyBlack>
+                            <Carousel thumbnailHeight={160} thumbnailAspectRatio={1.3} media={observation.advanced_fields.snowpack_media} displayCaptions={false} />
+                          </VStack>
+                        </>
+                      )}
+                    </>
+                  </CollapsibleCard>
+                )}
+            </VStack>
+          </ScrollView>
+        </VStack>
+      </SafeAreaView>
+    </View>
   );
 };
 

--- a/components/observations/ObservationFormData.ts
+++ b/components/observations/ObservationFormData.ts
@@ -77,6 +77,8 @@ export const simpleObservationFormSchema = z
     }
 
     // if instability.cracking, then we'll want cracking_description to be set
+    // cracking_description is an enum, so no max length validation is required -
+    // it just needs to be set
     if (arg.instability?.cracking) {
       const {cracking_description} = arg.instability;
       if (!cracking_description || cracking_description.length === 0) {
@@ -85,28 +87,18 @@ export const simpleObservationFormSchema = z
           message: required,
           path: ['instability', 'cracking_description'],
         });
-      } else if (cracking_description.length > 1024) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: tooLong,
-          path: ['instability', 'cracking_description'],
-        });
       }
     }
 
     // if instability.collapsing, then we'll want collapsing_description to be set
+    // collapsing_description is an enum, so no max length validation is required -
+    // it just needs to be set
     if (arg.instability?.collapsing) {
       const {collapsing_description} = arg.instability;
       if (!collapsing_description || collapsing_description.length === 0) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: required,
-          path: ['instability', 'collapsing_description'],
-        });
-      } else if (collapsing_description.length > 1024) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: tooLong,
           path: ['instability', 'collapsing_description'],
         });
       }

--- a/components/observations/ObservationsListView.tsx
+++ b/components/observations/ObservationsListView.tsx
@@ -15,7 +15,7 @@ import {useMapLayer} from 'hooks/useMapLayer';
 import {useNWACObservations} from 'hooks/useNWACObservations';
 import {OverviewFragment, useObservationsQuery} from 'hooks/useObservations';
 import {useRefresh} from 'hooks/useRefresh';
-import {FlatList, RefreshControl} from 'react-native';
+import {FlatList, FlatListProps, RefreshControl} from 'react-native';
 import {ObservationsStackNavigationProps} from 'routes';
 import {colorLookup} from 'theme';
 import {AvalancheCenterID, DangerLevel, MapLayer, PartnerType} from 'types/nationalAvalancheCenter';
@@ -24,11 +24,20 @@ import {apiDateString, RequestedTime, requestedTimeToUTCDate, utcDateToLocalDate
 
 // TODO: we could show the Avy center logo for obs that come from forecasters
 
-export const ObservationsListView: React.FunctionComponent<{
+interface ObservationsListViewItem {
+  id: OverviewFragment['id'];
+  observation: OverviewFragment;
+  source: 'nwac' | 'nac';
+  zone: string;
+}
+
+interface ObservationsListViewProps extends Omit<FlatListProps<ObservationsListViewItem>, 'data' | 'renderItem'> {
   center_id: AvalancheCenterID;
   requestedTime: RequestedTime;
   zone_name?: string;
-}> = ({center_id, requestedTime, zone_name}) => {
+}
+
+export const ObservationsListView: React.FunctionComponent<ObservationsListViewProps> = ({center_id, requestedTime, zone_name, ...props}) => {
   const mapResult = useMapLayer(center_id);
   const mapLayer = mapResult.data;
 
@@ -68,18 +77,18 @@ export const ObservationsListView: React.FunctionComponent<{
   }
 
   return (
-    <VStack space={8} backgroundColor={colorLookup('background.base')} pt={4}>
-      <FlatList
-        refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={refresh} />}
-        data={displayedObservations.map(observation => ({
-          id: observation.id,
-          observation: observation,
-          source: nwacObservations?.getObservationList.map(o => o.id).includes(observation.id) ? 'nwac' : 'nac',
-          zone: zone(mapLayer, observation.locationPoint?.lat, observation.locationPoint?.lng),
-        }))}
-        renderItem={({item}) => <ObservationSummaryCard source={item.source} observation={item.observation} zone={item.zone} />}
-      />
-    </VStack>
+    <FlatList
+      style={{backgroundColor: colorLookup('background.base')}}
+      refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={refresh} />}
+      data={displayedObservations.map(observation => ({
+        id: observation.id,
+        observation: observation,
+        source: nwacObservations?.getObservationList.map(o => o.id).includes(observation.id) ? 'nwac' : 'nac',
+        zone: zone(mapLayer, observation.locationPoint?.lat, observation.locationPoint?.lng),
+      }))}
+      renderItem={({item}) => <ObservationSummaryCard source={item.source} observation={item.observation} zone={item.zone} />}
+      {...props}
+    />
   );
 };
 

--- a/components/screens/ObservationsScreen.tsx
+++ b/components/screens/ObservationsScreen.tsx
@@ -1,26 +1,27 @@
+import {AntDesign} from '@expo/vector-icons';
+import {useNavigation} from '@react-navigation/native';
 import {createNativeStackNavigator, NativeStackScreenProps} from '@react-navigation/native-stack';
+import {HStack} from 'components/core';
 import {NWACObservationDetailView, ObservationDetailView} from 'components/observations/ObservationDetailView';
 import {ObservationsListView} from 'components/observations/ObservationsListView';
 import {ObservationsPortal} from 'components/observations/ObservationsPortal';
 import {SimpleForm} from 'components/observations/SimpleForm';
+import {Title3Black} from 'components/text';
 import React from 'react';
 import {StyleSheet, View} from 'react-native';
-import {ObservationsStackParamList, TabNavigatorParamList} from 'routes';
+import {SafeAreaView} from 'react-native-safe-area-context';
+import {ObservationsStackNavigationProps, ObservationsStackParamList, TabNavigatorParamList} from 'routes';
+import {colorLookup} from 'theme';
 import {parseRequestedTimeString} from 'utils/date';
 
 const ObservationsStack = createNativeStackNavigator<ObservationsStackParamList>();
 export const ObservationsTabScreen = ({route}: NativeStackScreenProps<TabNavigatorParamList, 'Observations'>) => {
   const {center_id, requestedTime} = route.params;
   return (
-    <ObservationsStack.Navigator initialRouteName="observationsPortal">
-      <ObservationsStack.Screen
-        name="observationsPortal"
-        component={ObservationsPortalScreen}
-        initialParams={{center_id: center_id, requestedTime}}
-        options={{headerShown: false}}
-      />
-      <ObservationsStack.Screen name="observationSubmit" component={ObservationSubmitScreen} options={{headerShown: false}} />
-      <ObservationsStack.Screen name="observationsList" component={ObservationsListScreen} options={() => ({title: `${center_id} Observations`})} />
+    <ObservationsStack.Navigator initialRouteName="observationsPortal" screenOptions={{headerShown: false}}>
+      <ObservationsStack.Screen name="observationsPortal" component={ObservationsPortalScreen} initialParams={{center_id: center_id, requestedTime}} />
+      <ObservationsStack.Screen name="observationSubmit" component={ObservationSubmitScreen} />
+      <ObservationsStack.Screen name="observationsList" component={ObservationsListScreen} />
       <ObservationsStack.Screen name="observation" component={ObservationScreen} />
       <ObservationsStack.Screen name="nwacObservation" component={NWACObservationScreen} />
     </ObservationsStack.Navigator>
@@ -39,9 +40,27 @@ const ObservationSubmitScreen = ({route}: NativeStackScreenProps<ObservationsSta
 
 const ObservationsListScreen = ({route}: NativeStackScreenProps<ObservationsStackParamList, 'observationsList'>) => {
   const {center_id, requestedTime} = route.params;
+  const navigation = useNavigation<ObservationsStackNavigationProps>();
+
+  const ListHeader = () => (
+    <HStack justifyContent="flex-start" pb={8} bg="white">
+      <AntDesign.Button
+        size={24}
+        color={colorLookup('text')}
+        name="arrowleft"
+        backgroundColor="white"
+        iconStyle={{marginLeft: 0, marginRight: 8}}
+        style={{textAlign: 'center'}}
+        onPress={() => navigation.goBack()}
+      />
+      <Title3Black>Observations</Title3Black>
+    </HStack>
+  );
   return (
-    <View style={styles.fullScreen}>
-      <ObservationsListView center_id={center_id} requestedTime={parseRequestedTimeString(requestedTime)} />
+    <View style={{...styles.fullScreen, backgroundColor: 'white'}}>
+      <SafeAreaView edges={['top', 'left', 'right']} style={{height: '100%', width: '100%'}}>
+        <ObservationsListView center_id={center_id} requestedTime={parseRequestedTimeString(requestedTime)} ListHeaderComponent={ListHeader} />
+      </SafeAreaView>
     </View>
   );
 };


### PR DESCRIPTION
_the diff looks huge, but a lot of it is whitespace changes_

1. Use the same navigation pattern as we do elsewhere:

list view | single observation
--- | ---
![simulator_screenshot_CFF4C9DA-CCEB-4D91-B8DB-601FF9897FDE](https://user-images.githubusercontent.com/101196/221994665-8d43ad60-8ac7-48e1-94a6-3639723a2220.png) | ![simulator_screenshot_95E5A769-54F7-4539-9FCB-9E3E81CE9F10](https://user-images.githubusercontent.com/101196/221994628-adb807fa-b847-4b5d-a4fd-ff8960a9603c.png)

2. Add a drop shadow to the tabs in the forecast view:
![simulator_screenshot_B7A093E2-E707-4CFE-BF16-C338125BA050](https://user-images.githubusercontent.com/101196/221994865-02e27b6f-0f6e-4907-99ce-e63488738996.png)

