### PR TITLE
Explicitly set tintColor and activeFontStyle on SwitchField's SegmentedControl

### DIFF
--- a/components/form/SwitchField.tsx
+++ b/components/form/SwitchField.tsx
@@ -25,6 +25,8 @@ export function SwitchField<T>({name, label, items, ...props}: SwitchFieldProps<
     <VStack width="100%" space={4} {...props}>
       <BodyXSmBlack>{label}</BodyXSmBlack>
       <SegmentedControl
+        tintColor="white"
+        activeFontStyle={{color: colorLookup('text') as string, fontSize: 16, fontFamily: 'Lato_400Regular'}}
         fontStyle={{color: colorLookup('text') as string, fontSize: 16, fontFamily: 'Lato_400Regular'}}
         values={items.map(i => i.label)}
         selectedIndex={Math.max(


### PR DESCRIPTION
@stevekuznetsov full confession: I don't know why this ever worked correctly inside the create observation form, but didn't work in the filter selection form. If I had to guess, I'd guess it's related to the latter being hosted inside a modal, and something in the React Native tree behaving differently in that case. But 🤷 that's just a guess. 

I found this fix by looking at the available props on `SegmentedControl` and playing around with them. Here's a movie showing that the control renders consistently in both places now:

https://user-images.githubusercontent.com/101196/227746171-4a755fb4-6613-4dd7-aca5-cb0a8ba00c90.mp4

Fixes #261 

