### PR TITLE
Fix scrollview sizing for all 3 forecast tabs

### DIFF
--- a/components/TabControl.tsx
+++ b/components/TabControl.tsx
@@ -31,7 +31,7 @@ export const TabControl: React.FunctionComponent<TabControlProps> = ({children, 
   } as const;
 
   return (
-    <VStack style={{width: '100%', backgroundColor}}>
+    <VStack style={{width: '100%', flex: 1, flexGrow: 1, justifyContent: 'space-between', backgroundColor}}>
       <HStack
         justifyContent="space-evenly"
         alignItems="center"

--- a/components/forecast/AvalancheForecast.tsx
+++ b/components/forecast/AvalancheForecast.tsx
@@ -6,7 +6,7 @@ import {useNavigation} from '@react-navigation/native';
 import {TouchableOpacity} from 'react-native';
 import * as Sentry from 'sentry-expo';
 
-import {HStack, View} from 'components/core';
+import {HStack, View, VStack} from 'components/core';
 
 import {Tab, TabControl} from 'components/TabControl';
 import {useAvalancheCenterMetadata} from 'hooks/useAvalancheCenterMetadata';
@@ -70,7 +70,7 @@ export const AvalancheForecast: React.FunctionComponent<AvalancheForecastProps> 
   const zones = uniq(center.zones.filter(z => z.status === 'active').map(z => z.name));
 
   return (
-    <>
+    <VStack style={{height: '100%', width: '100%', justifyContent: 'space-between'}}>
       <HStack justifyContent="space-between" alignItems="center" space={8} width="100%" height={64}>
         <View pl={8} py={8}>
           <TouchableOpacity onPress={onReturnToMapView}>
@@ -98,6 +98,6 @@ export const AvalancheForecast: React.FunctionComponent<AvalancheForecastProps> 
           <ObservationsTab zone_name={zone.name} center_id={center_id} requestedTime={requestedTime} />
         </Tab>
       </TabControl>
-    </>
+    </VStack>
   );
 };

--- a/components/observations/ObservationsListView.tsx
+++ b/components/observations/ObservationsListView.tsx
@@ -79,7 +79,7 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
 
   return (
     <FlatList
-      style={{backgroundColor: colorLookup('background.base')}}
+      style={{backgroundColor: colorLookup('background.base'), width: '100%', height: '100%'}}
       refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={refresh} />}
       data={displayedObservations.map(observation => ({
         id: observation.id,

--- a/components/screens/ForecastScreen.tsx
+++ b/components/screens/ForecastScreen.tsx
@@ -4,7 +4,6 @@ import {SafeAreaView} from 'react-native-safe-area-context';
 
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 
-import {View} from 'components/core';
 import {AvalancheForecast} from 'components/forecast/AvalancheForecast';
 import {HomeStackParamList} from 'routes';
 import {parseRequestedTimeString} from 'utils/date';
@@ -14,9 +13,7 @@ export const ForecastScreen = ({route}: NativeStackScreenProps<HomeStackParamLis
   return (
     // hat tip to https://github.com/react-navigation/react-navigation/issues/8694 for the use of `edges`
     <SafeAreaView style={StyleSheet.absoluteFillObject} edges={['top', 'left', 'right']}>
-      <View width="100%" height="100%">
-        <AvalancheForecast center_id={center_id} forecast_zone_id={forecast_zone_id} requestedTime={parseRequestedTimeString(requestedTime)} zoneName={zoneName} />
-      </View>
+      <AvalancheForecast center_id={center_id} forecast_zone_id={forecast_zone_id} requestedTime={parseRequestedTimeString(requestedTime)} zoneName={zoneName} />
     </SafeAreaView>
   );
 };


### PR DESCRIPTION
There were places where we were using 100% height inappropriately - simplified, it was something like this:

```html
<VStack height="100%">
  <View height={120}>
    ...some header content
  </View>
  <View height="100%">
    body content. by using 100%, we're hoping to fill the remaining height of the
    VStack parent, but instead we're getting _exactly_ the height of the VStack
  </View>
</VStack>
```

The solution was to make the VStack use `justifyContent="space-between"` and allow the last child to flex into the whole space.

https://user-images.githubusercontent.com/101196/222279518-16a3f1ae-4900-4a69-91f3-efb4d05d3717.mp4

