### PR TITLE
hooks: handle 404s explicitly

### DIFF
--- a/hooks/fetch.ts
+++ b/hooks/fetch.ts
@@ -1,5 +1,6 @@
 import {AxiosResponse} from 'axios';
 import {Logger} from 'browser-bunyan';
+import {NotFoundError} from 'types/requests';
 
 export const safeFetch = async <T>(request: () => Promise<AxiosResponse<T>>, logger: Logger) => {
   try {
@@ -8,7 +9,11 @@ export const safeFetch = async <T>(request: () => Promise<AxiosResponse<T>>, log
   } catch (error) {
     if (error.response) {
       logger.warn({status: error.response.status, error: error.response.data}, `error response on fetch`);
-      throw new Error(`error response ${error.response.status}: ${error.response.data.message}`);
+      if (error.response.status === 404) {
+        throw new NotFoundError(`error response ${error.response.status}: ${error.response.data.message}`);
+      } else {
+        throw new Error(`error response ${error.response.status}: ${error.response.data.message}`);
+      }
     } else if (error.request) {
       logger.warn({error: error.request}, `no response on fetch`);
       throw new Error(`no response: ${error.request}`);

--- a/hooks/useNWACWeatherForecast.ts
+++ b/hooks/useNWACWeatherForecast.ts
@@ -11,6 +11,7 @@ import {formatDistanceToNowStrict} from 'date-fns';
 import {safeFetch} from 'hooks/fetch';
 import {LoggerContext, LoggerProps} from 'loggerContext';
 import {reverseLookup} from 'types/nationalAvalancheCenter';
+import {NotFoundError} from 'types/requests';
 import {nominalNWACWeatherForecastDate, RequestedTime, requestedTimeToUTCDate, toDateTimeInterfaceATOM} from 'utils/date';
 import {z, ZodError} from 'zod';
 
@@ -22,9 +23,10 @@ export const useNWACWeatherForecast = (zone_id: number, requestedTime: Requested
   const thisLogger = logger.child({query: key});
   thisLogger.debug('initiating query');
 
-  return useQuery<NWACWeatherForecast, AxiosError | ZodError>({
+  return useQuery<NWACWeatherForecast, AxiosError | ZodError | NotFoundError>({
     queryKey: key,
     queryFn: () => fetchNWACWeatherForecast(nwacHost, zone_id, date, thisLogger),
+    retry: (failureCount, error): boolean => !(error instanceof NotFoundError), // 404s are terminal
     staleTime: 60 * 60 * 1000, // re-fetch in the background once an hour (in milliseconds)
     cacheTime: 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)
   });

--- a/types/requests.ts
+++ b/types/requests.ts
@@ -1,3 +1,5 @@
+import {NotFound} from 'components/content/QueryState';
+
 export type NotFound = {
   notFound: string;
 };
@@ -9,4 +11,11 @@ export function notFound(what: string): NotFound {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function isNotFound(obj: NotFound | any): obj is NotFound {
   return obj && (obj as NotFound).notFound !== undefined;
+}
+
+export class NotFoundError extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = 'NotFound';
+  }
 }


### PR DESCRIPTION
We likely want to extend the retry handler to every hook since 404s will always be terminal, but I'll save that for a follow-up.