### PR TITLE
eas.json: update the config

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -1,6 +1,6 @@
 {
   "cli": {
-    "version": ">= 0.60.0",
+    "version": ">= 3.7.2",
     "appVersionSource": "remote"
   },
   "build": {
@@ -24,6 +24,9 @@
         "appleId": "IOS_USER_ID",
         "appleTeamId": "IOS_TEAM_ID",
         "ascAppId": "IOS_APP_ID"
+      },
+      "android": {
+        "track": "internal"
       }
     },
     "release": {


### PR DESCRIPTION
We are still in draft mode on the app in Google Play, but perhaps if we explicitly target the release to internal testers, we won't need to upload it as a draft and then manually push buttons to send it out?