### PR TITLE
observations: fix modal

### DIFF
--- a/components/observations/ObservationsFilterForm.tsx
+++ b/components/observations/ObservationsFilterForm.tsx
@@ -296,7 +296,7 @@ export const ObservationsFilterForm: React.FunctionComponent<ObservationsFilterF
               mx={16}
               mt={16}
               buttonStyle="primary"
-              onPress={
+              onPress={() =>
                 void (async () => {
                   // Force validation errors to show up on fields that haven't been visited yet
                   await formContext.trigger();

--- a/components/observations/SimpleForm.tsx
+++ b/components/observations/SimpleForm.tsx
@@ -450,7 +450,7 @@ export const SimpleForm: React.FC<{
                     mt={16}
                     buttonStyle="primary"
                     disabled={mutation.isSuccess}
-                    onPress={
+                    onPress={() =>
                       void (async () => {
                         // Force validation errors to show up on fields that haven't been visited yet
                         await formContext.trigger();


### PR DESCRIPTION
Fixes #308 

@floatplane I messed up this IIFE ... the TypeScript `strict: true` mode had me doing back-bends and cartwheels to get async funcs in places like `onPress` to not error. Might have made the same bug in other spots.