### PR TITLE
hooks: add some more explicit return types

### DIFF
--- a/hooks/useAvalancheForecast.ts
+++ b/hooks/useAvalancheForecast.ts
@@ -30,7 +30,8 @@ export const useAvalancheForecast = (center_id: AvalancheCenterID, center: Avala
 
   return useQuery<Product | NotFound, AxiosError | ZodError>({
     queryKey: key,
-    queryFn: async () => fetchAvalancheForecast(queryClient, nationalAvalancheCenterHost, center_id, zone_id, requestedTime, expiryTimeZone, expiryTimeHours, thisLogger),
+    queryFn: async (): Promise<Product | NotFound> =>
+      fetchAvalancheForecast(queryClient, nationalAvalancheCenterHost, center_id, zone_id, requestedTime, expiryTimeZone, expiryTimeHours, thisLogger),
     enabled: !!expiryTimeHours,
     cacheTime: 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)
   });
@@ -85,7 +86,7 @@ const prefetchAvalancheForecast = async (
 
   await queryClient.prefetchQuery({
     queryKey: key,
-    queryFn: async () => {
+    queryFn: async (): Promise<Product | NotFound> => {
       const start = new Date();
       logger.trace(`prefetching`);
       const result = fetchAvalancheForecast(queryClient, nationalAvalancheCenterHost, center_id, zone_id, requestedTime, expiryTimeZone, expiryTimeHours, thisLogger);
@@ -104,7 +105,7 @@ const fetchAvalancheForecast = async (
   expiryTimeZone: string,
   expiryTimeHours: number,
   logger: Logger,
-) => {
+): Promise<Product | NotFound> => {
   if (requested_time === 'latest') {
     return fetchLatestAvalancheForecast(nationalAvalancheCenterHost, center_id, zone_id, logger);
   } else {
@@ -124,7 +125,7 @@ const fetchAvalancheForecast = async (
   }
 };
 
-const fetchLatestAvalancheForecast = async (nationalAvalancheCenterHost: string, center_id: string, zone_id: number, logger: Logger) => {
+const fetchLatestAvalancheForecast = async (nationalAvalancheCenterHost: string, center_id: string, zone_id: number, logger: Logger): Promise<Product> => {
   const url = `${nationalAvalancheCenterHost}/v2/public/product`;
   const params = {
     center_id: center_id,

--- a/hooks/useAvalancheForecastById.ts
+++ b/hooks/useAvalancheForecastById.ts
@@ -24,7 +24,7 @@ export const useAvalancheForecastById = (fragment: Product) => {
 
   return useQuery<Product, AxiosError | ZodError>({
     queryKey: key,
-    queryFn: () => fetchProduct(nationalAvalancheCenterHost, forecastId, thisLogger),
+    queryFn: (): Promise<Product> => fetchProduct(nationalAvalancheCenterHost, forecastId, thisLogger),
     enabled: !!forecastId,
     staleTime: 60 * 60 * 1000, // re-fetch in the background once an hour (in milliseconds)
     cacheTime: 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)
@@ -42,7 +42,7 @@ export const prefetchAvalancheForecast = async (queryClient: QueryClient, nation
 
   await queryClient.prefetchQuery({
     queryKey: key,
-    queryFn: async () => {
+    queryFn: async (): Promise<Product> => {
       const start = new Date();
       logger.trace(`prefetching`);
       const result = fetchProduct(nationalAvalancheCenterHost, forecastId, thisLogger);
@@ -53,7 +53,7 @@ export const prefetchAvalancheForecast = async (queryClient: QueryClient, nation
 };
 
 // TODO need to export?
-export const fetchProduct = async (nationalAvalancheCenterHost: string, forecastId: number, logger: Logger) => {
+export const fetchProduct = async (nationalAvalancheCenterHost: string, forecastId: number, logger: Logger): Promise<Product> => {
   const url = `${nationalAvalancheCenterHost}/v2/public/product/${forecastId}`;
   const thisLogger = logger.child({url: url, what: 'avalanche forecast'});
   const data = await safeFetch(() => axios.get(url), thisLogger);

--- a/hooks/useAvalancheForecastFragment.ts
+++ b/hooks/useAvalancheForecastFragment.ts
@@ -21,7 +21,7 @@ export const useAvalancheForecastFragment = (center_id: AvalancheCenterID, forec
 
   return useQuery<Product | NotFound, Error>({
     queryKey: key,
-    queryFn: async () => fetchAvalancheForecastFragment(queryClient, nationalAvalancheCenterHost, center_id, forecast_zone_id, date, thisLogger),
+    queryFn: async (): Promise<Product | NotFound> => fetchAvalancheForecastFragment(queryClient, nationalAvalancheCenterHost, center_id, forecast_zone_id, date, thisLogger),
     staleTime: 60 * 60 * 1000, // re-fetch in the background once an hour (in milliseconds)
     cacheTime: 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)
   });

--- a/hooks/useAvalancheForecastFragments.ts
+++ b/hooks/useAvalancheForecastFragments.ts
@@ -23,7 +23,7 @@ export const useAvalancheForecastFragments = (center_id: AvalancheCenterID, date
 
   return useQuery<Product[] | undefined, AxiosError | ZodError>({
     queryKey: key,
-    queryFn: async () => fetchAvalancheForecastFragments(nationalAvalancheCenterHost, center_id, date, thisLogger),
+    queryFn: async (): Promise<ProductArray> => fetchAvalancheForecastFragments(nationalAvalancheCenterHost, center_id, date, thisLogger),
   });
 };
 
@@ -38,7 +38,7 @@ const prefetchAvalancheForecastFragments = async (queryClient: QueryClient, nati
 
   await queryClient.prefetchQuery({
     queryKey: key,
-    queryFn: async () => {
+    queryFn: async (): Promise<ProductArray> => {
       const start = new Date();
       thisLogger.trace(`prefetching`);
       const result = await fetchAvalancheForecastFragments(nationalAvalancheCenterHost, center_id, date, thisLogger);

--- a/hooks/useAvalancheWarning.ts
+++ b/hooks/useAvalancheWarning.ts
@@ -23,7 +23,7 @@ export const useAvalancheWarning = (center_id: AvalancheCenterID, zone_id: numbe
 
   return useQuery<AvalancheWarning, AxiosError | ZodError>({
     queryKey: key,
-    queryFn: async () => fetchAvalancheWarning(nationalAvalancheCenterHost, center_id, zone_id, requested_time, thisLogger),
+    queryFn: async (): Promise<AvalancheWarning> => fetchAvalancheWarning(nationalAvalancheCenterHost, center_id, zone_id, requested_time, thisLogger),
     cacheTime: 12 * 60 * 60 * 1000, // hold on to this cached data for half a day (in milliseconds)
   });
 };

--- a/hooks/useMapLayer.ts
+++ b/hooks/useMapLayer.ts
@@ -22,7 +22,7 @@ export const useMapLayer = (center_id: AvalancheCenterID) => {
 
   return useQuery<MapLayer, AxiosError | ZodError>({
     queryKey: key,
-    queryFn: async () => fetchMapLayer(nationalAvalancheCenterHost, center_id, thisLogger),
+    queryFn: async (): Promise<MapLayer> => fetchMapLayer(nationalAvalancheCenterHost, center_id, thisLogger),
     enabled: !!center_id,
     staleTime: 24 * 60 * 60 * 1000, // don't bother re-fetching for one day (in milliseconds)
     cacheTime: Infinity, // hold on to this cached data forever
@@ -40,7 +40,7 @@ export const prefetchMapLayer = async (queryClient: QueryClient, nationalAvalanc
 
   await queryClient.prefetchQuery({
     queryKey: key,
-    queryFn: async () => {
+    queryFn: async (): Promise<MapLayer> => {
       const start = new Date();
       thisLogger.trace(`prefetching`);
       const result = await fetchMapLayer(nationalAvalancheCenterHost, center_id, thisLogger);
@@ -50,7 +50,7 @@ export const prefetchMapLayer = async (queryClient: QueryClient, nationalAvalanc
   });
 };
 
-const fetchMapLayer = async (nationalAvalancheCenterHost: string, center_id: AvalancheCenterID, logger: Logger) => {
+const fetchMapLayer = async (nationalAvalancheCenterHost: string, center_id: AvalancheCenterID, logger: Logger): Promise<MapLayer> => {
   const url = `${nationalAvalancheCenterHost}/v2/public/products/map-layer/${center_id}`;
   const thisLogger = logger.child({url: url, what: 'avalanche avalanche center map layer'});
   const data = await safeFetch(() => axios.get(url), thisLogger);

--- a/hooks/useMapLayerAvalancheForecasts.ts
+++ b/hooks/useMapLayerAvalancheForecasts.ts
@@ -3,7 +3,8 @@ import {ClientContext, ClientProps} from 'clientContext';
 import AvalancheForecastQuery from 'hooks/useAvalancheForecast';
 import {LoggerContext, LoggerProps} from 'loggerContext';
 import React from 'react';
-import {AvalancheCenter, AvalancheCenterID, MapLayer} from 'types/nationalAvalancheCenter';
+import {AvalancheCenter, AvalancheCenterID, MapLayer, Product} from 'types/nationalAvalancheCenter';
+import {NotFound} from 'types/requests';
 import {RequestedTime} from 'utils/date';
 
 export const useMapLayerAvalancheForecasts = (center_id: AvalancheCenterID, requestedTime: RequestedTime, mapLayer: MapLayer, metadata: AvalancheCenter) => {
@@ -18,7 +19,7 @@ export const useMapLayerAvalancheForecasts = (center_id: AvalancheCenterID, requ
       ? mapLayer.features.map(feature => {
           return {
             queryKey: AvalancheForecastQuery.queryKey(nationalAvalancheCenterHost, center_id, feature.id, requestedTime, expiryTimeZone, expiryTimeHours),
-            queryFn: async () =>
+            queryFn: async (): Promise<Product | NotFound> =>
               AvalancheForecastQuery.fetch(queryClient, nationalAvalancheCenterHost, center_id, feature.id, requestedTime, expiryTimeZone, expiryTimeHours, logger),
             enabled: !!expiryTimeHours,
             cacheTime: 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)

--- a/hooks/useMapLayerAvalancheWarnings.ts
+++ b/hooks/useMapLayerAvalancheWarnings.ts
@@ -3,7 +3,7 @@ import {ClientContext, ClientProps} from 'clientContext';
 import AvalancheWarningQuery from 'hooks/useAvalancheWarning';
 import {LoggerContext, LoggerProps} from 'loggerContext';
 import React from 'react';
-import {AvalancheCenterID, MapLayer} from 'types/nationalAvalancheCenter';
+import {AvalancheCenterID, AvalancheWarning, MapLayer} from 'types/nationalAvalancheCenter';
 import {RequestedTime} from 'utils/date';
 
 export const useMapLayerAvalancheWarnings = (center_id: AvalancheCenterID, requestedTime: RequestedTime, mapLayer: MapLayer) => {
@@ -15,7 +15,7 @@ export const useMapLayerAvalancheWarnings = (center_id: AvalancheCenterID, reque
       ? mapLayer.features.map(feature => {
           return {
             queryKey: AvalancheWarningQuery.queryKey(nationalAvalancheCenterHost, center_id, feature.id, requestedTime),
-            queryFn: async () => AvalancheWarningQuery.fetch(nationalAvalancheCenterHost, center_id, feature.id, requestedTime, logger),
+            queryFn: async (): Promise<AvalancheWarning> => AvalancheWarningQuery.fetch(nationalAvalancheCenterHost, center_id, feature.id, requestedTime, logger),
             cacheTime: 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)
           };
         })

--- a/hooks/useNACObservation.ts
+++ b/hooks/useNACObservation.ts
@@ -22,7 +22,7 @@ export const useNACObservation = (id: string) => {
 
   return useQuery<Observation, AxiosError | ZodError>({
     queryKey: key,
-    queryFn: () => fetchNACObservation(host, id, thisLogger),
+    queryFn: (): Promise<Observation> => fetchNACObservation(host, id, thisLogger),
     staleTime: 60 * 60 * 1000, // re-fetch in the background once an hour (in milliseconds)
     cacheTime: 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)
   });
@@ -39,7 +39,7 @@ export const prefetchNACObservation = async (queryClient: QueryClient, host: str
 
   await queryClient.prefetchQuery({
     queryKey: key,
-    queryFn: async () => {
+    queryFn: async (): Promise<Observation> => {
       const start = new Date();
       logger.trace(`prefetching`);
       const result = fetchNACObservation(host, id, thisLogger);

--- a/hooks/useNACObservations.ts
+++ b/hooks/useNACObservations.ts
@@ -58,7 +58,7 @@ export const prefetchNACObservations = async (
 
   await queryClient.prefetchInfiniteQuery({
     queryKey: key,
-    queryFn: async () => {
+    queryFn: async (): Promise<ObservationsQueryWithMeta> => {
       const start = new Date();
       logger.trace(`prefetching`);
       const result = fetchNACObservations(nationalAvalancheCenterHost, center_id, startDate, endDate, thisLogger);

--- a/hooks/useNWACObservation.ts
+++ b/hooks/useNWACObservation.ts
@@ -22,7 +22,7 @@ export const useNWACObservation = (id: number) => {
 
   return useQuery<Observation, AxiosError | ZodError>({
     queryKey: key,
-    queryFn: () => fetchNWACObservation(nwacHost, id, thisLogger),
+    queryFn: (): Promise<Observation> => fetchNWACObservation(nwacHost, id, thisLogger),
     staleTime: 60 * 60 * 1000, // re-fetch in the background once an hour (in milliseconds)
     cacheTime: 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)
   });


### PR DESCRIPTION
The LSP was starting to really grind to a halt when having to string together lots of implicit return types and zod schemas, so making these explicit improves DX by a load.