### PR TITLE
Fix weather card rendering to deal with various permutations of missing data

### DIFF
--- a/components/observations/ObservationDetailView.test.tsx
+++ b/components/observations/ObservationDetailView.test.tsx
@@ -3,7 +3,7 @@ jest.mock('@sentry/react-native', () => ({init: () => jest.fn()}));
 
 import {render, screen} from '@testing-library/react-native';
 
-import {WeatherCard} from 'components/observations/ObservationDetailView';
+import {WeatherCard, withUnits} from 'components/observations/ObservationDetailView';
 import {RenderHTMLConfigProvider, TRenderEngineProvider} from 'react-native-render-html';
 import {CloudCover} from 'types/nationalAvalancheCenter';
 
@@ -68,6 +68,23 @@ describe('ObservationDetailView', () => {
         expect(screen.queryByTestId('card')).not.toBeNull();
         expect(screen.queryByText('Scattered')).not.toBeNull();
       });
+    });
+  });
+
+  describe('withUnits', () => {
+    it('appends units to numbers and strings that look like numbers', () => {
+      expect(withUnits(2, 'light-years')).toEqual('2light-years');
+      expect(withUnits('2', 'light-years')).toEqual('2light-years');
+    });
+
+    it('leaves strings alone, even partially numeric ones', () => {
+      expect(withUnits('some', 'light-years')).toEqual('some');
+      expect(withUnits("7800'", 'feet')).toEqual("7800'");
+    });
+
+    it('returns a default for missing/null values', () => {
+      expect(withUnits(null, 'light-years')).toEqual('Unknown');
+      expect(withUnits(undefined, 'light-years')).toEqual('Unknown');
     });
   });
 });

--- a/components/observations/ObservationDetailView.test.tsx
+++ b/components/observations/ObservationDetailView.test.tsx
@@ -1,0 +1,73 @@
+// This class pulls in Sentry, which makes Jest blow up
+jest.mock('@sentry/react-native', () => ({init: () => jest.fn()}));
+
+import {render, screen} from '@testing-library/react-native';
+
+import {WeatherCard} from 'components/observations/ObservationDetailView';
+import {RenderHTMLConfigProvider, TRenderEngineProvider} from 'react-native-render-html';
+import {CloudCover} from 'types/nationalAvalancheCenter';
+
+describe('ObservationDetailView', () => {
+  describe('WeatherCard', () => {
+    describe('empty state', () => {
+      it("renders null when advanced_fields isn't set", () => {
+        render(<WeatherCard observation={{}} testID="card" />);
+        expect(() => screen.getByTestId('card')).toThrowError(/Unable to find an element with testID: card/);
+      });
+
+      it('renders null when weather_summary and weather are missing', () => {
+        render(<WeatherCard observation={{advanced_fields: {}}} testID="card" />);
+        expect(() => screen.getByTestId('card')).toThrowError(/Unable to find an element with testID: card/);
+      });
+
+      it('renders null when weather_summary and weather are null', () => {
+        render(<WeatherCard observation={{advanced_fields: {weather_summary: null, weather: null}}} testID="card" />);
+        expect(() => screen.getByTestId('card')).toThrowError(/Unable to find an element with testID: card/);
+      });
+
+      it('renders null when weather_summary is "" and weather is null', () => {
+        render(<WeatherCard observation={{advanced_fields: {weather_summary: '', weather: null}}} testID="card" />);
+        expect(() => screen.getByTestId('card')).toThrowError(/Unable to find an element with testID: card/);
+      });
+
+      it('renders null when weather_summary is "" and weather is {}', () => {
+        render(<WeatherCard observation={{advanced_fields: {weather_summary: '', weather: {}}}} testID="card" />);
+        expect(() => screen.getByTestId('card')).toThrowError(/Unable to find an element with testID: card/);
+      });
+
+      it('renders null when weather_summary is "" and weather is {cloud_cover: ""}', () => {
+        render(<WeatherCard observation={{advanced_fields: {weather_summary: '', weather: {cloud_cover: ''}}}} testID="card" />);
+        expect(() => screen.getByTestId('card')).toThrowError(/Unable to find an element with testID: card/);
+      });
+    });
+
+    describe('normal state', () => {
+      it('renders summary when weather summary set', () => {
+        // When rendering HTML content, we need TRenderEngineProvider & RenderHTMLConfigProvider in the tree
+        render(
+          <TRenderEngineProvider>
+            <RenderHTMLConfigProvider>
+              <WeatherCard observation={{advanced_fields: {weather_summary: '<p>it was cold</p>'}}} testID="card" />
+            </RenderHTMLConfigProvider>
+          </TRenderEngineProvider>,
+        );
+
+        expect(screen.queryByTestId('card')).not.toBeNull();
+        expect(screen.queryByText('it was cold')).not.toBeNull();
+      });
+
+      it('renders cloud_cover when set', () => {
+        render(
+          <TRenderEngineProvider>
+            <RenderHTMLConfigProvider>
+              <WeatherCard observation={{advanced_fields: {weather: {cloud_cover: CloudCover.Scattered}, weather_summary: '<p>it was cold</p>'}}} testID="card" />
+            </RenderHTMLConfigProvider>
+          </TRenderEngineProvider>,
+        );
+
+        expect(screen.queryByTestId('card')).not.toBeNull();
+        expect(screen.queryByText('Scattered')).not.toBeNull();
+      });
+    });
+  });
+});

--- a/components/observations/ObservationDetailView.tsx
+++ b/components/observations/ObservationDetailView.tsx
@@ -125,6 +125,16 @@ export const WeatherCard = ({observation, ...props}: {observation: Observation} 
   );
 };
 
+export const withUnits = (value: string | number | null | undefined, units: string) => {
+  if (value == null) {
+    return 'Unknown';
+  } else if (Number.isNaN(Number(value))) {
+    return value;
+  } else {
+    return `${value}${units}`;
+  }
+};
+
 export const ObservationCard: React.FunctionComponent<{
   observation: Observation;
   mapLayer: MapLayer;
@@ -278,11 +288,11 @@ export const ObservationCard: React.FunctionComponent<{
                         )}
                         <TableRow
                           label={'Start Zone'}
-                          value={`${FormatAvalancheAspect(item.aspect as AvalancheAspect)}${item.slopeAngle ? `, ${item.slopeAngle}°` : ''} at ${item.elevation}ft`}
+                          value={`${FormatAvalancheAspect(item.aspect as AvalancheAspect)}${item.slopeAngle ? `, ${item.slopeAngle}°` : ''} at ${withUnits(item.elevation, 'ft')}`}
                         />
-                        {item.verticalFall && <TableRow label={'Vertical Fall'} value={`${item.verticalFall}ft`} />}
-                        {item.avgCrownDepth && <TableRow label={'Crown Thickness'} value={`${item.avgCrownDepth}cm`} />}
-                        {item.width && <TableRow label={'Width'} value={`${item.width}ft`} />}
+                        {item.verticalFall && <TableRow label={'Vertical Fall'} value={`${withUnits(item.verticalFall, 'ft')}`} />}
+                        {item.avgCrownDepth && <TableRow label={'Crown Thickness'} value={`${withUnits(item.avgCrownDepth, 'cm')}`} />}
+                        {item.width && <TableRow label={'Width'} value={`${withUnits(item.width, 'ft')}`} />}
                         {item.avalancheType && <TableRow label={'Type'} value={FormatAvalancheType(item.avalancheType as AvalancheType)} />}
                         {item.verticalFall && <TableRow label={'Bed Surface'} value={FormatAvalancheBedSurface(item.bedSfc as AvalancheBedSurface)} />}
                         {item.media && item.media.length > 0 && (

--- a/components/observations/ObservationDetailView.tsx
+++ b/components/observations/ObservationDetailView.tsx
@@ -1,5 +1,3 @@
-import log from 'logger';
-
 import React from 'react';
 import {Image, ScrollView, StyleSheet} from 'react-native';
 
@@ -113,9 +111,9 @@ export const WeatherCard = ({observation, ...props}: {observation: Observation} 
         {/* Using Boolean() here so that we don't end up rendering empty strings inline */}
         {Boolean(weather_summary) && <HTML source={{html: weather_summary}} />}
         {Boolean(cloud_cover) && <TableRow label={'Cloud Cover'} value={FormatCloudCover(cloud_cover as CloudCover)} />}
-        {Boolean(air_temp) && <TableRow label={'Temperature (F)'} value={air_temp || 'Unknown'} />}
+        {Boolean(air_temp) && <TableRow label={'Temperature (F)'} value={air_temp} />}
         {Boolean(recent_snowfall) && <TableRow label={'New or Recent Snowfall'} value={recent_snowfall} />}
-        {Boolean(rain_elevation) && <TableRow label={'Rain/Snow Line (ft)'} value={rain_elevation || 'Unknown'} />}
+        {Boolean(rain_elevation) && <TableRow label={'Rain/Snow Line (ft)'} value={rain_elevation} />}
         {Boolean(snow_avail_for_transport) && (
           <TableRow label={'Snow Available For Transport'} value={FormatSnowAvailableForTransport(snow_avail_for_transport as SnowAvailableForTransport)} />
         )}
@@ -142,7 +140,6 @@ export const ObservationCard: React.FunctionComponent<{
   const navigation = useNavigation<ObservationsStackNavigationProps>();
   const {avalanches_observed, avalanches_triggered, avalanches_caught} = observation.instability;
 
-  log.info(observation);
   return (
     <View style={{...StyleSheet.absoluteFillObject, backgroundColor: 'white'}}>
       <SafeAreaView edges={['top', 'left', 'right']} style={{height: '100%', width: '100%'}}>

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@graphql-codegen/add": "^3.2.3",
     "@graphql-codegen/typescript-operations": "^2.5.10",
     "@graphql-codegen/typescript-react-query": "^4.0.6",
-    "@testing-library/jest-native": "^5.4.1",
+    "@testing-library/jest-native": "^5.4.2",
     "@testing-library/react-native": "^11.5.0",
     "@types/color": "^3.0.3",
     "@types/jest": "^29.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3418,7 +3418,7 @@
     "@tanstack/query-core" "4.24.9"
     use-sync-external-store "^1.2.0"
 
-"@testing-library/jest-native@^5.4.1":
+"@testing-library/jest-native@^5.4.2":
   version "5.4.2"
   resolved "https://registry.yarnpkg.com/@testing-library/jest-native/-/jest-native-5.4.2.tgz#6b0c987cc57f8d900763e763025d00d26ccbc85f"
   integrity sha512-Vo/CE1uvCVH1H8YPoOEXLXVsm+BjzSQTq35+wkri1fr0O5D+A2WZ+m3ni5g6f1OCzNKNGIAHmisBEWkDs1P1mw==


### PR DESCRIPTION
This is a quick follow up to #229, which tried to be clever about only rendering the pieces of the weather section that actually had data. Now it's not clever, but is provably more correct, and has tests attached to prove it.