### PR TITLE
Fix for flipped thumbnails on observation

### DIFF
--- a/components/observations/ObservationFormData.ts
+++ b/components/observations/ObservationFormData.ts
@@ -1,6 +1,8 @@
+import {ImagePickerAsset} from 'expo-image-picker';
 import {merge} from 'lodash';
-import {Activity, InstabilityDistribution, MediaUsage, Observation, PartnerType} from 'types/nationalAvalancheCenter';
 import {z} from 'zod';
+
+import {Activity, InstabilityDistribution, MediaUsage, Observation, PartnerType} from 'types/nationalAvalancheCenter';
 
 export const defaultObservationFormData = (initialValues: Partial<Observation> | null = null): ObservationFormData =>
   merge(
@@ -108,5 +110,5 @@ export const simpleObservationFormSchema = z
   });
 
 export interface ObservationFormData extends z.infer<typeof simpleObservationFormSchema> {
-  uploadPaths: string[];
+  images: ImagePickerAsset[];
 }

--- a/components/observations/SimpleForm.tsx
+++ b/components/observations/SimpleForm.tsx
@@ -108,7 +108,7 @@ export const SimpleForm: React.FC<{
       mutation.reset();
       return;
     }
-    data.uploadPaths = images.map(image => image.uri);
+    data.images = images;
     mutation.mutate(data);
   };
 
@@ -152,6 +152,7 @@ export const SimpleForm: React.FC<{
       quality: 1,
       orderedSelection: true,
       selectionLimit: maxImageCount,
+      exif: true,
     });
 
     if (!result.canceled) {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "expo-device": "~5.0.0",
     "expo-file-system": "~15.1.1",
     "expo-font": "~11.0.1",
+    "expo-image-manipulator": "~11.0.0",
     "expo-image-picker": "~14.0.2",
     "expo-location": "~15.0.1",
     "expo-splash-screen": "~0.17.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6725,6 +6725,13 @@ expo-image-loader@~4.0.0:
   resolved "https://registry.yarnpkg.com/expo-image-loader/-/expo-image-loader-4.0.0.tgz#a17e5f95a4c1671791168dd5dfc221bf2f88480c"
   integrity sha512-hVMhXagsO1cSng5s70IEjuJAuHy2hX/inu5MM3T0ecJMf7L/7detKf22molQBRymerbk6Tzu+20h11eU0n/3jQ==
 
+expo-image-manipulator@~11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/expo-image-manipulator/-/expo-image-manipulator-11.0.0.tgz#f863bfcbc1534d92e9efc6f9265cf152cf7988c1"
+  integrity sha512-CDiqOrhN1TSWw/4t7Xo97U+Xzoc437oCHbZH7+4RhhmPBlu5/2b4UjoEiw/gPWu9DD7OS/TRvO027axod9QNDQ==
+  dependencies:
+    expo-image-loader "~4.0.0"
+
 expo-image-picker@~14.0.2:
   version "14.0.3"
   resolved "https://registry.yarnpkg.com/expo-image-picker/-/expo-image-picker-14.0.3.tgz#ea0bbe796ccc3bd5e58fc00487be22bac317afeb"


### PR DESCRIPTION
This fixes a bug observed in this observation: https://forecasts.avalanche.org/observations/#/view/3223b09d-3a04-416c-bd5f-403402913412. The thumbnails are flipped upside-down. The original image orientation is set as upside-down, because I took the photos one-handed with the phone considered "upside-down" (lenses were along the bottom edge if that helps you visualize).

Many apps (but certainly not all!) take this orientation field into account and flip the images automatically for you. The NAC thumbnail generation pipeline does not, so the thumbnails just get saved as "normal" even though they're not.

I let @thechrislundy know about this issue on the NAC side, but in the meantime this PR works around the bug by automatically creating new copies of the images locally before uploading. There is a downside: the saved images are smaller (1800x1200), but at least they look right.