### PR TITLE
map: force an async re-render to handle races

### DIFF
--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -52,6 +52,8 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
   const forecastResults = useMapLayerAvalancheForecasts(center, requestedTime, mapLayer, metadata);
   const warningResults = useMapLayerAvalancheWarnings(center, requestedTime, mapLayer);
 
+  const topElements = React.useRef(null);
+
   const navigation = useNavigation<HomeStackNavigationProps>();
   const [selectedZoneId, setSelectedZoneId] = useState<number | null>(null);
   const onPressMapView = useCallback(() => {
@@ -152,6 +154,7 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
       <SafeAreaView>
         <View>
           <VStack
+            ref={topElements}
             width="100%"
             position="absolute"
             top={0}
@@ -165,6 +168,16 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
               event.currentTarget.measureInWindow((x, y, width, height) => {
                 controller.animateUsingUpdatedTopElementsHeight(y, height);
               });
+
+              // we seem to see races between onLayout firing and the measureInWindow picking up the correct
+              // SafeAreaView bounds, so let's queue up another render pass in the future to hopefully converge
+              setTimeout(() => {
+                if (topElements.current) {
+                  topElements.current.measureInWindow((x, y, width, height) => {
+                    controller.animateUsingUpdatedTopElementsHeight(y, height);
+                  });
+                }
+              }, 50);
             }}>
             <DangerScale width="100%" />
           </VStack>

--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -97,7 +97,7 @@ export const AvalancheForecastZoneMap: React.FunctionComponent<MapProps> = ({cen
     return <QueryState results={[mapLayerResult, metadataResult, ...forecastResults, ...warningResults]} />;
   }
 
-  // default to the values in the map layer, but update it with the forecasts and wranings we've fetched
+  // default to the values in the map layer, but update it with the forecasts and warnings we've fetched
   const zonesById: Record<number, MapViewZone> = mapLayer.features.reduce((accum, feature) => {
     accum[feature.id] = {
       zone_id: feature.id,

--- a/hooks/useAvalancheCenterMetadata.ts
+++ b/hooks/useAvalancheCenterMetadata.ts
@@ -61,12 +61,12 @@ export const fetchAvalancheCenterMetadataQuery = async (queryClient: QueryClient
 const fetchAvalancheCenterMetadata = async (nationalAvalancheCenterHost: string, center_id: AvalancheCenterID, logger: Logger): Promise<AvalancheCenter> => {
   const url = `${nationalAvalancheCenterHost}/v2/public/avalanche-center/${center_id}`;
   const what = 'avalanche center metadata';
-  const thisLogger = logger.child({url: url, what: what});
+  const thisLogger = logger.child({url: url, center: center_id, what: what});
   const data = await safeFetch(() => axios.get(url), thisLogger, what);
 
   const parseResult = avalancheCenterSchema.safeParse(data);
   if (parseResult.success === false) {
-    thisLogger.warn({url: url, center: center_id, error: parseResult.error}, 'failed to parse');
+    thisLogger.warn({error: parseResult.error}, 'failed to parse');
     Sentry.Native.captureException(parseResult.error, {
       tags: {
         zod_error: true,

--- a/hooks/useWeatherStations.ts
+++ b/hooks/useWeatherStations.ts
@@ -104,7 +104,7 @@ export const useWeatherStations = ({mapLayer, token, sources}: Props) => {
           if (matchingZones.length === 0) {
             stationLogger.warn(`unable to find matching zone for weather station`);
           } else if (matchingZones.length > 1) {
-            stationLogger.warn({matchingZones: matchingZones.map(z => z.feature.properties.name)}, `found multiple matching zones for weather station}`);
+            stationLogger.warn({matchingZones: matchingZones.map(z => z.feature.properties.name)}, `found multiple matching zones for weather station`);
           } else {
             // Mapped station to a single zone. Now, should it appear in the UI as part of a group?
             const groupMapping = Object.entries(stationGroupMapping).find(([_name, stids]) => stids.includes(s.stid));


### PR DESCRIPTION
hooks: fix a typo

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

hooks: update a logging call

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

map: force an async re-render to handle races

It seems like sometimes our onLayout routines race with the SafeAreaView
being fully set up, and there's no way to get a race-less function here
as far as I can tell, so why don't we try just re-rendering the whole
thing in 50ms, which should be long enough on the machine to get out of
the race condition but not quite long enough to annoy humans.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

