### PR TITLE
observations: use a map marker to show the location

### DIFF
--- a/components/observations/ObservationDetailView.tsx
+++ b/components/observations/ObservationDetailView.tsx
@@ -10,7 +10,7 @@ import {Card, CardProps} from 'components/content/Card';
 import {Carousel} from 'components/content/carousel';
 import {incompleteQueryState, QueryState} from 'components/content/QueryState';
 import {ZoneMap} from 'components/content/ZoneMap';
-import {Center, HStack, View, VStack} from 'components/core';
+import {HStack, View, VStack} from 'components/core';
 import {NACIcon} from 'components/icons/nac-icons';
 import {zone} from 'components/observations/ObservationsListView';
 import {AllCapsSm, AllCapsSmBlack, Body, BodyBlack, BodySemibold, bodySize, Title3Black} from 'components/text';
@@ -18,6 +18,7 @@ import {HTML} from 'components/text/HTML';
 import {useMapLayer} from 'hooks/useMapLayer';
 import {useNACObservation} from 'hooks/useNACObservation';
 import {useNWACObservation} from 'hooks/useNWACObservation';
+import {Marker} from 'react-native-maps';
 import {ObservationsStackNavigationProps} from 'routes';
 import {colorLookup} from 'theme';
 import {
@@ -192,9 +193,9 @@ export const ObservationCard: React.FunctionComponent<{
                         latitudeDelta: 0.075,
                         longitudeDelta: 0.075,
                       }}>
-                      <Center width="100%" height="100%" position="absolute" backgroundColor={undefined} pointerEvents="none">
-                        <Image source={require('assets/map-marker.png')} style={{width: 40, height: 40, transform: [{translateY: -20}]}} />
-                      </Center>
+                      <Marker coordinate={{latitude: observation.location_point.lat, longitude: observation.location_point.lng}} anchor={{x: 0.5, y: 1}}>
+                        <Image source={require('assets/map-marker.png')} style={{width: 40, height: 40}} />
+                      </Marker>
                     </ZoneMap>
                   )}
                   <TableRow label="Location" value={observation.location_name} />

--- a/components/screens/ObservationsScreen.tsx
+++ b/components/screens/ObservationsScreen.tsx
@@ -7,7 +7,6 @@ import {ObservationsListView} from 'components/observations/ObservationsListView
 import {ObservationsPortal} from 'components/observations/ObservationsPortal';
 import {SimpleForm} from 'components/observations/SimpleForm';
 import {Title3Black} from 'components/text';
-import log from 'logger';
 import React from 'react';
 import {StyleSheet, View} from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
@@ -68,7 +67,6 @@ const ObservationsListScreen = ({route}: NativeStackScreenProps<ObservationsStac
 
 export const ObservationScreen = ({route}: NativeStackScreenProps<ObservationsStackParamList, 'observation'>) => {
   const {id} = route.params;
-  log.info('navigating to NAC observation', id);
   return (
     <View style={styles.fullScreen}>
       <ObservationDetailView id={id} />
@@ -78,7 +76,6 @@ export const ObservationScreen = ({route}: NativeStackScreenProps<ObservationsSt
 
 export const NWACObservationScreen = ({route}: NativeStackScreenProps<ObservationsStackParamList, 'nwacObservation'>) => {
   const {id} = route.params;
-  log.info('navigating to NWAC observation', id);
   return (
     <View style={styles.fullScreen}>
       <NWACObservationDetailView id={id} />


### PR DESCRIPTION
observations: use a map marker to show the location

You are not supposed to be putting other types of elements into the
children of the map, and the map marker component from the library is
what we want here, anyway. We can't use the built-in `image` prop on the
marker since we need to re-size our marker; apparently there are
performance problems when there are many markers with custom image
children on one map, but we know we will only ever have one here.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

logging: remove some spammy logs

These are not really that useful when we get them from a user.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

