### PR TITLE
A few miscellaneous things

### DIFF
--- a/components/content/AvalancheCenterList.tsx
+++ b/components/content/AvalancheCenterList.tsx
@@ -18,8 +18,8 @@ const AvalancheCenterListItem: React.FC<AvalancheCenterListItemProps> = ({data, 
   const center_id: AvalancheCenterID = data.center.id as AvalancheCenterID;
   return (
     <TouchableOpacity onPress={() => setSelected(center_id)} activeOpacity={0.8}>
-      <HStack justifyContent="space-between" alignItems="flex-start" space={4}>
-        <HStack space={8} flexShrink={1} alignItems="flex-start">
+      <HStack justifyContent="space-between" alignItems="center" space={4}>
+        <HStack space={8} flexShrink={1} alignItems="center">
           <AvalancheCenterLogo style={{height: 24, width: 24, resizeMode: 'contain', flex: 0, flexGrow: 0}} avalancheCenterId={center_id} />
           <VStack space={2} flexShrink={1}>
             <Body>

--- a/components/content/Button.tsx
+++ b/components/content/Button.tsx
@@ -1,6 +1,7 @@
 import {Center, View, ViewProps} from 'components/core';
+import {bodySize} from 'components/text';
 import React, {useState} from 'react';
-import {ColorValue, GestureResponderEvent, Pressable, Text} from 'react-native';
+import {ActivityIndicator, ColorValue, GestureResponderEvent, Pressable, Text} from 'react-native';
 import {colorLookup} from 'theme';
 
 interface ButtonStyle {
@@ -70,6 +71,7 @@ const styles = {
 interface BaseButtonProps extends ViewProps {
   onPress?: (event: GestureResponderEvent) => void;
   disabled?: boolean;
+  busy?: boolean;
 }
 
 interface StyledButtonProps extends BaseButtonProps {
@@ -77,7 +79,7 @@ interface StyledButtonProps extends BaseButtonProps {
   onPress?: (event: GestureResponderEvent) => void;
 }
 
-const StyledButton: React.FC<StyledButtonProps> = ({buttonStyle, children, onPress, disabled = false, ...props}) => {
+const StyledButton: React.FC<StyledButtonProps> = ({buttonStyle, children, onPress, disabled = false, busy = false, ...props}) => {
   const [pressed, setIsPressed] = useState<boolean>(false);
   const colorStyleSource = disabled ? buttonStyle.disabled : pressed ? buttonStyle.pressed : buttonStyle;
   const {backgroundColor, borderColor, textColor} = colorStyleSource;
@@ -86,7 +88,10 @@ const StyledButton: React.FC<StyledButtonProps> = ({buttonStyle, children, onPre
     <View borderColor={borderColor} borderWidth={2} borderRadius={8} py={12} px={16} {...props} backgroundColor={backgroundColor}>
       <Pressable disabled={disabled} onPressIn={() => setIsPressed(true)} onPressOut={() => setIsPressed(false)} onPress={event => onPress?.(event)}>
         <Center>
-          <Text style={{color: textColor}}>{children}</Text>
+          <View style={{position: 'relative'}}>
+            <Text style={{color: textColor}}>{children}</Text>
+            {busy && <ActivityIndicator size={bodySize} color={textColor} style={{position: 'absolute', right: -1.5 * bodySize, top: 0.25 * bodySize}} />}
+          </View>
         </Center>
       </Pressable>
     </View>

--- a/components/content/Card.tsx
+++ b/components/content/Card.tsx
@@ -11,19 +11,30 @@ import {colorLookup} from 'theme';
 export interface CardProps extends ViewProps {
   header?: ReactNode;
   onPress?: () => void;
+  borderWidth?: number;
   borderRadius?: number;
   borderColor?: ColorValue;
   noDivider?: boolean;
   noInternalSpace?: boolean;
 }
 
-export const Card: React.FunctionComponent<PropsWithChildren<CardProps>> = ({header, onPress, borderColor, borderRadius, noDivider, noInternalSpace, children, ...boxProps}) => {
+export const Card: React.FunctionComponent<PropsWithChildren<CardProps>> = ({
+  header,
+  onPress,
+  borderColor,
+  borderRadius,
+  borderWidth,
+  noDivider,
+  noInternalSpace,
+  children,
+  ...boxProps
+}) => {
   const pressHandler = useCallback(() => onPress?.(), [onPress]);
 
   return (
     <View {...boxProps}>
       <TouchableOpacity onPress={pressHandler} disabled={!onPress}>
-        <View bg="white" borderWidth={2} borderRadius={borderRadius ?? 8} borderColor={borderColor ?? 'light.300'} p={16}>
+        <View bg="white" borderWidth={borderWidth ?? 2} borderRadius={borderRadius ?? 8} borderColor={borderColor ?? 'light.300'} p={16}>
           <VStack space={noInternalSpace ? 0 : 8}>
             <>{header}</>
             {noDivider || <Divider />}

--- a/components/content/Outcome.tsx
+++ b/components/content/Outcome.tsx
@@ -15,7 +15,7 @@ export interface OutcomeOptions {
 
 export const Outcome: React.FunctionComponent<OutcomeOptions> = ({outcome, reason, illustration, inline, onRetry, onClose}) => {
   return (
-    <View style={inline ? {} : {height: '100%', width: '100%'}} bg="white">
+    <View style={inline ? {} : {height: '100%', width: '100%'}} bg="white" pb={32}>
       <VStack justifyContent={'center'} flex={1}>
         <View mx={16}>
           <VStack space={24} alignItems={'center'}>

--- a/components/content/QueryState.tsx
+++ b/components/content/QueryState.tsx
@@ -61,7 +61,7 @@ export const Loading: React.FunctionComponent = () => {
 };
 
 export const NotFound: React.FunctionComponent<{what?: NotFoundError[]; terminal?: boolean; inline?: boolean}> = ({what, terminal, inline}) => {
-  let thing = 'requested resource';
+  let thing = 'the requested resource';
   if (what && what[0] && what[0] instanceof NotFoundError && what[0].pretty) {
     thing = what[0].pretty;
   }
@@ -71,7 +71,7 @@ export const NotFound: React.FunctionComponent<{what?: NotFoundError[]; terminal
   if (terminal) {
     onClose = undefined;
   }
-  return <Outcome outcome={'No results found'} reason={`We could not find the ${thing}.`} inline={inline} illustration={<NoSearchResult />} onClose={onClose} />;
+  return <Outcome outcome={'No results found'} reason={`We could not find ${thing}.`} inline={inline} illustration={<NoSearchResult />} onClose={onClose} />;
 };
 
 export const ConnectionLost: React.FunctionComponent = () => {

--- a/components/observations/ObservationsListView.tsx
+++ b/components/observations/ObservationsListView.tsx
@@ -24,10 +24,10 @@ import {NotFoundError} from 'types/requests';
 import {RequestedTime, utcDateToLocalDateString} from 'utils/date';
 
 interface ObservationsListViewItem {
-  id?: ObservationFragment['id'];
-  observation?: ObservationFragment;
-  source?: string;
-  zone?: string;
+  id: ObservationFragment['id'];
+  observation: ObservationFragment;
+  source: string;
+  zone: string;
 }
 
 interface ObservationsListViewProps extends Omit<FlatListProps<ObservationsListViewItem>, 'data' | 'renderItem'> {
@@ -88,14 +88,14 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
           <HStack px={16} pt={12} pb={12} space={24} backgroundColor={colorLookup('background.base')}>
             <TouchableOpacity onPress={() => setFilterModalVisible(true)}>
               <HStack bg={'white'} px={12} py={8} space={8} borderRadius={30} borderWidth={1}>
-                <FontAwesome name="sliders" size={16} color="black" />
+                <FontAwesome name="sliders" size={16} color={colorLookup('text')} />
                 <BodySmBlack>Filters{resolvedFilters.length > 0 && ` (${resolvedFilters.length})`}</BodySmBlack>
               </HStack>
             </TouchableOpacity>
           </HStack>
         }
         ListFooterComponent={
-          nacObservationsResult.hasNextPage || nwacObservationsResult.hasNextPage ? (
+          displayedObservations.length > 0 && (nacObservationsResult.hasNextPage || nwacObservationsResult.hasNextPage) ? (
             <HStack justifyContent="center" mt={4}>
               <Button
                 width={'50%'}
@@ -111,25 +111,16 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
             </HStack>
           ) : null
         }
+        ListEmptyComponent={<NotFound inline terminal what={[new NotFoundError('no observations found', 'any matching observations')]} />}
         style={{backgroundColor: colorLookup('background.base'), width: '100%', height: '100%'}}
         refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={void refresh} />}
-        data={
-          displayedObservations.length > 0
-            ? displayedObservations.map(observation => ({
-                id: observation.id,
-                observation: observation,
-                source: nwacObservations.map(o => o.id).includes(observation.id) ? 'nwac' : 'nac',
-                zone: zone(mapLayer, observation.locationPoint.lat, observation.locationPoint.lng),
-              }))
-            : [{}]
-        }
-        renderItem={({item}) =>
-          item.id && item.observation && item.source && item.zone ? (
-            <ObservationSummaryCard source={item.source} observation={item.observation} zone={item.zone} />
-          ) : (
-            <NotFound inline terminal what={[new NotFoundError('no observations found', 'any matching observations')]} />
-          )
-        }
+        data={displayedObservations.map(observation => ({
+          id: observation.id,
+          observation: observation,
+          source: nwacObservations.map(o => o.id).includes(observation.id) ? 'nwac' : 'nac',
+          zone: zone(mapLayer, observation.locationPoint.lat, observation.locationPoint.lng),
+        }))}
+        renderItem={({item}) => <ObservationSummaryCard source={item.source} observation={item.observation} zone={item.zone} />}
         {...props}
       />
     </>

--- a/components/observations/ObservationsListView.tsx
+++ b/components/observations/ObservationsListView.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {Feather, FontAwesome, MaterialCommunityIcons} from '@expo/vector-icons';
+import {FontAwesome, MaterialCommunityIcons} from '@expo/vector-icons';
 import {useNavigation} from '@react-navigation/native';
 import {colorFor} from 'components/AvalancheDangerPyramid';
 import {Button} from 'components/content/Button';
@@ -10,15 +10,15 @@ import {incompleteQueryState, NotFound, QueryState} from 'components/content/Que
 import {HStack, View, VStack} from 'components/core';
 import {NACIcon} from 'components/icons/nac-icons';
 import {filtersForConfig, ObservationFilterConfig, ObservationsFilterForm, zone} from 'components/observations/ObservationsFilterForm';
-import {Body, BodyBlack, BodySemibold, BodySmBlack, Caption1Black} from 'components/text';
+import {Body, BodyBlack, BodySmBlack, Caption1} from 'components/text';
 import {compareDesc, parseISO, setDayOfYear} from 'date-fns';
 import {useMapLayer} from 'hooks/useMapLayer';
 import {useNACObservations} from 'hooks/useNACObservations';
 import {useNWACObservations} from 'hooks/useNWACObservations';
 import {useRefresh} from 'hooks/useRefresh';
-import {ActivityIndicator, FlatList, FlatListProps, Modal, RefreshControl, TouchableOpacity} from 'react-native';
+import {FlatList, FlatListProps, Modal, RefreshControl, TouchableOpacity} from 'react-native';
 import {ObservationsStackNavigationProps} from 'routes';
-import theme, {colorLookup} from 'theme';
+import {colorLookup} from 'theme';
 import {AvalancheCenterID, DangerLevel, MediaType, ObservationFragment, PartnerType} from 'types/nationalAvalancheCenter';
 import {NotFoundError} from 'types/requests';
 import {RequestedTime, utcDateToLocalDateString} from 'utils/date';
@@ -87,38 +87,29 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
         ListHeaderComponent={
           <HStack px={16} pt={12} pb={12} space={24} backgroundColor={colorLookup('background.base')}>
             <TouchableOpacity onPress={() => setFilterModalVisible(true)}>
-              <HStack bg={'white'} px={12} py={8} space={8} borderRadius={30} borderWidth={1} style={{...theme.shadows['5']}}>
-                <FontAwesome name="sliders" size={24} color="black" />
-                <BodySemibold>Filters{resolvedFilters.length > 0 && ` (${resolvedFilters.length})`}</BodySemibold>
+              <HStack bg={'white'} px={12} py={8} space={8} borderRadius={30} borderWidth={1}>
+                <FontAwesome name="sliders" size={16} color="black" />
+                <BodySmBlack>Filters{resolvedFilters.length > 0 && ` (${resolvedFilters.length})`}</BodySmBlack>
               </HStack>
             </TouchableOpacity>
           </HStack>
         }
         ListFooterComponent={
-          <>
-            {nacObservationsResult.isFetchingNextPage || nwacObservationsResult.isFetchingNextPage ? (
-              <View borderRadius={8} py={12} px={16}>
-                <HStack width={'100%'} space={8} justifyContent={'center'} alignItems={'center'}>
-                  <BodyBlack>Loading more...</BodyBlack>
-                  <ActivityIndicator />
-                </HStack>
-              </View>
-            ) : (
-              (nacObservationsResult.hasNextPage || nwacObservationsResult.hasNextPage) && (
-                <HStack justifyContent="center">
-                  <Button
-                    width={'50%'}
-                    buttonStyle={'primary'}
-                    onPress={() => {
-                      void nwacObservationsResult.fetchNextPage();
-                      void nacObservationsResult.fetchNextPage();
-                    }}>
-                    <BodyBlack>Load more...</BodyBlack>
-                  </Button>
-                </HStack>
-              )
-            )}
-          </>
+          nacObservationsResult.hasNextPage || nwacObservationsResult.hasNextPage ? (
+            <HStack justifyContent="center" mt={4}>
+              <Button
+                width={'50%'}
+                buttonStyle={'primary'}
+                disabled={nacObservationsResult.isFetchingNextPage || nwacObservationsResult.isFetchingNextPage}
+                busy={nacObservationsResult.isFetchingNextPage || nwacObservationsResult.isFetchingNextPage}
+                onPress={() => {
+                  void nwacObservationsResult.fetchNextPage();
+                  void nacObservationsResult.fetchNextPage();
+                }}>
+                <BodyBlack>Load more...</BodyBlack>
+              </Button>
+            </HStack>
+          ) : null
         }
         style={{backgroundColor: colorLookup('background.base'), width: '100%', height: '100%'}}
         refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={void refresh} />}
@@ -173,11 +164,11 @@ export const ObservationSummaryCard: React.FunctionComponent<{
   return (
     <Card
       mx={8}
-      px={8}
       my={2}
       py={4}
       borderRadius={10}
-      borderColor="white"
+      borderColor={colorLookup('light.300')}
+      borderWidth={1}
       onPress={() => {
         if (source === 'nwac') {
           navigation.navigate('nwacObservation', {
@@ -189,31 +180,27 @@ export const ObservationSummaryCard: React.FunctionComponent<{
           });
         }
       }}
-      noDivider
       header={
         <HStack alignContent="flex-start" justifyContent="space-between" flexWrap="wrap" alignItems="center" space={8}>
           <BodySmBlack>{utcDateToLocalDateString(observation.createdAt)}</BodySmBlack>
           <View px={8} py={6} borderRadius={12} backgroundColor={colorsFor(observation.observerType).secondary}>
             <HStack space={8}>
               <View height={12} width={12} borderRadius={6} backgroundColor={colorsFor(observation.observerType).primary} />
-              <Caption1Black style={{textTransform: 'uppercase', color: colorsFor(observation.observerType).primary}}>{observation.observerType}</Caption1Black>
+              <Caption1 style={{textTransform: 'uppercase', color: colorsFor(observation.observerType).primary}}>{observation.observerType}</Caption1>
             </HStack>
           </View>
         </HStack>
       }>
       <HStack space={48} justifyContent="space-between" alignItems={'flex-start'}>
-        <HStack space={8} alignItems={'flex-start'} flex={1}>
-          <Feather name="map-pin" size={20} color="black" />
-          <VStack space={4} alignItems={'flex-start'} flex={1}>
-            <BodyBlack>{zone}</BodyBlack>
-            <Body>{observation.locationName}</Body>
-            <HStack space={8}>
-              {redFlags && <MaterialCommunityIcons name="flag" size={24} color={colorFor(DangerLevel.Considerable).string()} />}
-              {avalanches && <NACIcon name="avalanche" size={24} color={colorFor(DangerLevel.High).string()} />}
-            </HStack>
-          </VStack>
-        </HStack>
-        <View width={52} flex={0} mx={8}>
+        <VStack space={4} alignItems={'flex-start'} flex={1}>
+          <BodyBlack>{zone}</BodyBlack>
+          <Body color="text.secondary">{observation.locationName}</Body>
+          <HStack space={8}>
+            {redFlags && <MaterialCommunityIcons name="flag" size={24} color={colorFor(DangerLevel.Considerable).string()} />}
+            {avalanches && <NACIcon name="avalanche" size={24} color={colorFor(DangerLevel.High).string()} />}
+          </HStack>
+        </VStack>
+        <View width={52} flex={0} ml={8}>
           {observation.media && observation.media.length > 0 && observation.media[0].type === MediaType.Image && observation.media[0].url?.thumbnail && (
             <NetworkImage width={52} height={52} uri={observation.media[0].url.thumbnail} imageStyle={{borderRadius: 4}} index={0} onPress={undefined} onStateChange={undefined} />
           )}

--- a/components/observations/SimpleForm.tsx
+++ b/components/observations/SimpleForm.tsx
@@ -7,14 +7,14 @@ import {AxiosError} from 'axios';
 import * as ImagePicker from 'expo-image-picker';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {FieldErrors, FormProvider, useForm, useWatch} from 'react-hook-form';
-import {ActivityIndicator, findNodeHandle, KeyboardAvoidingView, Platform, ScrollView, View as RNView} from 'react-native';
+import {findNodeHandle, KeyboardAvoidingView, Platform, ScrollView, View as RNView} from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
 
 import {ClientContext, ClientProps} from 'clientContext';
 import {Button} from 'components/content/Button';
 import {Card} from 'components/content/Card';
 import {ImageList} from 'components/content/carousel/ImageList';
-import {HStack, View, VStack} from 'components/core';
+import {View, VStack} from 'components/core';
 import {Conditional} from 'components/form/Conditional';
 import {DateField} from 'components/form/DateField';
 import {LocationField} from 'components/form/LocationField';
@@ -450,6 +450,7 @@ export const SimpleForm: React.FC<{
                     mt={16}
                     buttonStyle="primary"
                     disabled={mutation.isSuccess}
+                    busy={mutation.isLoading}
                     onPress={() =>
                       void (async () => {
                         // Force validation errors to show up on fields that haven't been visited yet
@@ -458,13 +459,7 @@ export const SimpleForm: React.FC<{
                         void formContext.handleSubmit(onSubmitHandler, onSubmitErrorHandler)();
                       })()
                     }>
-                    {mutation.isLoading && (
-                      <HStack space={8} alignItems="center" pt={3}>
-                        <ActivityIndicator size="small" />
-                        <BodyBlack color={colorLookup('white')}>Cancel submission</BodyBlack>
-                      </HStack>
-                    )}
-                    {!mutation.isLoading && <BodySemibold>Submit your observation</BodySemibold>}
+                    <BodySemibold>{mutation.isLoading ? 'Cancel submission' : 'Submit your observation'}</BodySemibold>
                   </Button>
                   <VStack mx={16} mt={16} mb={32}>
                     {mutation.isSuccess && <Body>Thanks for your observation!</Body>}


### PR DESCRIPTION
- avalanche center picker elements weren't center-aligned (icon/text/checkbox)
- observation list feedback from [Figma](https://www.figma.com/file/Bai2w7x0vUakL5WRjPGRg7/Native-App?type=design&node-id=1312-174816&mode=design&t=kFWAMAmCxjIJCpB3-0)
- added a `busy` prop to `Button` for the common case of needing to append an `ActivityIndicator` to the text within
  - replace existing usage in observation submission
  - switch to this pattern when loading more observations

https://github.com/stevekuznetsov/avalanche-forecast/assets/101196/0f1eccee-8e1e-4100-81a1-371fc1611c44

