### PR TITLE
workflows: stop doing ios, requiring tests

### DIFF
--- a/.github/workflows/publish-build.yaml
+++ b/.github/workflows/publish-build.yaml
@@ -11,12 +11,8 @@ defaults:
     shell: bash
 
 jobs:
-  ci:
-    uses: ./.github/workflows/ci.yaml # use the callable ci job to run CI checks
 
   build-android:
-    # CI ideally *shouldn't* fail post-merge, but you could imagine criss-crossing PRs that break tests
-    needs: [ci]
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup repo
@@ -35,27 +31,4 @@ jobs:
           IOS_APP_ID: ${{ secrets.IOS_APP_ID }}
           PROFILE: ${{ github.ref_name }}
           PLATFORM: 'android'
-        run: ./eas_build_and_submit.sh
-
-  build-ios:
-    # CI ideally *shouldn't* fail post-merge, but you could imagine criss-crossing PRs that break tests
-    needs: [ci]
-    runs-on: ubuntu-latest
-    steps:
-      - name: 🏗 Setup repo
-        uses: actions/checkout@v2
-
-      - name: 🏗 Setup build environment
-        uses: ./.github/actions/setup
-        with:
-          install_expo: true
-          expo_token: ${{ secrets.EXPO_TOKEN }}
-
-      - name: 🚀 Build IOS app
-        env:
-          IOS_USER_ID: ${{ secrets.IOS_USER_ID }}
-          IOS_TEAM_ID: ${{ secrets.IOS_TEAM_ID }}
-          IOS_APP_ID: ${{ secrets.IOS_APP_ID }}
-          PROFILE: ${{ github.ref_name }}
-          PLATFORM: 'ios'
         run: ./eas_build_and_submit.sh


### PR DESCRIPTION
I will revert this later - this just makes the workflow minimal so I can trigger it a couple times to get our Android build numbers in order.