### PR TITLE
Add time machine for debugging

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "eslint.useESLintClass": true
+}

--- a/App.tsx
+++ b/App.tsx
@@ -61,6 +61,7 @@ import {PreferencesProvider, usePreferences} from 'Preferences';
 import {TamaguiProvider, Theme} from 'tamagui';
 import config from 'tamagui.config';
 import {NotFoundError} from 'types/requests';
+import {formatRequestedTime, RequestedTime} from 'utils/date';
 
 const logLevel = (Constants.expoConfig?.extra?.log_level as string) ?? 'INFO';
 
@@ -219,9 +220,12 @@ const App = () => {
 
 const AppWithClientContext = () => {
   const [staging, setStaging] = React.useState(false);
+  const [requestedTime, setRequestedTime] = React.useState<RequestedTime>('latest');
 
   const contextValue = {
     ...(staging ? stagingHosts : productionHosts),
+    requestedTime,
+    setRequestedTime,
   };
 
   return (
@@ -248,7 +252,7 @@ const BaseApp: React.FunctionComponent<{
     [setPreferences],
   );
 
-  const {nationalAvalancheCenterHost, nationalAvalancheCenterWordpressHost, nwacHost, snowboundHost} = React.useContext<ClientProps>(ClientContext);
+  const {nationalAvalancheCenterHost, nationalAvalancheCenterWordpressHost, nwacHost, snowboundHost, requestedTime} = React.useContext<ClientProps>(ClientContext);
   const queryClient = useQueryClient();
   useEffect(() => {
     void (async () => {
@@ -343,26 +347,27 @@ const BaseApp: React.FunctionComponent<{
                         tabBarActiveTintColor: colorLookup('primary') as string,
                         tabBarInactiveTintColor: colorLookup('text.secondary') as string,
                       })}>
-                      <TabNavigator.Screen name="Home" initialParams={{center_id: avalancheCenterId, requestedTime: 'latest'}} options={{title: 'Map'}}>
-                        {state => HomeTabScreen(merge(state, {route: {params: {center_id: avalancheCenterId}}}))}
+                      <TabNavigator.Screen name="Home" initialParams={{center_id: avalancheCenterId}} options={{title: 'Map'}}>
+                        {state => HomeTabScreen(merge(state, {route: {params: {center_id: avalancheCenterId, requestedTime: formatRequestedTime(requestedTime)}}}))}
                       </TabNavigator.Screen>
-                      <TabNavigator.Screen name="Observations" initialParams={{center_id: avalancheCenterId, requestedTime: 'latest'}}>
+                      <TabNavigator.Screen name="Observations" initialParams={{center_id: avalancheCenterId}}>
                         {state =>
                           ObservationsTabScreen(
                             merge(state, {
                               route: {
                                 params: {
                                   center_id: avalancheCenterId,
+                                  requestedTime: formatRequestedTime(requestedTime),
                                 },
                               },
                             }),
                           )
                         }
                       </TabNavigator.Screen>
-                      <TabNavigator.Screen name="Weather Data" initialParams={{center_id: avalancheCenterId, requestedTime: 'latest'}}>
-                        {state => WeatherScreen(merge(state, {route: {params: {center_id: avalancheCenterId}}}))}
+                      <TabNavigator.Screen name="Weather Data" initialParams={{center_id: avalancheCenterId}}>
+                        {state => WeatherScreen(merge(state, {route: {params: {center_id: avalancheCenterId, requestedTime: formatRequestedTime(requestedTime)}}}))}
                       </TabNavigator.Screen>
-                      <TabNavigator.Screen name="Menu" initialParams={{center_id: avalancheCenterId, requestedTime: 'latest'}}>
+                      <TabNavigator.Screen name="Menu" initialParams={{center_id: avalancheCenterId}}>
                         {state => MenuStackScreen(state, queryCache, avalancheCenterId, setAvalancheCenterId, staging, setStaging)}
                       </TabNavigator.Screen>
                     </TabNavigator.Navigator>

--- a/clientContext.ts
+++ b/clientContext.ts
@@ -1,10 +1,13 @@
 import React, {Context} from 'react';
+import {RequestedTime} from 'utils/date';
 
 export interface ClientProps {
   nationalAvalancheCenterHost: string;
   nationalAvalancheCenterWordpressHost: string;
   snowboundHost: string;
   nwacHost: string;
+  requestedTime: RequestedTime;
+  setRequestedTime: (requestedTime: RequestedTime) => void;
 }
 
 export const productionHosts = {
@@ -24,4 +27,8 @@ export const stagingHosts = {
 
 export const ClientContext: Context<ClientProps> = React.createContext<ClientProps>({
   ...productionHosts,
+  requestedTime: 'latest',
+  setRequestedTime: () => {
+    undefined;
+  },
 });

--- a/components/observations/ObservationsFilterForm.tsx
+++ b/components/observations/ObservationsFilterForm.tsx
@@ -42,30 +42,30 @@ const observationFilterConfigSchema = z
   .deepPartial();
 export type ObservationFilterConfig = z.infer<typeof observationFilterConfigSchema>;
 
-const matchesDates = (dates: z.infer<typeof observationFilterConfigSchema.shape.dates>, observation: ObservationFragment): boolean => {
+const matchesDates = (currentDate: Date, dates: z.infer<typeof observationFilterConfigSchema.shape.dates>, observation: ObservationFragment): boolean => {
   let matches = true;
   if (!dates) {
     return matches;
   }
   switch (dates.value) {
     case 'past_day':
-      dates.to = new Date();
+      dates.to = currentDate;
       dates.from = sub(dates.to, {days: 1});
       break;
     case 'past_3_days':
-      dates.to = new Date();
+      dates.to = currentDate;
       dates.from = sub(dates.to, {days: 3});
       break;
     case 'past_week':
-      dates.to = new Date();
+      dates.to = currentDate;
       dates.from = sub(dates.to, {weeks: 1});
       break;
     case 'past_month':
-      dates.to = new Date();
+      dates.to = currentDate;
       dates.from = sub(dates.to, {months: 1});
       break;
     case 'past_season':
-      dates.to = new Date();
+      dates.to = currentDate;
       // the season starts Nov 1st, that's either this year or last year depending on when we are asking
       if (getMonth(dates.to) <= 11) {
         dates.from = new Date(`${getYear(sub(dates.to, {years: 1}))}-11-01`);
@@ -119,7 +119,7 @@ const matchesAvalancheInstability = (instability: avalancheInstability, observat
   throw new Error(`Unknown instability: ${invalid}`);
 };
 
-export const filtersForConfig = (mapLayer: MapLayer, config: ObservationFilterConfig): ((fragment: ObservationFragment) => boolean)[] => {
+export const filtersForConfig = (mapLayer: MapLayer, config: ObservationFilterConfig, currentDate: Date): ((fragment: ObservationFragment) => boolean)[] => {
   if (!config) {
     return [];
   }
@@ -130,7 +130,7 @@ export const filtersForConfig = (mapLayer: MapLayer, config: ObservationFilterCo
   }
 
   if (config.dates && config.dates.value) {
-    filterFuncs.push(observation => matchesDates(config.dates, observation));
+    filterFuncs.push(observation => matchesDates(currentDate, config.dates, observation));
   }
 
   if (config.observerType) {

--- a/components/observations/ObservationsListView.tsx
+++ b/components/observations/ObservationsListView.tsx
@@ -95,7 +95,7 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
           </HStack>
         }
         ListFooterComponent={
-          displayedObservations.length > 0 && (nacObservationsResult.hasNextPage || nwacObservationsResult.hasNextPage) ? (
+          nacObservationsResult.hasNextPage || nwacObservationsResult.hasNextPage ? (
             <HStack justifyContent="center" mt={4}>
               <Button
                 width={'50%'}

--- a/components/observations/ObservationsListView.tsx
+++ b/components/observations/ObservationsListView.tsx
@@ -21,7 +21,7 @@ import {ObservationsStackNavigationProps} from 'routes';
 import {colorLookup} from 'theme';
 import {AvalancheCenterID, DangerLevel, MediaType, ObservationFragment, PartnerType} from 'types/nationalAvalancheCenter';
 import {NotFoundError} from 'types/requests';
-import {RequestedTime, utcDateToLocalDateString} from 'utils/date';
+import {RequestedTime, requestedTimeToUTCDate, utcDateToLocalDateString} from 'utils/date';
 
 interface ObservationsListViewItem {
   id: ObservationFragment['id'];
@@ -37,10 +37,11 @@ interface ObservationsListViewProps extends Omit<FlatListProps<ObservationsListV
 }
 
 export const ObservationsListView: React.FunctionComponent<ObservationsListViewProps> = ({center_id, requestedTime, initialFilterConfig, ...props}) => {
+  const endDate = requestedTimeToUTCDate(requestedTime);
   const originalFilterConfig: ObservationFilterConfig = {
     dates: {
-      from: setDayOfYear(new Date(), 1),
-      to: new Date(),
+      from: setDayOfYear(endDate, 1),
+      to: endDate,
     },
     ...initialFilterConfig,
   };
@@ -67,7 +68,7 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
 
   // the displayed observations need to match all filters - for instance, if a user chooses a zone *and*
   // an observer type, we only show observations that match both of those at the same time
-  const resolvedFilters = filtersForConfig(mapLayer, filterConfig);
+  const resolvedFilters = filtersForConfig(mapLayer, filterConfig, endDate);
   const displayedObservations: ObservationFragment[] = observations.filter(observation =>
     resolvedFilters.map(filter => filter(observation)).reduce((currentValue, accumulator) => accumulator && currentValue, true),
   );

--- a/components/screens/MenuScreen.tsx
+++ b/components/screens/MenuScreen.tsx
@@ -753,6 +753,9 @@ const TimeMachine = () => {
       <DateTimePicker value={requestedTimeToUTCDate(requestedTime)} mode="date" display="inline" onChange={onDateSelected} />
       <Divider />
       <BodyBlack>Other interesting days</BodyBlack>
+      <Button buttonStyle="normal" onPress={() => changeTime(new Date('2023-02-20T5:21:00-0800'))}>
+        2/20/2023 - Active warning day
+      </Button>
       <Button buttonStyle="normal" onPress={() => changeTime(new Date(2023, 2, 1))}>
         3/1/2023 - random winter day
       </Button>

--- a/routes.ts
+++ b/routes.ts
@@ -97,6 +97,7 @@ export type MenuStackParamList = {
   buttonStylePreview: undefined;
   textStylePreview: undefined;
   toastPreview: undefined;
+  timeMachine: undefined;
   avalancheCenter: {
     center_id: AvalancheCenterID;
     requestedTime: RequestedTimeString;


### PR DESCRIPTION
It's really hard to work on stuff in the summertime, so I made a time machine!

screenshot | in action
--- | ---
<img src='https://github.com/stevekuznetsov/avalanche-forecast/assets/101196/6784a679-64d8-499f-844e-fa7c25f5697e' height=480 /> |<img src='https://github.com/stevekuznetsov/avalanche-forecast/assets/101196/1028601d-5114-4e54-b1a1-14c63e90f308' height=480 />


Notes

- I wanted a simpler way to flip *all* the parts of the app to a new day (and hopefully it's useful to browse particular days when investigating bugs). The existing mechanism in the screens section didn't change the query date for Weather Data, for example
- Observations list is still querying starting at `now`, I haven't looked into that but I assume/hope it's pretty easy to fix
- I didn't make the selected date sticky across runs
- There's nothing in the UI that tells you that you're browsing a particular date (which is one reason I didn't make it sticky)
- There's nothing to stop you from picking a stupid date like 1855, so don't do that
- I'll keep building the collection of good days/times to view
  - This could be especially useful when exploring those weird times around midnight UTC / local midnight / local forecast update time 😬 