### PR TITLE
workflows: stop submitting

### DIFF
--- a/.github/workflows/publish-build.yaml
+++ b/.github/workflows/publish-build.yaml
@@ -27,7 +27,7 @@ jobs:
           install_expo: true
           expo_token: ${{ secrets.EXPO_TOKEN }}
 
-      - name: 🚀 Build and submit Android and IOS apps
+      - name: 🚀 Build Android app
         env:
           IOS_USER_ID: ${{ secrets.IOS_USER_ID }}
           IOS_TEAM_ID: ${{ secrets.IOS_TEAM_ID }}
@@ -50,7 +50,7 @@ jobs:
           install_expo: true
           expo_token: ${{ secrets.EXPO_TOKEN }}
 
-      - name: 🚀 Build and submit Android and IOS apps
+      - name: 🚀 Build IOS app
         env:
           IOS_USER_ID: ${{ secrets.IOS_USER_ID }}
           IOS_TEAM_ID: ${{ secrets.IOS_TEAM_ID }}

--- a/eas_build_and_submit.sh
+++ b/eas_build_and_submit.sh
@@ -38,5 +38,5 @@ jq  < eas.json.tmpl > eas.json \
   '.submit.release.ios={appleId:$IOS_USER_ID,appleTeamId:$IOS_TEAM_ID,ascAppId:$IOS_APP_ID} | .submit.preview.ios=.submit.release.ios'
 
 set -o xtrace
-eas build --non-interactive --platform "${PLATFORM}" --profile "${PROFILE}" --auto-submit
+eas build --non-interactive --platform "${PLATFORM}" --profile "${PROFILE}"
 set +o xtrace


### PR DESCRIPTION
We need to rev the build numbers a bit to get them to a) line up and b) get above the manual stuff we did before. Only *after* that we can do the submission.