### PR TITLE
observations: use infinite queries

### DIFF
--- a/components/content/Outcome.tsx
+++ b/components/content/Outcome.tsx
@@ -8,13 +8,14 @@ export interface OutcomeOptions {
   outcome: string; // the main outcome to show the user
   reason: string; // some explanatory text
   illustration: ReactNode;
+  inline?: boolean;
   onRetry?: (event: GestureResponderEvent) => void; // action to bind to the retry button
   onClose?: (event: GestureResponderEvent) => void; // action to bind to the close button
 }
 
-export const Outcome: React.FunctionComponent<OutcomeOptions> = ({outcome, reason, illustration, onRetry, onClose}) => {
+export const Outcome: React.FunctionComponent<OutcomeOptions> = ({outcome, reason, illustration, inline, onRetry, onClose}) => {
   return (
-    <View style={{height: '100%', width: '100%'}} bg="white">
+    <View style={inline ? {} : {height: '100%', width: '100%'}} bg="white">
       <VStack justifyContent={'center'} flex={1}>
         <View mx={16}>
           <VStack space={24} alignItems={'center'}>

--- a/components/content/QueryState.tsx
+++ b/components/content/QueryState.tsx
@@ -40,13 +40,14 @@ export const QueryState: React.FunctionComponent<{results: UseQueryResult[]}> = 
 
 const isResultNotFound = (result: UseQueryResult): boolean => result.isSuccess && isNotFound(result.data);
 
-export const InternalError: React.FunctionComponent = () => {
+export const InternalError: React.FunctionComponent = (inline?: boolean) => {
   const navigation = useNavigation<TabNavigationProps>();
   return (
     <Outcome
       outcome={'Oops, something went wrong!'}
       reason={"We're sorry, but we cannot complete your request at this time."}
       illustration={<ErrorIllustration />}
+      inline={inline}
       onClose={() => navigation.navigate('Home')}
     />
   );
@@ -60,14 +61,14 @@ export const Loading: React.FunctionComponent = () => {
   );
 };
 
-export const NotFound: React.FunctionComponent<{what?: NotFoundType[]; terminal?: boolean}> = ({what, terminal}) => {
+export const NotFound: React.FunctionComponent<{what?: NotFoundType[]; terminal?: boolean; inline?: boolean}> = ({what, terminal, inline}) => {
   const thing = what[0]?.notFound ? what[0].notFound : 'the requested resource';
   const navigation = useNavigation<TabNavigationProps>();
   let onClose = () => navigation.navigate('Home');
   if (terminal) {
     onClose = null;
   }
-  return <Outcome outcome={'No results found'} reason={`We could not find ${thing}.`} illustration={<NoSearchResult />} onClose={onClose} />;
+  return <Outcome outcome={'No results found'} reason={`We could not find ${thing}.`} inline={inline} illustration={<NoSearchResult />} onClose={onClose} />;
 };
 
 export const ConnectionLost: React.FunctionComponent = () => {

--- a/hooks/useNACObservations.ts
+++ b/hooks/useNACObservations.ts
@@ -1,0 +1,126 @@
+import React from 'react';
+
+import {QueryClient, useInfiniteQuery} from '@tanstack/react-query';
+import axios, {AxiosError} from 'axios';
+
+import {Logger} from 'browser-bunyan';
+import {ClientContext, ClientProps} from 'clientContext';
+import {formatDistanceToNowStrict, sub} from 'date-fns';
+import {safeFetch} from 'hooks/fetch';
+import {ObservationsDocument, ObservationsQuery} from 'hooks/useObservations';
+import {LoggerContext, LoggerProps} from 'loggerContext';
+import {AvalancheCenterID} from 'types/nationalAvalancheCenter';
+import {apiDateString, formatRequestedTime, parseRequestedTimeString, requestedTimeToUTCDate} from 'utils/date';
+import {ZodError} from 'zod';
+
+export const useNACObservations = (center_id: AvalancheCenterID, endDate: Date) => {
+  const {nationalAvalancheCenterHost} = React.useContext<ClientProps>(ClientContext);
+  const {logger} = React.useContext<LoggerProps>(LoggerContext);
+  const key = queryKey(nationalAvalancheCenterHost, center_id);
+  const thisLogger = logger.child({query: key});
+  thisLogger.debug('initiating query');
+  const fetchNACObservationsPage = async ({pageParam = formatRequestedTime(endDate)}): Promise<ObservationsQueryWithMeta> => {
+    const endDate: Date = requestedTimeToUTCDate(parseRequestedTimeString(pageParam));
+    const startDate = sub(endDate, {weeks: 2});
+    return fetchNACObservations(nationalAvalancheCenterHost, center_id, startDate, endDate, thisLogger);
+  };
+
+  return useInfiniteQuery<ObservationsQueryWithMeta, AxiosError | ZodError>({
+    queryKey: key,
+    queryFn: fetchNACObservationsPage,
+    getNextPageParam: lastPage => lastPage.startDate,
+    staleTime: 60 * 60 * 1000, // re-fetch in the background once an hour (in milliseconds)
+    cacheTime: 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)
+  });
+};
+
+function queryKey(nationalAvalancheCenterHost: string, center_id: AvalancheCenterID) {
+  return [
+    'nac-observations',
+    {
+      host: nationalAvalancheCenterHost,
+      center_id: center_id,
+    },
+  ];
+}
+
+export const prefetchNACObservations = async (
+  queryClient: QueryClient,
+  nationalAvalancheCenterHost: string,
+  center_id: AvalancheCenterID,
+  startDate: Date,
+  endDate: Date,
+  logger: Logger,
+) => {
+  const key = queryKey(nationalAvalancheCenterHost, center_id);
+  const thisLogger = logger.child({query: key});
+  thisLogger.debug('initiating query');
+
+  await queryClient.prefetchInfiniteQuery({
+    queryKey: key,
+    queryFn: async () => {
+      const start = new Date();
+      logger.trace(`prefetching`);
+      const result = fetchNACObservations(nationalAvalancheCenterHost, center_id, startDate, endDate, thisLogger);
+      thisLogger.trace({duration: formatDistanceToNowStrict(start)}, `finished prefetching`);
+      return result;
+    },
+  });
+};
+
+interface ObservationsQueryWithMeta extends ObservationsQuery {
+  endDate: string;
+  startDate: string;
+}
+
+export const fetchNACObservations = async (
+  nationalAvalancheCenterHost: string,
+  center_id: AvalancheCenterID,
+  startDate: Date,
+  endDate: Date,
+  logger: Logger,
+): Promise<ObservationsQueryWithMeta> => {
+  const url = `${nationalAvalancheCenterHost}/obs/v1/public/graphql`;
+  const variables = {
+    center: center_id,
+    startDate: apiDateString(startDate),
+    endDate: apiDateString(endDate),
+  };
+  const thisLogger = logger.child({url: url, variables: variables, what: 'NAC observations'});
+  const data = await safeFetch(
+    () =>
+      axios.post(
+        url,
+        {
+          query: ObservationsDocument,
+          variables: variables,
+        },
+        {
+          headers: {
+            // Public API uses the Origin header to determine who's authorized to call it
+            Origin: 'https://nwac.us',
+          },
+        },
+      ),
+    thisLogger,
+  );
+
+  if (data.error) {
+    logger.warn({error: data.error}, `error response on fetch`);
+    throw new Error(`GraphQL error response: ${JSON.stringify(data.error)}`);
+  }
+
+  // TODO(skuznets): we're not validating the response with Zod since we can trust the GraphQL layer, as long
+  // as our clients are up-to-date. Is this sufficient? Should we do more?
+  return {
+    startDate: formatRequestedTime(startDate),
+    endDate: formatRequestedTime(endDate),
+    ...(data.data as ObservationsQuery),
+  };
+};
+
+export default {
+  queryKey,
+  fetch: fetchNACObservations,
+  prefetch: prefetchNACObservations,
+};


### PR DESCRIPTION
When a user scrolls to the bottom of the observations list, they can now push a button to load more historical observations.