### PR TITLE
observations: cache imprecise results

### DIFF
--- a/components/observations/ObservationsListView.tsx
+++ b/components/observations/ObservationsListView.tsx
@@ -49,7 +49,7 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
   const mapLayer = mapResult.data;
 
   const date = requestedTimeToUTCDate(requestedTime);
-  const startDate = sub(date, {weeks: 1});
+  const startDate = sub(date, {weeks: 2});
   const endDate = date;
   const observationsResult = useObservationsQuery({
     center: center_id,


### PR DESCRIPTION
We only allow for "newest" observation fetching today, and for that we would prefer to have stale but present cached data versus precise but missing data. If we simply cache that we're getting *any* observations for a day, and refresh hourly, we should make sure that users can come back to these screens and see something useful every time, especially since we're pre-fetching. When/if we expand to allow viewing results from a specific range in the past, we can update those calls to use a different key and cache, since we need to differentiate those from "latest" calls and we can cache those precisely.