### PR TITLE
*: show the conditions blog tab when configured

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -55,6 +55,7 @@ require('date-time-format-timezone');
 import axios, {AxiosRequestConfig} from 'axios';
 import {createLogger, stdSerializers} from 'browser-bunyan';
 import {ConsoleFormattedStream} from 'logging/consoleFormattedStream';
+import {NotFoundError} from 'types/requests';
 
 // we're reading a field that was previously defined in app.json, so we know it's non-null:
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -133,6 +134,7 @@ const queryClient: QueryClient = new QueryClient({
   defaultOptions: {
     queries: {
       cacheTime: 1000 * 60 * 60 * 24, // 24 hours
+      retry: (failureCount, error): boolean => !(error instanceof NotFoundError), // 404s are terminal
     },
   },
 });

--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -36,7 +36,6 @@ import md5 from 'md5';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {HomeStackNavigationProps} from 'routes';
 import {AvalancheCenterID, DangerLevel} from 'types/nationalAvalancheCenter';
-import {isNotFound} from 'types/requests';
 import {formatRequestedTime, RequestedTime, toISOStringUTC, utcDateToLocalTimeString} from 'utils/date';
 
 export interface MapProps {
@@ -113,9 +112,6 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
     .map(result => result.data) // get data from the results
     .filter(data => data) // only operate on results that have succeeded
     .forEach(forecast => {
-      if (isNotFound(forecast)) {
-        return;
-      }
       forecast.forecast_zone?.forEach(({id}) => {
         const mapViewZoneData = zonesById[id];
         if (mapViewZoneData) {

--- a/components/TabControl.tsx
+++ b/components/TabControl.tsx
@@ -59,19 +59,21 @@ export const TabControl: React.FunctionComponent<TabControlProps> = ({children, 
         {React.Children.map(children, (child, index) => {
           const selected = selectedIndex === index;
           return (
-            <TouchableOpacity onPress={() => setSelectedIndex(index)} style={tabStyle} key={`tabcontrol-item-${index}`}>
-              <Center>
-                <View borderColor={selected ? selectedTextColor : backgroundColor} borderBottomWidth={4} borderRadius={0}>
-                  {selected ? (
-                    <BodySemibold color={selectedTextColor} style={textStyle}>
-                      {child.props.title}
-                    </BodySemibold>
-                  ) : (
-                    <Body style={textStyle}>{child.props.title}</Body>
-                  )}
-                </View>
-              </Center>
-            </TouchableOpacity>
+            child && (
+              <TouchableOpacity onPress={() => setSelectedIndex(index)} style={tabStyle} key={`tabcontrol-item-${index}`}>
+                <Center>
+                  <View borderColor={selected ? selectedTextColor : backgroundColor} borderBottomWidth={4} borderRadius={0}>
+                    {selected ? (
+                      <BodySemibold color={selectedTextColor} style={textStyle}>
+                        {child.props.title}
+                      </BodySemibold>
+                    ) : (
+                      <Body style={textStyle}>{child.props.title}</Body>
+                    )}
+                  </View>
+                </Center>
+              </TouchableOpacity>
+            )
           );
         })}
       </HStack>

--- a/components/content/carousel/ImageList.tsx
+++ b/components/content/carousel/ImageList.tsx
@@ -5,7 +5,7 @@ import {FlatList, FlatListProps, NativeScrollEvent, NativeSyntheticEvent, Scroll
 import {NetworkImage, NetworkImageProps, NetworkImageState} from 'components/content/carousel/NetworkImage';
 import {View, VStack} from 'components/core';
 import {HTML} from 'components/text/HTML';
-import {MediaItem} from 'types/nationalAvalancheCenter';
+import {MediaItem, MediaType} from 'types/nationalAvalancheCenter';
 
 export interface ImageListProps extends Omit<FlatListProps<MediaItem>, 'data' | 'renderItem'> {
   imageHeight: number;
@@ -87,7 +87,7 @@ export const ImageList: React.FC<PropsWithChildren<ImageListProps>> = ({
   return (
     <FlatList
       horizontal
-      data={media}
+      data={media.filter(item => item.type === MediaType.Image).filter(item => item.url)}
       extraData={loadingState}
       renderItem={renderItem}
       ItemSeparatorComponent={() => <View width={space} />}

--- a/components/forecast/AvalancheForecast.tsx
+++ b/components/forecast/AvalancheForecast.tsx
@@ -17,6 +17,7 @@ import {Dropdown} from 'components/content/Dropdown';
 import {incompleteQueryState, NotFound, QueryState} from 'components/content/QueryState';
 import {AvalancheTab} from 'components/forecast/AvalancheTab';
 import {ObservationsTab} from 'components/forecast/ObservationsTab';
+import {SynopsisTab} from 'components/forecast/SynopsisTab';
 import {WeatherTab} from 'components/forecast/WeatherTab';
 import {HomeStackNavigationProps} from 'routes';
 import {notFound} from 'types/requests';
@@ -97,6 +98,11 @@ export const AvalancheForecast: React.FunctionComponent<AvalancheForecastProps> 
         <Tab title="Observations">
           <ObservationsTab zone_name={zone.name} center_id={center_id} requestedTime={requestedTime} />
         </Tab>
+        {center.config?.blog && center.config?.blog_title && (
+          <Tab title={center.config?.blog_title ? center.config?.blog_title : 'Blog'}>
+            <SynopsisTab center={center} center_id={center_id} forecast_zone_id={forecast_zone_id} requestedTime={requestedTime} />
+          </Tab>
+        )}
       </TabControl>
     </VStack>
   );

--- a/components/forecast/AvalancheForecast.tsx
+++ b/components/forecast/AvalancheForecast.tsx
@@ -20,7 +20,7 @@ import {ObservationsTab} from 'components/forecast/ObservationsTab';
 import {SynopsisTab} from 'components/forecast/SynopsisTab';
 import {WeatherTab} from 'components/forecast/WeatherTab';
 import {HomeStackNavigationProps} from 'routes';
-import {notFound} from 'types/requests';
+import {NotFoundError} from 'types/requests';
 import {formatRequestedTime, RequestedTime} from 'utils/date';
 
 export interface AvalancheForecastProps {
@@ -64,8 +64,9 @@ export const AvalancheForecast: React.FunctionComponent<AvalancheForecastProps> 
 
   const zone: AvalancheForecastZone | undefined = center.zones.find(item => item.id === forecast_zone_id);
   if (!zone) {
-    Sentry.Native.captureException(new Error(`Avalanche center ${center_id} had no zone with id ${forecast_zone_id}: ${JSON.stringify(center)}`));
-    return <NotFound what={[notFound('the avalanche forecast zone')]} />;
+    const message = `Avalanche center ${center_id} had no zone with id ${forecast_zone_id}`;
+    Sentry.Native.captureException(new Error(message));
+    return <NotFound what={[new NotFoundError(message, 'avalanche forecast zone')]} />;
   }
 
   const zones = uniq(center.zones.filter(z => z.status === 'active').map(z => z.name));

--- a/components/forecast/SynopsisTab.tsx
+++ b/components/forecast/SynopsisTab.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+
+import {formatDistanceToNow, isAfter} from 'date-fns';
+
+import {useNavigation} from '@react-navigation/native';
+import {Card} from 'components/content/Card';
+import {Carousel} from 'components/content/carousel';
+import {incompleteQueryState, QueryState} from 'components/content/QueryState';
+import {HStack, VStack} from 'components/core';
+import {AllCapsSm, AllCapsSmBlack, BodyBlack, Title3Black} from 'components/text';
+import {HTML} from 'components/text/HTML';
+import {useRefresh} from 'hooks/useRefresh';
+import {useSynopsis} from 'hooks/useSynopsis';
+import {RefreshControl, ScrollView} from 'react-native';
+import Toast from 'react-native-toast-message';
+import {HomeStackNavigationProps} from 'routes';
+import {colorLookup} from 'theme';
+import {AvalancheCenter, AvalancheCenterID, Synopsis} from 'types/nationalAvalancheCenter';
+import {RequestedTime, utcDateToLocalTimeString} from 'utils/date';
+
+interface SynopsisTabProps {
+  center_id: AvalancheCenterID;
+  center: AvalancheCenter;
+  requestedTime: RequestedTime;
+  forecast_zone_id: number;
+}
+
+export const SynopsisTab: React.FunctionComponent<SynopsisTabProps> = React.memo(({center_id, center, forecast_zone_id, requestedTime}) => {
+  const synopsisResult = useSynopsis(center_id, forecast_zone_id, requestedTime);
+  const synopsis: Synopsis = synopsisResult.data;
+  const {isRefreshing, refresh} = useRefresh(synopsisResult.refetch);
+
+  const navigation = useNavigation<HomeStackNavigationProps>();
+  React.useEffect(() => {
+    return navigation.addListener('beforeRemove', () => {
+      Toast.hide();
+    });
+  }, [navigation]);
+
+  if (incompleteQueryState(synopsisResult)) {
+    return <QueryState results={[synopsisResult]} />;
+  }
+
+  const expires_time = new Date(synopsis.expires_time);
+  if (synopsis.expires_time && isAfter(new Date(), expires_time)) {
+    Toast.show({
+      type: 'error',
+      text1: `This blog expired ${formatDistanceToNow(expires_time)} ago.`,
+      autoHide: false,
+      position: 'bottom',
+      onPress: () => Toast.hide(),
+    });
+  }
+  return (
+    <ScrollView refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={refresh} />}>
+      <VStack space={8} backgroundColor={colorLookup('background.base')}>
+        <Card borderRadius={0} borderColor="white" header={<Title3Black>{center.config?.blog_title ? center.config?.blog_title : 'Blog'}</Title3Black>}>
+          <HStack justifyContent="space-evenly" space={8}>
+            <VStack space={8} style={{flex: 1}}>
+              <AllCapsSmBlack>Issued</AllCapsSmBlack>
+              <AllCapsSm style={{textTransform: 'none'}} color="text.secondary">
+                {utcDateToLocalTimeString(synopsis.published_time)}
+              </AllCapsSm>
+            </VStack>
+            {synopsis.expires_time && (
+              <VStack space={8} style={{flex: 1}}>
+                <AllCapsSmBlack>Expires</AllCapsSmBlack>
+                <AllCapsSm style={{textTransform: 'none'}} color="text.secondary">
+                  {utcDateToLocalTimeString(synopsis.expires_time)}
+                </AllCapsSm>
+              </VStack>
+            )}
+            <VStack space={8} style={{flex: 1}}>
+              <AllCapsSmBlack>Author</AllCapsSmBlack>
+              <AllCapsSm style={{textTransform: 'none'}} color="text.secondary">
+                {synopsis.author || 'Unknown'}
+                {'\n'}
+              </AllCapsSm>
+            </VStack>
+          </HStack>
+        </Card>
+        <Card borderRadius={0} borderColor="white" header={<BodyBlack>{synopsis.bottom_line}</BodyBlack>}>
+          <HTML source={{html: synopsis.hazard_discussion}} />
+          <Carousel thumbnailHeight={160} thumbnailAspectRatio={1.3} media={synopsis.media} displayCaptions={false} />
+        </Card>
+      </VStack>
+    </ScrollView>
+  );
+});

--- a/components/observations/ObservationsListView.tsx
+++ b/components/observations/ObservationsListView.tsx
@@ -21,7 +21,7 @@ import {ActivityIndicator, FlatList, FlatListProps, Modal, RefreshControl, Touch
 import {ObservationsStackNavigationProps} from 'routes';
 import theme, {colorLookup} from 'theme';
 import {AvalancheCenterID, DangerLevel, PartnerType} from 'types/nationalAvalancheCenter';
-import {notFound} from 'types/requests';
+import {NotFoundError} from 'types/requests';
 import {RequestedTime, requestedTimeToUTCDate, utcDateToLocalDateString} from 'utils/date';
 
 interface ObservationsListViewItem {
@@ -144,7 +144,7 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
           item.id ? (
             <ObservationSummaryCard source={item.source} observation={item.observation} zone={item.zone} />
           ) : (
-            <NotFound inline terminal what={[notFound('any matching observations')]} />
+            <NotFound inline terminal what={[new NotFoundError('no observations found', 'any matching observations')]} />
           )
         }
         {...props}

--- a/hooks/fetch.ts
+++ b/hooks/fetch.ts
@@ -2,16 +2,16 @@ import {AxiosResponse} from 'axios';
 import {Logger} from 'browser-bunyan';
 import {NotFoundError} from 'types/requests';
 
-export const safeFetch = async <T>(request: () => Promise<AxiosResponse<T>>, logger: Logger) => {
+export const safeFetch = async <T>(request: () => Promise<AxiosResponse<T>>, logger: Logger, pretty: string) => {
   try {
     const {data} = await request();
     return data;
   } catch (error) {
     if (error.response) {
-      logger.warn({status: error.response.status, error: error.response.data}, `error response on fetch`);
       if (error.response.status === 404) {
-        throw new NotFoundError(`error response ${error.response.status}: ${error.response.data.message}`);
+        throw new NotFoundError(`error response ${error.response.status}: ${error.response.data.message}`, pretty);
       } else {
+        logger.warn({status: error.response.status, error: error.response.data}, `error response on fetch`);
         throw new Error(`error response ${error.response.status}: ${error.response.data.message}`);
       }
     } else if (error.request) {

--- a/hooks/useAvalancheForecastById.ts
+++ b/hooks/useAvalancheForecastById.ts
@@ -55,8 +55,9 @@ export const prefetchAvalancheForecast = async (queryClient: QueryClient, nation
 // TODO need to export?
 export const fetchProduct = async (nationalAvalancheCenterHost: string, forecastId: number, logger: Logger): Promise<Product> => {
   const url = `${nationalAvalancheCenterHost}/v2/public/product/${forecastId}`;
-  const thisLogger = logger.child({url: url, what: 'avalanche forecast'});
-  const data = await safeFetch(() => axios.get(url), thisLogger);
+  const what = 'avalanche forecast';
+  const thisLogger = logger.child({url: url, what: what});
+  const data = await safeFetch(() => axios.get(url), thisLogger, what);
 
   const parseResult = productSchema.safeParse(data);
   if (parseResult.success === false) {

--- a/hooks/useAvalancheForecastFragment.ts
+++ b/hooks/useAvalancheForecastFragment.ts
@@ -8,7 +8,7 @@ import {ClientContext, ClientProps} from 'clientContext';
 import AvalancheForecastFragments from 'hooks/useAvalancheForecastFragments';
 import {LoggerContext, LoggerProps} from 'loggerContext';
 import {AvalancheCenterID, Product} from 'types/nationalAvalancheCenter';
-import {notFound, NotFound} from 'types/requests';
+import {NotFoundError} from 'types/requests';
 import {apiDateString} from 'utils/date';
 
 export const useAvalancheForecastFragment = (center_id: AvalancheCenterID, forecast_zone_id: number, date: Date) => {
@@ -19,9 +19,9 @@ export const useAvalancheForecastFragment = (center_id: AvalancheCenterID, forec
   const thisLogger = logger.child({query: key});
   thisLogger.debug('initiating query');
 
-  return useQuery<Product | NotFound, Error>({
+  return useQuery<Product, Error>({
     queryKey: key,
-    queryFn: async (): Promise<Product | NotFound> => fetchAvalancheForecastFragment(queryClient, nationalAvalancheCenterHost, center_id, forecast_zone_id, date, thisLogger),
+    queryFn: async (): Promise<Product> => fetchAvalancheForecastFragment(queryClient, nationalAvalancheCenterHost, center_id, forecast_zone_id, date, thisLogger),
     staleTime: 60 * 60 * 1000, // re-fetch in the background once an hour (in milliseconds)
     cacheTime: 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)
   });
@@ -40,13 +40,13 @@ const fetchAvalancheForecastFragment = async (
   forecast_zone_id: number,
   date: Date,
   logger: Logger,
-): Promise<Product | NotFound> => {
+): Promise<Product> => {
   const fragments = await AvalancheForecastFragments.fetchQuery(queryClient, nationalAvalancheCenterHost, center_id, date, logger);
   const fragment = fragments?.find(
     forecast => isBetween(forecast.published_time, forecast.expires_time, date) && forecast.forecast_zone.find(zone => zone.id === forecast_zone_id),
   );
   if (!fragments || !fragment) {
-    return notFound('the avalanche forecast');
+    throw new NotFoundError(`no avalanche forecast found for center ${center_id} and zone ${forecast_zone_id} active on ${date}`, 'avalanche forecast');
   }
   return fragment;
 };

--- a/hooks/useAvalancheForecastFragments.ts
+++ b/hooks/useAvalancheForecastFragments.ts
@@ -75,13 +75,15 @@ const fetchAvalancheForecastFragments = async (nationalAvalancheCenterHost: stri
     date_start: apiDateString(sub(date, {days: 2})),
     date_end: apiDateString(add(date, {days: 1})),
   };
-  const thisLogger = logger.child({url: url, params: params, what: 'avalanche forecast fragments'});
+  const what = 'avalanche forecast fragments';
+  const thisLogger = logger.child({url: url, params: params, what: what});
   const data = await safeFetch(
     () =>
       axios.get(url, {
         params: params,
       }),
     thisLogger,
+    what,
   );
 
   const parseResult = productArraySchema.safeParse(data);

--- a/hooks/useAvalancheWarning.ts
+++ b/hooks/useAvalancheWarning.ts
@@ -89,13 +89,15 @@ const fetchAvalancheWarning = async (
   if (requested_time !== 'latest') {
     params['published_time'] = apiDateString(requested_time); // the API accepts a _date_ and appends 19:00 to it for a time...
   }
-  const thisLogger = logger.child({url: url, params: params, what: 'avalanche warning'});
+  const what = 'avalanche warning';
+  const thisLogger = logger.child({url: url, params: params, what: what});
   const data = await safeFetch(
     () =>
       axios.get(url, {
         params: params,
       }),
     thisLogger,
+    what,
   );
 
   const parseResult = avalancheWarningSchema.deepPartial().safeParse(data);

--- a/hooks/useMapLayer.ts
+++ b/hooks/useMapLayer.ts
@@ -52,8 +52,9 @@ export const prefetchMapLayer = async (queryClient: QueryClient, nationalAvalanc
 
 const fetchMapLayer = async (nationalAvalancheCenterHost: string, center_id: AvalancheCenterID, logger: Logger): Promise<MapLayer> => {
   const url = `${nationalAvalancheCenterHost}/v2/public/products/map-layer/${center_id}`;
-  const thisLogger = logger.child({url: url, what: 'avalanche avalanche center map layer'});
-  const data = await safeFetch(() => axios.get(url), thisLogger);
+  const what = 'avalanche avalanche center map layer';
+  const thisLogger = logger.child({url: url, what: what});
+  const data = await safeFetch(() => axios.get(url), thisLogger, what);
 
   const parseResult = mapLayerSchema.safeParse(data);
   if (parseResult.success === false) {

--- a/hooks/useMapLayerAvalancheForecasts.ts
+++ b/hooks/useMapLayerAvalancheForecasts.ts
@@ -4,14 +4,13 @@ import AvalancheForecastQuery from 'hooks/useAvalancheForecast';
 import {LoggerContext, LoggerProps} from 'loggerContext';
 import React from 'react';
 import {AvalancheCenter, AvalancheCenterID, MapLayer, Product} from 'types/nationalAvalancheCenter';
-import {NotFound} from 'types/requests';
 import {RequestedTime} from 'utils/date';
 
 export const useMapLayerAvalancheForecasts = (center_id: AvalancheCenterID, requestedTime: RequestedTime, mapLayer: MapLayer, metadata: AvalancheCenter) => {
   const {logger} = React.useContext<LoggerProps>(LoggerContext);
   const queryClient = useQueryClient();
   const {nationalAvalancheCenterHost} = React.useContext<ClientProps>(ClientContext);
-  const expiryTimeHours = metadata?.config.expires_time;
+  const expiryTimeHours = metadata?.config?.expires_time;
   const expiryTimeZone = metadata?.timezone;
 
   return useQueries({
@@ -19,7 +18,7 @@ export const useMapLayerAvalancheForecasts = (center_id: AvalancheCenterID, requ
       ? mapLayer.features.map(feature => {
           return {
             queryKey: AvalancheForecastQuery.queryKey(nationalAvalancheCenterHost, center_id, feature.id, requestedTime, expiryTimeZone, expiryTimeHours),
-            queryFn: async (): Promise<Product | NotFound> =>
+            queryFn: async (): Promise<Product> =>
               AvalancheForecastQuery.fetch(queryClient, nationalAvalancheCenterHost, center_id, feature.id, requestedTime, expiryTimeZone, expiryTimeHours, logger),
             enabled: !!expiryTimeHours,
             cacheTime: 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)

--- a/hooks/useNACObservation.ts
+++ b/hooks/useNACObservation.ts
@@ -51,7 +51,8 @@ export const prefetchNACObservation = async (queryClient: QueryClient, host: str
 
 export const fetchNACObservation = async (host: string, id: string, logger: Logger): Promise<Observation> => {
   const url = `${host}/obs/v1/public/observation/${id}`;
-  const thisLogger = logger.child({url: url, what: 'NAC observation'});
+  const what = 'NAC observation';
+  const thisLogger = logger.child({url: url, what: what});
   const data = await safeFetch(
     () =>
       axios.get(url, {
@@ -61,6 +62,7 @@ export const fetchNACObservation = async (host: string, id: string, logger: Logg
         },
       }),
     thisLogger,
+    what,
   );
 
   const parseResult = observationSchema.deepPartial().safeParse(data);

--- a/hooks/useNACObservations.ts
+++ b/hooks/useNACObservations.ts
@@ -86,7 +86,8 @@ export const fetchNACObservations = async (
     startDate: apiDateString(startDate),
     endDate: apiDateString(endDate),
   };
-  const thisLogger = logger.child({url: url, variables: variables, what: 'NAC observations'});
+  const what = 'NAC observations';
+  const thisLogger = logger.child({url: url, variables: variables, what: what});
   const data = await safeFetch(
     () =>
       axios.post(
@@ -103,6 +104,7 @@ export const fetchNACObservations = async (
         },
       ),
     thisLogger,
+    what,
   );
 
   if (data.error) {

--- a/hooks/useNWACObservation.ts
+++ b/hooks/useNWACObservation.ts
@@ -66,8 +66,9 @@ const nwacObservationSchema = z.object({
 
 export const fetchNWACObservation = async (nwacHost: string, id: number, logger: Logger): Promise<Observation> => {
   const url = `${nwacHost}/api/v2/observation/${id}`;
-  const thisLogger = logger.child({url: url, id: id, what: 'NWAC observation'});
-  const data = await safeFetch(() => axios.get(url), thisLogger);
+  const what = 'NWAC observation';
+  const thisLogger = logger.child({url: url, id: id, what: what});
+  const data = await safeFetch(() => axios.get(url), thisLogger, what);
 
   const parseResult = nwacObservationSchema.safeParse(data);
   if (parseResult.success === false) {

--- a/hooks/useNWACObservations.ts
+++ b/hooks/useNWACObservations.ts
@@ -112,13 +112,15 @@ export const fetchNWACObservations = async (
     published_after: toDateTimeInterfaceATOM(published_after),
     published_before: toDateTimeInterfaceATOM(published_before),
   };
-  const thisLogger = logger.child({url: url, params: params, what: 'NWAC observations'});
+  const what = 'NWAC observations';
+  const thisLogger = logger.child({url: url, params: params, what: what});
   const data = await safeFetch(
     () =>
       axios.get(url, {
         params: params,
       }),
     thisLogger,
+    what,
   );
 
   const parseResult = nwacObservationsSchema.safeParse(data);

--- a/network/prefetchAllActiveForecasts.ts
+++ b/network/prefetchAllActiveForecasts.ts
@@ -28,7 +28,9 @@ export const prefetchAllActiveForecasts = async (queryClient: QueryClient, cente
     .forEach(async zone => {
       void NWACWeatherForecastQuery.prefetch(queryClient, nwacHost, zone.id, currentDateTime, logger);
       void AvalancheWarningQuery.prefetch(queryClient, nationalAvalancheCenterHost, center_id, zone.id, requestedTime, logger);
-      void SynopsisQuery.prefetch(queryClient, nationalAvalancheCenterHost, center_id, zone.id, requestedTime, logger);
+      if (metadata.config?.blog) {
+        void SynopsisQuery.prefetch(queryClient, nationalAvalancheCenterHost, center_id, zone.id, requestedTime, logger);
+      }
       await AvalancheForecastQuery.prefetch(queryClient, nationalAvalancheCenterHost, center_id, zone.id, requestedTime, metadata?.timezone, metadata?.config.expires_time, logger);
       const forecastData = queryClient.getQueryData<Product>(
         AvalancheForecastQuery.queryKey(nationalAvalancheCenterHost, center_id, zone.id, requestedTime, metadata?.timezone, metadata?.config.expires_time),

--- a/network/prefetchAllActiveForecasts.ts
+++ b/network/prefetchAllActiveForecasts.ts
@@ -39,6 +39,7 @@ export const prefetchAllActiveForecasts = async (queryClient: QueryClient, cente
         .flat()
         .filter(item => item != null)
         .filter(item => item.type === MediaType.Image) // TODO: handle prefetching other types of media
+        .filter(item => item.url)
         .map(item => [item.url.thumbnail, item.url.original])
         .flat()
         .forEach(async url => ImageCache.prefetch(queryClient, logger, url));

--- a/types/nationalAvalancheCenter/schemas.ts
+++ b/types/nationalAvalancheCenter/schemas.ts
@@ -258,6 +258,7 @@ export const avalancheCenterConfigurationSchema = z.object({
   expires_time: z.number().optional().nullable(),
   published_time: z.number().optional().nullable(),
   blog: z.boolean().optional(),
+  blog_title: z.string().optional(),
   weather_table: z.array(avalancheCenterWeatherConfigurationSchema).optional(),
   zone_order: z.array(z.number()).optional(),
 });

--- a/types/requests.ts
+++ b/types/requests.ts
@@ -1,21 +1,8 @@
-import {NotFound} from 'components/content/QueryState';
-
-export type NotFound = {
-  notFound: string;
-};
-
-export function notFound(what: string): NotFound {
-  return {notFound: what};
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isNotFound(obj: NotFound | any): obj is NotFound {
-  return obj && (obj as NotFound).notFound !== undefined;
-}
-
 export class NotFoundError extends Error {
-  constructor(message?: string) {
+  pretty: string;
+  constructor(message?: string, pretty?: string) {
     super(message);
     this.name = 'NotFound';
+    this.pretty = pretty ? pretty : 'the requested resource';
   }
 }


### PR DESCRIPTION
TabControl: handle null children

We get these when using conditional TSX to set up tabs.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

ImageList: only render images

We were incorrectly trying to render videos here.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

*: show the conditions blog tab when configured

Centers choose to opt into this feature using a field on the back-end
that we can see in the center meta-data, so we can show the tab for
those centers as requested.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

hooks: always throw errors

Instead of sometimes throwing an error and sometimes returning sentinel
data, we can always throw. This is still not really that ergonomic but
at least it's simpler.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

