### PR TITLE
Patch for crash on missing weather station data

### DIFF
--- a/components/content/InfoTooltip.tsx
+++ b/components/content/InfoTooltip.tsx
@@ -49,7 +49,7 @@ export const InfoTooltip: React.FC<InfoTooltipProps> = ({
   return (
     <>
       {/* unfortunate ant misspelling: infocirlceo */}
-      <AntDesign.Button name={outlineIcon} color={colorLookup(color)} backgroundColor="rgba(1, 1, 1, 0)" onPress={openModal} size={size} iconStyle={{marginRight: 0}} {...props} />
+      <AntDesign.Button name={outlineIcon} color={colorLookup(color)} backgroundColor="white" onPress={openModal} size={size} iconStyle={{marginRight: 0}} {...props} />
       {/* Pressing the Android back button dismisses the modal */}
       <Modal visible={showModal} transparent animationType="fade" onRequestClose={closeModal}>
         {/* Pressing anywhere outside the modal dismisses the modal */}


### PR DESCRIPTION
This keeps #243 from crashing the app. However, the function TimeSeriesTable ultimately needs to be updated, to correctly handle the case where multiple stations have data for datetime values that are not even guaranteed to overlap.