### PR TITLE
Observation list tweaks, fix some react warnings

### DIFF
--- a/components/AvalancheForecastZoneMap.tsx
+++ b/components/AvalancheForecastZoneMap.tsx
@@ -6,7 +6,6 @@ import {
   FlatList,
   GestureResponderEvent,
   LayoutChangeEvent,
-  ListRenderItem,
   NativeScrollEvent,
   NativeSyntheticEvent,
   PanResponder,
@@ -534,8 +533,6 @@ const AvalancheForecastZoneCards: React.FunctionComponent<{
     setPreviousSelectedZoneId(selectedZoneId);
   }
 
-  const renderItem: ListRenderItem<MapViewZone> = ({item}) => <AvalancheForecastZoneCard key={item.zone_id} zone={item} date={date} />;
-
   return (
     <Animated.FlatList
       onLayout={(event: LayoutChangeEvent) => controller.animateUsingUpdatedCardDrawerMaximumHeight(event.nativeEvent.layout.height)}
@@ -557,8 +554,8 @@ const AvalancheForecastZoneCards: React.FunctionComponent<{
       onScrollEndDrag={() => setUserScrolling(false)}
       {...panResponder.panHandlers}
       {...flatListProps}
-      data={zones}
-      renderItem={renderItem}
+      data={zones.map(zone => ({key: zone.zone_id, zone, date}))}
+      renderItem={({item}) => <AvalancheForecastZoneCard {...item} />}
     />
   );
 };
@@ -566,7 +563,7 @@ const AvalancheForecastZoneCards: React.FunctionComponent<{
 const AvalancheForecastZoneCard: React.FunctionComponent<{
   date: RequestedTime;
   zone: MapViewZone;
-}> = ({date, zone}) => {
+}> = React.memo(({date, zone}: {date: RequestedTime; zone: MapViewZone}) => {
   const {width} = useWindowDimensions();
   const navigation = useNavigation<HomeStackNavigationProps>();
 
@@ -609,7 +606,8 @@ const AvalancheForecastZoneCard: React.FunctionComponent<{
       </VStack>
     </TouchableOpacity>
   );
-};
+});
+AvalancheForecastZoneCard.displayName = 'AvalancheForecastZoneCard';
 
 const DangerLevelTitle: React.FunctionComponent<{
   dangerLevel: DangerLevel;

--- a/components/content/carousel/NetworkImage.tsx
+++ b/components/content/carousel/NetworkImage.tsx
@@ -67,7 +67,7 @@ export const NetworkImage: React.FC<NetworkImageProps> = ({uri, width, height, o
           <Body>Media failed to load.</Body>
         </VStack>
       )}
-      {(status === 'success' || status === 'loading') && image}
+      {status === 'success' && image}
     </Center>
   );
 };

--- a/components/forecast/AvalancheTab.tsx
+++ b/components/forecast/AvalancheTab.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 
 import {addDays, formatDistanceToNow, isAfter} from 'date-fns';
 
@@ -86,6 +86,21 @@ export const AvalancheTab: React.FunctionComponent<AvalancheTabProps> = ({elevat
     });
   }, [navigation]);
 
+  useEffect(() => {
+    if (forecast?.expires_time) {
+      const expires_time = new Date(forecast.expires_time);
+      if (isAfter(new Date(), expires_time)) {
+        Toast.show({
+          type: 'error',
+          text1: `This avalanche forecast expired ${formatDistanceToNow(expires_time)} ago.`,
+          autoHide: false,
+          position: 'bottom',
+          onPress: () => Toast.hide(),
+        });
+      }
+    }
+  }, [forecast]);
+
   if (incompleteQueryState(forecastResult, warningResult) || !forecast || !warning) {
     return <QueryState results={[forecastResult, warningResult]} />;
   }
@@ -101,19 +116,6 @@ export const AvalancheTab: React.FunctionComponent<AvalancheTabProps> = ({elevat
       highestDangerToday = Math.max(currentDanger.lower, currentDanger.middle, currentDanger.upper);
     }
     outlookDanger = forecast.danger.find(item => item.valid_day === ForecastPeriod.Tomorrow);
-  }
-
-  if (forecast.expires_time) {
-    const expires_time = new Date(forecast.expires_time);
-    if (isAfter(new Date(), expires_time)) {
-      Toast.show({
-        type: 'error',
-        text1: `This avalanche forecast expired ${formatDistanceToNow(expires_time)} ago.`,
-        autoHide: false,
-        position: 'bottom',
-        onPress: () => Toast.hide(),
-      });
-    }
   }
 
   const imageItems = images(forecast.media);

--- a/components/forecast/SynopsisTab.tsx
+++ b/components/forecast/SynopsisTab.tsx
@@ -37,21 +37,23 @@ export const SynopsisTab: React.FunctionComponent<SynopsisTabProps> = ({center_i
     });
   }, [navigation]);
 
+  React.useEffect(() => {
+    if (synopsis?.expires_time) {
+      const expires_time = new Date(synopsis.expires_time);
+      if (isAfter(new Date(), expires_time)) {
+        Toast.show({
+          type: 'error',
+          text1: `This blog expired ${formatDistanceToNow(expires_time)} ago.`,
+          autoHide: false,
+          position: 'bottom',
+          onPress: () => Toast.hide(),
+        });
+      }
+    }
+  }, [synopsis]);
+
   if (incompleteQueryState(synopsisResult) || !synopsis) {
     return <QueryState results={[synopsisResult]} />;
-  }
-
-  if (synopsis.expires_time) {
-    const expires_time = new Date(synopsis.expires_time);
-    if (synopsis.expires_time && isAfter(new Date(), expires_time)) {
-      Toast.show({
-        type: 'error',
-        text1: `This blog expired ${formatDistanceToNow(expires_time)} ago.`,
-        autoHide: false,
-        position: 'bottom',
-        onPress: () => Toast.hide(),
-      });
-    }
   }
 
   const imageItems = images(synopsis.media);

--- a/components/observations/ObservationsListView.tsx
+++ b/components/observations/ObservationsListView.tsx
@@ -10,7 +10,7 @@ import {incompleteQueryState, NotFound, QueryState} from 'components/content/Que
 import {HStack, View, VStack} from 'components/core';
 import {NACIcon} from 'components/icons/nac-icons';
 import {filtersForConfig, ObservationFilterConfig, ObservationsFilterForm, zone} from 'components/observations/ObservationsFilterForm';
-import {Body, BodyBlack, BodySmBlack, Caption1Semibold} from 'components/text';
+import {Body, BodyBlack, bodySize, BodySmBlack, Caption1Semibold} from 'components/text';
 import {compareDesc, parseISO, setDayOfYear} from 'date-fns';
 import {useMapLayer} from 'hooks/useMapLayer';
 import {useNACObservations} from 'hooks/useNACObservations';
@@ -121,6 +121,7 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
           source: nwacObservations.map(o => o.id).includes(observation.id) ? 'nwac' : 'nac',
           zone: zone(mapLayer, observation.locationPoint.lat, observation.locationPoint.lng),
         }))}
+        getItemLayout={(data, index) => ({length: OBSERVATION_SUMMARY_CARD_HEIGHT, offset: OBSERVATION_SUMMARY_CARD_HEIGHT * index, index})}
         renderItem={({item}) => <ObservationSummaryCard source={item.source} observation={item.observation} zone={item.zone} />}
         {...props}
       />
@@ -151,6 +152,8 @@ export interface ObservationSummaryCardProps {
   zone: string;
 }
 
+const OBSERVATION_SUMMARY_CARD_HEIGHT = 132;
+
 export const ObservationSummaryCard: React.FunctionComponent<ObservationSummaryCardProps> = React.memo(({source, zone, observation}: ObservationSummaryCardProps) => {
   const navigation = useNavigation<ObservationsStackNavigationProps>();
   const avalanches = observation.instability.avalanches_caught || observation.instability.avalanches_observed || observation.instability.avalanches_triggered;
@@ -177,21 +180,23 @@ export const ObservationSummaryCard: React.FunctionComponent<ObservationSummaryC
       header={
         <HStack alignContent="flex-start" justifyContent="space-between" flexWrap="wrap" alignItems="center" space={8}>
           <BodySmBlack>{utcDateToLocalDateString(observation.createdAt)}</BodySmBlack>
-          <Caption1Semibold color={colorsFor(observation.observerType).primary} style={{textTransform: 'uppercase'}}>
-            {observation.observerType}
-          </Caption1Semibold>
+          <HStack space={8} alignItems="center">
+            {redFlags && <MaterialCommunityIcons name="flag" size={bodySize} color={colorFor(DangerLevel.Considerable).string()} />}
+            {avalanches && <NACIcon name="avalanche" size={bodySize} color={colorFor(DangerLevel.High).string()} />}
+            <Caption1Semibold color={colorsFor(observation.observerType).primary} style={{textTransform: 'uppercase'}}>
+              {observation.observerType}
+            </Caption1Semibold>
+          </HStack>
         </HStack>
       }>
       <HStack space={48} justifyContent="space-between" alignItems={'flex-start'}>
         <VStack space={4} alignItems={'flex-start'} flex={1}>
           <BodyBlack>{zone}</BodyBlack>
-          <Body color="text.secondary">{observation.locationName}</Body>
-          <HStack space={8}>
-            {redFlags && <MaterialCommunityIcons name="flag" size={24} color={colorFor(DangerLevel.Considerable).string()} />}
-            {avalanches && <NACIcon name="avalanche" size={24} color={colorFor(DangerLevel.High).string()} />}
-          </HStack>
+          <Body color="text.secondary" numberOfLines={1}>
+            {observation.locationName}
+          </Body>
         </VStack>
-        <View width={52} flex={0} ml={8}>
+        <View width={52} height={52} flex={0} ml={8}>
           {observation.media && observation.media.length > 0 && observation.media[0].type === MediaType.Image && observation.media[0].url?.thumbnail && (
             <NetworkImage width={52} height={52} uri={observation.media[0].url.thumbnail} imageStyle={{borderRadius: 4}} index={0} onPress={undefined} onStateChange={undefined} />
           )}

--- a/components/observations/ObservationsListView.tsx
+++ b/components/observations/ObservationsListView.tsx
@@ -145,11 +145,13 @@ const colorsFor = (partnerType: PartnerType) => {
   throw new Error(`Unknown partner type: ${invalid}`);
 };
 
-export const ObservationSummaryCard: React.FunctionComponent<{
+export interface ObservationSummaryCardProps {
   source: string;
   observation: ObservationFragment;
   zone: string;
-}> = ({source, zone, observation}) => {
+}
+
+export const ObservationSummaryCard: React.FunctionComponent<ObservationSummaryCardProps> = React.memo(({source, zone, observation}: ObservationSummaryCardProps) => {
   const navigation = useNavigation<ObservationsStackNavigationProps>();
   const avalanches = observation.instability.avalanches_caught || observation.instability.avalanches_observed || observation.instability.avalanches_triggered;
   const redFlags = observation.instability.collapsing || observation.instability.cracking;
@@ -197,4 +199,5 @@ export const ObservationSummaryCard: React.FunctionComponent<{
       </HStack>
     </Card>
   );
-};
+});
+ObservationSummaryCard.displayName = 'ObservationSummaryCard';

--- a/components/observations/ObservationsListView.tsx
+++ b/components/observations/ObservationsListView.tsx
@@ -10,7 +10,7 @@ import {incompleteQueryState, NotFound, QueryState} from 'components/content/Que
 import {HStack, View, VStack} from 'components/core';
 import {NACIcon} from 'components/icons/nac-icons';
 import {filtersForConfig, ObservationFilterConfig, ObservationsFilterForm, zone} from 'components/observations/ObservationsFilterForm';
-import {Body, BodyBlack, BodySmBlack, Caption1} from 'components/text';
+import {Body, BodyBlack, BodySmBlack, Caption1Semibold} from 'components/text';
 import {compareDesc, parseISO, setDayOfYear} from 'date-fns';
 import {useMapLayer} from 'hooks/useMapLayer';
 import {useNACObservations} from 'hooks/useNACObservations';
@@ -175,12 +175,9 @@ export const ObservationSummaryCard: React.FunctionComponent<{
       header={
         <HStack alignContent="flex-start" justifyContent="space-between" flexWrap="wrap" alignItems="center" space={8}>
           <BodySmBlack>{utcDateToLocalDateString(observation.createdAt)}</BodySmBlack>
-          <View px={8} py={6} borderRadius={12} backgroundColor={colorsFor(observation.observerType).secondary}>
-            <HStack space={8}>
-              <View height={12} width={12} borderRadius={6} backgroundColor={colorsFor(observation.observerType).primary} />
-              <Caption1 style={{textTransform: 'uppercase', color: colorsFor(observation.observerType).primary}}>{observation.observerType}</Caption1>
-            </HStack>
-          </View>
+          <Caption1Semibold color={colorsFor(observation.observerType).primary} style={{textTransform: 'uppercase'}}>
+            {observation.observerType}
+          </Caption1Semibold>
         </HStack>
       }>
       <HStack space={48} justifyContent="space-between" alignItems={'flex-start'}>


### PR DESCRIPTION
This is a mixed bag of changes, but each commit is standalone. In order:

- Observation list feedback from Figma
- Use React.memo to make list item components pure - should (hopefully) address console warnings of the form `VirtualizedList: You have a large list that is slow to update`. LMK if they keep popping up
- Calling `Toast.show` directly from a render function triggers errors of the form `Cannot update a component from inside the function body of a different component.`. You have to call it from an input handler or from `useEffect` cc @stevekuznetsov 
- The NetworkImage component wasn't rendering its spinner correctly, fixed that
- Make Observation list cells fixed height, so scrolling is smooooth