### PR TITLE
Update button styles

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -48,6 +48,7 @@ import ImageCache from 'hooks/useCachedImageURI';
 import {useOnlineManager} from 'hooks/useOnlineManager';
 import {prefetchAllActiveForecasts} from 'network/prefetchAllActiveForecasts';
 import {TabNavigatorParamList} from 'routes';
+import {colorLookup} from 'theme';
 import {AvalancheCenterID} from 'types/nationalAvalancheCenter';
 require('date-time-format-timezone');
 
@@ -249,6 +250,9 @@ const BaseApp: React.FunctionComponent<{
                         return <MaterialCommunityIcons name="dots-horizontal" size={size} color={color} />;
                       }
                     },
+                    // these two properties should really take ColorValue but oh well
+                    tabBarActiveTintColor: colorLookup('primary') as string,
+                    tabBarInactiveTintColor: colorLookup('text.secondary') as string,
                   })}>
                   <TabNavigator.Screen name="Home" initialParams={{center_id: avalancheCenterId, requestedTime: 'latest'}}>
                     {state => HomeTabScreen(merge(state, {route: {params: {center_id: avalancheCenterId}}}))}

--- a/components/content/Button.tsx
+++ b/components/content/Button.tsx
@@ -2,16 +2,21 @@ import {Center, View, ViewProps} from 'components/core';
 import React, {useState} from 'react';
 import {ColorValue, GestureResponderEvent, Pressable, Text} from 'react-native';
 import {colorLookup} from 'theme';
-import tinycolor from 'tinycolor2';
 
 interface ButtonStyle {
   backgroundColor?: ColorValue;
   borderColor: ColorValue;
   textColor: ColorValue;
-  disabledBackgroundColor?: ColorValue;
-  disabledBorderColor: ColorValue;
-  disabledTextColor: ColorValue;
-  pressedBackgroundColor: ColorValue;
+  disabled: {
+    backgroundColor?: ColorValue;
+    borderColor: ColorValue;
+    textColor: ColorValue;
+  };
+  pressed: {
+    backgroundColor?: ColorValue;
+    borderColor: ColorValue;
+    textColor: ColorValue;
+  };
 }
 
 type PredefinedButtonStyle = 'normal' | 'primary' | 'destructive';
@@ -20,28 +25,45 @@ const styles = {
   normal: {
     borderColor: colorLookup('primary'),
     textColor: colorLookup('primary'),
-    disabledBorderColor: tinycolor(colorLookup('primary')).desaturate(80).toRgbString(),
-    disabledTextColor: tinycolor(colorLookup('primary')).desaturate(80).toRgbString(),
-    disabledBackgroundColor: tinycolor(colorLookup('primary')).setAlpha(0.2).desaturate(80).toRgbString(),
-    pressedBackgroundColor: tinycolor(colorLookup('primary')).setAlpha(0.2).toRgbString(),
+    disabled: {
+      backgroundColor: colorLookup('disabled'),
+      borderColor: colorLookup('disabled'),
+      textColor: colorLookup('text'),
+    },
+    pressed: {
+      borderColor: colorLookup('blue2'),
+      textColor: colorLookup('blue2'),
+    },
   },
   primary: {
     backgroundColor: colorLookup('primary'),
     borderColor: colorLookup('primary'),
     textColor: colorLookup('white'),
-    disabledBackgroundColor: tinycolor(colorLookup('primary')).desaturate(80).toRgbString(),
-    disabledBorderColor: tinycolor(colorLookup('primary')).desaturate(80).toRgbString(),
-    disabledTextColor: tinycolor(colorLookup('white')).desaturate(80).toRgbString(),
-    pressedBackgroundColor: tinycolor(colorLookup('primary')).setAlpha(0.6).toRgbString(),
+    disabled: {
+      backgroundColor: colorLookup('disabled'),
+      borderColor: colorLookup('disabled'),
+      textColor: colorLookup('text'),
+    },
+    pressed: {
+      borderColor: colorLookup('blue2'),
+      backgroundColor: colorLookup('blue2'),
+      textColor: colorLookup('white'),
+    },
   },
   destructive: {
-    backgroundColor: colorLookup('red.700'),
-    borderColor: colorLookup('red.700'),
+    backgroundColor: colorLookup('error.color'),
+    borderColor: colorLookup('error.color'),
     textColor: colorLookup('white'),
-    disabledBackgroundColor: tinycolor(colorLookup('red.700')).desaturate(80).toRgbString(),
-    disabledBorderColor: tinycolor(colorLookup('red.700')).desaturate(80).toRgbString(),
-    disabledTextColor: tinycolor(colorLookup('red.700')).desaturate(80).toRgbString(),
-    pressedBackgroundColor: tinycolor(colorLookup('red.700')).setAlpha(0.6).toRgbString(),
+    disabled: {
+      backgroundColor: colorLookup('disabled'),
+      borderColor: colorLookup('disabled'),
+      textColor: colorLookup('text'),
+    },
+    pressed: {
+      borderColor: colorLookup('error.color-primary'),
+      backgroundColor: colorLookup('error.color-primary'),
+      textColor: colorLookup('white'),
+    },
   },
 };
 
@@ -57,19 +79,14 @@ interface StyledButtonProps extends BaseButtonProps {
 
 const StyledButton: React.FC<StyledButtonProps> = ({buttonStyle, children, onPress, disabled = false, ...props}) => {
   const [pressed, setIsPressed] = useState<boolean>(false);
-  const {borderColor, textColor, pressedBackgroundColor, backgroundColor, disabledBackgroundColor, disabledBorderColor, disabledTextColor} = buttonStyle;
+  const colorStyleSource = disabled ? buttonStyle.disabled : pressed ? buttonStyle.pressed : buttonStyle;
+  const {backgroundColor, borderColor, textColor} = colorStyleSource;
 
   return (
-    <View
-      borderColor={disabled ? disabledBorderColor : borderColor}
-      borderWidth={2}
-      borderRadius={12}
-      p={8}
-      {...props}
-      backgroundColor={disabled ? disabledBackgroundColor : pressed ? pressedBackgroundColor : backgroundColor}>
+    <View borderColor={borderColor} borderWidth={2} borderRadius={8} py={12} px={16} {...props} backgroundColor={backgroundColor}>
       <Pressable disabled={disabled} onPressIn={() => setIsPressed(true)} onPressOut={() => setIsPressed(false)} onPress={event => onPress?.(event)}>
         <Center>
-          <Text style={{color: disabled ? disabledTextColor : textColor}}>{children}</Text>
+          <Text style={{color: textColor}}>{children}</Text>
         </Center>
       </Pressable>
     </View>

--- a/components/content/InfoTooltip.tsx
+++ b/components/content/InfoTooltip.tsx
@@ -1,7 +1,7 @@
 import {AntDesign} from '@expo/vector-icons';
 import {Button} from 'components/content/Button';
 import {Center, View, VStack} from 'components/core';
-import {Body, Title3Semibold} from 'components/text';
+import {BodyBlack, Title3Semibold} from 'components/text';
 import {HTML, HTMLRendererConfig, HTMLRendererConfigProps} from 'components/text/HTML';
 import {merge} from 'lodash';
 import React, {useCallback, useState} from 'react';
@@ -64,7 +64,7 @@ export const InfoTooltip: React.FC<InfoTooltipProps> = ({
                     <HTML source={{html: content}} />
                   </HTMLRendererConfig>
                   <Button onPress={closeModal} alignSelf="stretch">
-                    <Body>Close</Body>
+                    <BodyBlack>Close</BodyBlack>
                   </Button>
                 </VStack>
               </Center>

--- a/components/content/Outcome.tsx
+++ b/components/content/Outcome.tsx
@@ -1,6 +1,6 @@
 import {Button} from 'components/content/Button';
 import {View, VStack} from 'components/core';
-import {Body, BodySemibold, FeatureTitleBlack} from 'components/text';
+import {Body, BodyBlack, FeatureTitleBlack} from 'components/text';
 import React, {ReactNode} from 'react';
 import {GestureResponderEvent} from 'react-native';
 
@@ -25,11 +25,11 @@ export const Outcome: React.FunctionComponent<OutcomeOptions> = ({outcome, reaso
             </VStack>
             {onRetry && (
               <Button width={'100%'} buttonStyle="primary" onPress={onRetry}>
-                <BodySemibold>Retry</BodySemibold>
+                <BodyBlack>Retry</BodyBlack>
               </Button>
             )}
             <Button width={'100%'} buttonStyle={onRetry ? 'normal' : 'primary'} onPress={onClose}>
-              <BodySemibold>Close</BodySemibold>
+              <BodyBlack>Close</BodyBlack>
             </Button>
           </VStack>
         </View>

--- a/components/observations/ObservationsPortal.tsx
+++ b/components/observations/ObservationsPortal.tsx
@@ -2,7 +2,7 @@ import {useNavigation} from '@react-navigation/native';
 import Topo from 'assets/illustrations/topo.svg';
 import {Button} from 'components/content/Button';
 import {View, VStack} from 'components/core';
-import {Body, BodySemibold, Title3Black} from 'components/text';
+import {Body, BodyBlack, Title3Black} from 'components/text';
 import React from 'react';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {ObservationsStackNavigationProps} from 'routes';
@@ -24,10 +24,10 @@ export const ObservationsPortal: React.FC<{
           <Title3Black textAlign="center">You haven't submitted any observations in the App yet</Title3Black>
           <Body textAlign="center">Help keep the {center_id} community informed by submitting your observation.</Body>
           <Button buttonStyle="primary" onPress={() => navigation.navigate('observationSubmit', {center_id})}>
-            <BodySemibold>Submit an observation</BodySemibold>
+            <BodyBlack>Submit an observation</BodyBlack>
           </Button>
           <Button onPress={() => navigation.navigate('observationsList', {center_id, requestedTime: formatRequestedTime(requestedTime)})}>
-            <BodySemibold>View all observations</BodySemibold>
+            <BodyBlack>View all observations</BodyBlack>
           </Button>
         </VStack>
       </SafeAreaView>

--- a/components/observations/SimpleForm.tsx
+++ b/components/observations/SimpleForm.tsx
@@ -25,7 +25,7 @@ import {SwitchField} from 'components/form/SwitchField';
 import {TextField} from 'components/form/TextField';
 import {defaultObservationFormData, ObservationFormData, simpleObservationFormSchema} from 'components/observations/ObservationFormData';
 import {submitObservation} from 'components/observations/submitObservation';
-import {Body, BodySemibold, Title3Black, Title3Semibold} from 'components/text';
+import {Body, BodyBlack, BodySemibold, Title3Black, Title3Semibold} from 'components/text';
 import {ObservationsStackNavigationProps} from 'routes';
 import {colorLookup} from 'theme';
 import {AvalancheCenterID, InstabilityDistribution, MediaItem, MediaType, Observation} from 'types/nationalAvalancheCenter';
@@ -455,7 +455,7 @@ export const SimpleForm: React.FC<{
                         />
                       )}
                       <Button buttonStyle="normal" onPress={pickImage} disabled={images.length === maxImageCount}>
-                        <BodySemibold>Select an image</BodySemibold>
+                        <BodyBlack>Select an image</BodyBlack>
                       </Button>
                     </VStack>
                   </Card>
@@ -474,7 +474,7 @@ export const SimpleForm: React.FC<{
                     {mutation.isLoading && (
                       <HStack space={8} alignItems="center" pt={3}>
                         <ActivityIndicator size="small" />
-                        <BodySemibold color={colorLookup('white')}>Cancel submission</BodySemibold>
+                        <BodyBlack color={colorLookup('white')}>Cancel submission</BodyBlack>
                       </HStack>
                     )}
                     {!mutation.isLoading && <BodySemibold>Submit your observation</BodySemibold>}

--- a/components/screens/MenuScreen.tsx
+++ b/components/screens/MenuScreen.tsx
@@ -75,6 +75,7 @@ export const MenuStackScreen = (
         component={AvalancheCenterSelectorScreen(avalancheCenterId, setAvalancheCenter)}
         options={{title: `Choose An Avalanche Center`}}
       />
+      <MenuStack.Screen name="buttonStylePreview" component={ButtonStylePreview} options={{title: `Button style preview`}} />
       <MenuStack.Screen name="textStylePreview" component={TextStylePreview} options={{title: `Text style preview`}} />
       <MenuStack.Screen name="avalancheCenter" component={MapScreen} initialParams={{center_id: center_id, requestedTime: requestedTime}} options={() => ({headerShown: false})} />
       <MenuStack.Screen name="forecast" component={ForecastScreen} initialParams={{center_id: center_id, requestedTime: requestedTime}} options={() => ({headerShown: false})} />
@@ -179,6 +180,13 @@ export const MenuScreen = (queryCache: QueryCache, avalancheCenterId: AvalancheC
                     <Card borderRadius={0} borderColor="white" header={<Title3Black>Design Previews</Title3Black>}>
                       <ActionList
                         actions={[
+                          {
+                            label: 'Open button style preview',
+                            data: 'Button Style Preview',
+                            action: () => {
+                              navigation.navigate('buttonStylePreview');
+                            },
+                          },
                           {
                             label: 'Open text style preview',
                             data: 'Text Style Preview',
@@ -368,6 +376,29 @@ export const MenuScreen = (queryCache: QueryCache, avalancheCenterId: AvalancheC
     );
   };
 };
+
+const ButtonStylePreview = () => (
+  <VStack width="100%" height="100%" space={32} px={32} alignItems="stretch" justifyContent="center">
+    <Button buttonStyle="primary" onPress={() => undefined}>
+      <BodyBlack>Primary button</BodyBlack>
+    </Button>
+    <Button buttonStyle="primary" disabled onPress={() => undefined}>
+      <BodyBlack>Primary button (disabled)</BodyBlack>
+    </Button>
+    <Button buttonStyle="normal" onPress={() => undefined}>
+      <BodyBlack>Normal button</BodyBlack>
+    </Button>
+    <Button buttonStyle="normal" disabled onPress={() => undefined}>
+      <BodyBlack>Normal button (disabled)</BodyBlack>
+    </Button>
+    <Button buttonStyle="destructive" onPress={() => undefined}>
+      <BodyBlack>Destructive button</BodyBlack>
+    </Button>
+    <Button buttonStyle="destructive" disabled onPress={() => undefined}>
+      <BodyBlack>Destructive button (disabled)</BodyBlack>
+    </Button>
+  </VStack>
+);
 
 const TextStylePreview = () => {
   const data = [

--- a/routes.ts
+++ b/routes.ts
@@ -92,6 +92,7 @@ export type ObservationsStackNavigationProps = NativeStackNavigationProp<Observa
 export type MenuStackParamList = {
   menu: undefined;
   avalancheCenterSelector: undefined;
+  buttonStylePreview: undefined;
   textStylePreview: undefined;
   avalancheCenter: {
     center_id: AvalancheCenterID;

--- a/theme/colors.ts
+++ b/theme/colors.ts
@@ -1,4 +1,21 @@
 import {ColorValue} from 'react-native';
+import tinycolor from 'tinycolor2';
+
+// A lot of colors from the designers are specified with alpha channels, but we want these colors to
+// be solid as opposed to letting the underlying colors through. Also, things with alpha channels are sometimes
+// treated differently - as an example, a color with alpha will render differently in a background vs a border.
+const rgbaToHexString = (rgba: string): string => {
+  const c = tinycolor(rgba).toRgb();
+  if (c.r === 0 && c.g === 0 && c.b === 0) {
+    // if the color is specified as black, then just multiplying black by the alpha channel will always give you black back
+    // instead, we use white and (1 - alpha)
+    c.r = 255.0;
+    c.g = 255.0;
+    c.b = 255.0;
+    c.a = 1.0 - c.a;
+  }
+  return tinycolor({r: Math.round(c.r * c.a), g: Math.round(c.g * c.a), b: Math.round(c.b * c.a)}).toHexString();
+};
 
 export const COLORS = {
   //
@@ -8,24 +25,27 @@ export const COLORS = {
   primary: '#096DD9',
   'primary.hover': '#40A9FF',
   'primary.active': '#096DD9',
-  'primary.outline': 'rgba(24, 144, 255, 0.2)',
+  'primary.outline': rgbaToHexString('rgba(24, 144, 255, 0.2)'),
   //
   // UI
-  blue1: 'rgba(24, 144, 255, 1)',
-  blue2: 'rgba(0, 80, 179, 1)',
-  blue3: 'rgba(0, 58, 140, 1)',
-  'NWAC-dark': 'rgba(20, 45, 86, 1)',
-  'NWAC-light': 'rgba(160, 204, 216, 1)',
+  blue1: rgbaToHexString('rgba(24, 144, 255, 1)'),
+  blue2: rgbaToHexString('rgba(0, 80, 179, 1)'),
+  blue3: rgbaToHexString('rgba(0, 58, 140, 1)'),
+  'NWAC-dark': rgbaToHexString('rgba(20, 45, 86, 1)'),
+  'NWAC-light': rgbaToHexString('rgba(160, 204, 216, 1)'),
   //
   // Neutral
-  text: 'rgba(0, 0, 0, 0.85)',
-  'text.secondary': 'rgba(0, 0, 0, 0.7)',
-  'text.tertiary': 'rgba(0, 0, 0, 0.45)',
-  disabled: 'rgba(0, 0, 0, 0.25)',
-  'border.base': 'rgba(0, 0, 0, 0.15)',
-  'border.split': 'rgba(0, 0, 0, 0.06)',
-  'background.base': 'rgba(0, 0, 0, 0.04)',
-  'background.light': 'rgba(0, 0, 0, 0.02)',
+  text: rgbaToHexString('rgba(0, 0, 0, 0.85)'),
+  'text.secondary': rgbaToHexString('rgba(0, 0, 0, 0.7)'),
+  'text.tertiary': rgbaToHexString('rgba(0, 0, 0, 0.45)'),
+  disabled: rgbaToHexString('rgba(0, 0, 0, 0.25)'),
+  'border.base': rgbaToHexString('rgba(0, 0, 0, 0.15)'),
+  'border.split': rgbaToHexString('rgba(0, 0, 0, 0.06)'),
+  'background.base': rgbaToHexString('rgba(0, 0, 0, 0.04)'),
+  'background.color-light': rgbaToHexString('rgba(0, 0, 0, 0.02)'),
+
+  'error.color': rgbaToHexString('rgba(222, 75, 70, 1)'),
+  'error.color-primary': rgbaToHexString('rgba(218, 55, 49, 1)'),
 
   // Color aliases from NativeBase
   'rose.50': '#fff1f2',


### PR DESCRIPTION
- pre-process our RGBA color definitions to remove the alpha channel, so that the color is consistent no matter what it renders on top of
- update button styles to match figma (font, colors, borders)
- add a button style view for easier debugging

![simulator_screenshot_2D2F321E-A75A-496E-BC2E-A2466E06F38F](https://user-images.githubusercontent.com/101196/223865013-da313dda-8b00-410c-91ed-4d9512192926.png)
