### PR TITLE
Infinite scroll in observations list

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -63,6 +63,8 @@ import config from 'tamagui.config';
 import {NotFoundError} from 'types/requests';
 import {formatRequestedTime, RequestedTime} from 'utils/date';
 
+export const QUERY_CACHE_ASYNC_STORAGE_KEY = `QUERY_CACHE_ASYNC_STORAGE_KEY`;
+
 const logLevel = (Constants.expoConfig?.extra?.log_level as string) ?? 'INFO';
 
 const logger = createLogger({
@@ -178,6 +180,7 @@ void BackgroundFetch.registerTaskAsync(BACKGROUND_CACHE_RECONCILIATION_TASK, {
 
 const asyncStoragePersister = createAsyncStoragePersister({
   storage: AsyncStorage,
+  key: QUERY_CACHE_ASYNC_STORAGE_KEY,
 });
 
 void clearUploadCache();

--- a/components/content/Button.tsx
+++ b/components/content/Button.tsx
@@ -32,6 +32,7 @@ const styles = {
       textColor: colorLookup('text'),
     },
     pressed: {
+      backgroundColor: colorLookup('blue2Background'),
       borderColor: colorLookup('blue2'),
       textColor: colorLookup('blue2'),
     },

--- a/components/content/QueryState.tsx
+++ b/components/content/QueryState.tsx
@@ -55,7 +55,7 @@ export const InternalError: React.FunctionComponent<{inline?: boolean}> = ({inli
 export const Loading: React.FunctionComponent = () => {
   return (
     <HStack width={'100%'} space={8} style={{flex: 1}} justifyContent={'center'} alignItems={'center'}>
-      <ActivityIndicator />
+      <ActivityIndicator size="large" />
     </HStack>
   );
 };

--- a/components/observations/ObservationsListView.tsx
+++ b/components/observations/ObservationsListView.tsx
@@ -156,7 +156,7 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
               </Center>
             );
           } else {
-            return null;
+            return <View height={OBSERVATION_SUMMARY_CARD_HEIGHT} />;
           }
         }}
         ListEmptyComponent={<NotFound inline terminal what={[new NotFoundError('no observations found', 'any matching observations')]} />}

--- a/components/observations/ObservationsListView.tsx
+++ b/components/observations/ObservationsListView.tsx
@@ -1,22 +1,22 @@
-import React from 'react';
+import React, {useCallback} from 'react';
 
 import {FontAwesome, MaterialCommunityIcons} from '@expo/vector-icons';
 import {useNavigation} from '@react-navigation/native';
 import {colorFor} from 'components/AvalancheDangerPyramid';
-import {Button} from 'components/content/Button';
 import {Card} from 'components/content/Card';
 import {NetworkImage} from 'components/content/carousel/NetworkImage';
 import {incompleteQueryState, NotFound, QueryState} from 'components/content/QueryState';
-import {HStack, View, VStack} from 'components/core';
+import {Center, HStack, View, VStack} from 'components/core';
 import {NACIcon} from 'components/icons/nac-icons';
 import {filtersForConfig, ObservationFilterConfig, ObservationsFilterForm, zone} from 'components/observations/ObservationsFilterForm';
 import {Body, BodyBlack, bodySize, BodySmBlack, Caption1Semibold} from 'components/text';
-import {compareDesc, parseISO, setDayOfYear} from 'date-fns';
+import {add, compareDesc, parseISO} from 'date-fns';
 import {useMapLayer} from 'hooks/useMapLayer';
 import {useNACObservations} from 'hooks/useNACObservations';
 import {useNWACObservations} from 'hooks/useNWACObservations';
+import {DEFAULT_OBSERVATIONS_WINDOW} from 'hooks/useObservations';
 import {useRefresh} from 'hooks/useRefresh';
-import {FlatList, FlatListProps, Modal, RefreshControl, TouchableOpacity} from 'react-native';
+import {ActivityIndicator, FlatList, FlatListProps, Modal, RefreshControl, TouchableOpacity} from 'react-native';
 import {ObservationsStackNavigationProps} from 'routes';
 import {colorLookup} from 'theme';
 import {AvalancheCenterID, DangerLevel, MediaType, ObservationFragment, PartnerType} from 'types/nationalAvalancheCenter';
@@ -40,7 +40,7 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
   const endDate = requestedTimeToUTCDate(requestedTime);
   const originalFilterConfig: ObservationFilterConfig = {
     dates: {
-      from: setDayOfYear(endDate, 1),
+      from: add(endDate, DEFAULT_OBSERVATIONS_WINDOW),
       to: endDate,
     },
     ...initialFilterConfig,
@@ -50,15 +50,41 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
   const mapResult = useMapLayer(center_id);
   const mapLayer = mapResult.data;
 
-  const nacObservationsResult = useNACObservations(center_id, requestedTime);
+  // TODO brian wire up duration correctly - there's an interaction between useInfiniteQuery (which has a cached
+  // notion of whether there's more data) and this duration, and I'm not sure of the best way to solve it.
+  // Right now, the queryKey in useNACObservations/useNWACObservations doesn't use the duration, so it's not invalidated when the duration changes.
+  // That has the nice property of not re-fetching data when the duration changes, but it also means that if you make the duration longer, you won't get new data.
+  const nacObservationsResult = useNACObservations(center_id, requestedTime, DEFAULT_OBSERVATIONS_WINDOW);
   const nacObservations: ObservationFragment[] = nacObservationsResult.data?.pages?.flatMap(page => page.data) ?? [];
-  const nwacObservationsResult = useNWACObservations(center_id, requestedTime);
+  const nwacObservationsResult = useNWACObservations(center_id, requestedTime, DEFAULT_OBSERVATIONS_WINDOW);
   const nwacObservations: ObservationFragment[] = nwacObservationsResult.data?.pages?.flatMap(page => page.data) ?? [];
   const observations: ObservationFragment[] = nacObservations
     .concat(nwacObservations)
     .filter(observation => observation) // when nothing is returned from the NAC, we get a null
     .filter((v, i, a) => a.findIndex(v2 => v2.id === v.id) === i); // sometimes, the NWAC API gives us duplicates
   const {isRefreshing, refresh} = useRefresh(mapResult.refetch, nacObservationsResult.refetch, nwacObservationsResult.refetch);
+
+  const fetchMoreData = useCallback(async (observationsResult: ReturnType<typeof useNACObservations> | ReturnType<typeof useNWACObservations>) => {
+    const {isFetchingNextPage} = observationsResult;
+    let {hasNextPage, fetchNextPage} = observationsResult;
+    if (isFetchingNextPage || !hasNextPage) {
+      return;
+    }
+
+    // Fetch until we get to the end of the data, or get at least one item
+    while (hasNextPage) {
+      const pageResult = await fetchNextPage();
+      if (!pageResult.hasNextPage) {
+        break;
+      }
+      const fetchCount = pageResult.data?.pages[pageResult.data?.pages.length - 1].data?.length ?? 0;
+      if (fetchCount > 0) {
+        break;
+      }
+      hasNextPage = pageResult.hasNextPage;
+      fetchNextPage = pageResult.fetchNextPage;
+    }
+  }, []);
 
   if (incompleteQueryState(nacObservationsResult, nwacObservationsResult, mapResult) || !observations || !mapLayer) {
     return <QueryState results={[nacObservationsResult, nwacObservationsResult, mapResult]} />;
@@ -85,6 +111,12 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
         />
       </Modal>
       <FlatList
+        // when within 2 page lengths of the end, start fetching the next set of data
+        onEndReachedThreshold={2}
+        onEndReached={() => {
+          void fetchMoreData(nwacObservationsResult);
+          void fetchMoreData(nacObservationsResult);
+        }}
         ListHeaderComponent={
           <HStack px={16} pt={12} pb={12} space={24} backgroundColor={colorLookup('background.base')}>
             <TouchableOpacity onPress={() => setFilterModalVisible(true)}>
@@ -95,23 +127,26 @@ export const ObservationsListView: React.FunctionComponent<ObservationsListViewP
             </TouchableOpacity>
           </HStack>
         }
-        ListFooterComponent={
-          nacObservationsResult.hasNextPage || nwacObservationsResult.hasNextPage ? (
-            <HStack justifyContent="center" mt={4}>
-              <Button
-                width={'50%'}
-                buttonStyle={'primary'}
-                disabled={nacObservationsResult.isFetchingNextPage || nwacObservationsResult.isFetchingNextPage}
-                busy={nacObservationsResult.isFetchingNextPage || nwacObservationsResult.isFetchingNextPage}
-                onPress={() => {
-                  void nwacObservationsResult.fetchNextPage();
-                  void nacObservationsResult.fetchNextPage();
-                }}>
-                <BodyBlack>Load more...</BodyBlack>
-              </Button>
-            </HStack>
-          ) : null
-        }
+        ListFooterComponent={() => {
+          if (!nacObservationsResult.hasNextPage && !nwacObservationsResult.hasNextPage) {
+            return (
+              <Center height={80}>
+                <Body>
+                  {/* this is super-sketchy, need to implement proper string localization/formatting */}
+                  {displayedObservations.length} observation{displayedObservations.length > 1 ? 's' : ''} in selected time period
+                </Body>
+              </Center>
+            );
+          } else if (nacObservationsResult.isFetchingNextPage || nwacObservationsResult.isFetchingNextPage) {
+            return (
+              <Center height={80}>
+                <ActivityIndicator size={'large'} color={colorLookup('textColor')} />
+              </Center>
+            );
+          } else {
+            return null;
+          }
+        }}
         ListEmptyComponent={<NotFound inline terminal what={[new NotFoundError('no observations found', 'any matching observations')]} />}
         style={{backgroundColor: colorLookup('background.base'), width: '100%', height: '100%'}}
         refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={void refresh} />}

--- a/components/screens/MenuScreen.tsx
+++ b/components/screens/MenuScreen.tsx
@@ -23,6 +23,7 @@ import * as Updates from 'expo-updates';
 import * as WebBrowser from 'expo-web-browser';
 
 import {QueryCache} from '@tanstack/react-query';
+import {QUERY_CACHE_ASYNC_STORAGE_KEY} from 'App';
 import {ClientContext} from 'clientContext';
 import {AvalancheCenters} from 'components/avalancheCenterList';
 import {ActionList} from 'components/content/ActionList';
@@ -221,7 +222,7 @@ export const MenuScreen = (queryCache: QueryCache, avalancheCenterId: AvalancheC
                           buttonStyle="normal"
                           onPress={() => {
                             void (async () => {
-                              await AsyncStorage.clear();
+                              await AsyncStorage.removeItem(QUERY_CACHE_ASYNC_STORAGE_KEY);
                               queryCache.clear();
                               await clearUploadCache();
                             })();

--- a/hooks/useNWACObservations.ts
+++ b/hooks/useNWACObservations.ts
@@ -7,32 +7,45 @@ import * as Sentry from 'sentry-expo';
 
 import {Logger} from 'browser-bunyan';
 import {ClientContext, ClientProps} from 'clientContext';
-import {formatDistanceToNowStrict, sub} from 'date-fns';
+import {add, formatDistanceToNowStrict} from 'date-fns';
 import {safeFetch} from 'hooks/fetch';
+import {DEFAULT_OBSERVATIONS_WINDOW} from 'hooks/useObservations';
 import {LoggerContext, LoggerProps} from 'loggerContext';
 import {AvalancheCenterID, nwacObservationsListSchema, ObservationFragment} from 'types/nationalAvalancheCenter';
-import {formatRequestedTime, parseRequestedTimeString, RequestedTime, requestedTimeToUTCDate, toDateTimeInterfaceATOM} from 'utils/date';
+import {formatRequestedTime, RequestedTime, requestedTimeToUTCDate, toDateTimeInterfaceATOM} from 'utils/date';
 import {ZodError} from 'zod';
 
-export const useNWACObservations = (center_id: AvalancheCenterID, endDate: RequestedTime) => {
+const DEFAULT_PAGE_SIZE = 50;
+
+export const useNWACObservations = (center_id: AvalancheCenterID, endDate: RequestedTime, window: Duration = DEFAULT_OBSERVATIONS_WINDOW) => {
   const {nwacHost} = React.useContext<ClientProps>(ClientContext);
   const {logger} = React.useContext<LoggerProps>(LoggerContext);
+  // We key on end date, but not window - window merely controls how far we'll fetch backwards
   const key = queryKey(nwacHost, center_id, endDate);
+  const windowStart: Date = add(requestedTimeToUTCDate(endDate), window);
   const thisLogger = logger.child({query: key});
   thisLogger.debug('initiating query');
   const fetchNWACObservationsPage = async (props: {pageParam?: unknown}): Promise<ObservationsQueryWithMeta> => {
     // On the first page, pageParam comes in as null - *not* undefined
-    // Subsequent pages come in as strings that are set by us in getNextPageParam
-    const pageParam = typeof props.pageParam === 'string' ? props.pageParam : formatRequestedTime(endDate);
-    const pageEndDate: Date = requestedTimeToUTCDate(parseRequestedTimeString(pageParam));
-    const pageStartDate = sub(pageEndDate, {weeks: 2});
-    return fetchNWACObservations(nwacHost, center_id, pageStartDate, pageEndDate, thisLogger);
+    // Subsequent pages come in as numbers that are set by us in getNextPageParam
+    const offset = typeof props.pageParam === 'number' ? props.pageParam : 0;
+    const limit = DEFAULT_PAGE_SIZE;
+    thisLogger.debug('fetching NWAC page', offset, limit, windowStart, requestedTimeToUTCDate(endDate));
+    return fetchNWACObservations(nwacHost, center_id, windowStart, requestedTimeToUTCDate(endDate), offset, limit, thisLogger);
   };
 
   return useInfiniteQuery<ObservationsQueryWithMeta, AxiosError | ZodError>({
     queryKey: key,
     queryFn: fetchNWACObservationsPage,
-    getNextPageParam: lastPage => lastPage.published_after,
+    getNextPageParam: (lastPage: ObservationsQueryWithMeta) => {
+      thisLogger.debug('nwac getNextPageParam', key, JSON.stringify(lastPage.meta, null, 2));
+      if (lastPage.meta.next) {
+        return lastPage.meta.offset + lastPage.meta.limit;
+      } else {
+        thisLogger.debug('nwac getNextPageParam', 'no more data available in window!', key, lastPage.meta, windowStart, window);
+        return undefined;
+      }
+    },
     staleTime: 60 * 60 * 1000, // re-fetch in the background once an hour (in milliseconds)
     cacheTime: 24 * 60 * 60 * 1000, // hold on to this cached data for a day (in milliseconds)
   });
@@ -67,7 +80,7 @@ export const prefetchNWACObservations = async (
     queryFn: async () => {
       const start = new Date();
       logger.trace(`prefetching`);
-      const result = fetchNWACObservations(nwacHost, center_id, published_after, published_before, thisLogger);
+      const result = fetchNWACObservations(nwacHost, center_id, published_after, published_before, 0, DEFAULT_PAGE_SIZE, thisLogger);
       thisLogger.trace({duration: formatDistanceToNowStrict(start)}, `finished prefetching`);
       return result;
     },
@@ -78,6 +91,11 @@ interface ObservationsQueryWithMeta {
   data: ObservationFragment[];
   published_before: string;
   published_after: string;
+  meta: {
+    limit: number;
+    offset: number;
+    next: string | null;
+  };
 }
 
 export const fetchNWACObservations = async (
@@ -85,6 +103,8 @@ export const fetchNWACObservations = async (
   center_id: AvalancheCenterID,
   published_after: Date,
   published_before: Date,
+  offset: number,
+  limit: number,
   logger: Logger,
 ): Promise<ObservationsQueryWithMeta> => {
   if (center_id !== 'NWAC') {
@@ -92,15 +112,23 @@ export const fetchNWACObservations = async (
       published_after: formatRequestedTime(published_after),
       published_before: formatRequestedTime(published_before),
       data: [],
+      meta: {
+        limit: limit,
+        offset: offset,
+        next: null,
+      },
     };
   }
   const url = `${nwacHost}/api/v2/observations`;
   const params = {
     published_after: toDateTimeInterfaceATOM(published_after),
     published_before: toDateTimeInterfaceATOM(published_before),
+    limit: limit,
+    offset: offset,
   };
   const what = 'NWAC observations';
   const thisLogger = logger.child({url: url, params: params, what: what});
+  thisLogger.debug('fetchNWACObservations', published_after, published_before, offset, limit);
   const data = await safeFetch(
     () =>
       axios.get<AxiosResponse<unknown>>(url, {
@@ -121,6 +149,7 @@ export const fetchNWACObservations = async (
     });
     throw parseResult.error;
   } else {
+    thisLogger.debug('fetchNWACObservations complete', published_after, published_before, parseResult.data.objects.length, parseResult.data.meta);
     return {
       published_after: formatRequestedTime(published_after),
       published_before: formatRequestedTime(published_before),
@@ -135,6 +164,11 @@ export const fetchNWACObservations = async (
         locationPoint: object.content.location_point,
         media: object.content.media ?? [],
       })),
+      meta: {
+        limit: limit,
+        offset: offset,
+        next: parseResult.data.meta.next || null,
+      },
     };
   }
 };

--- a/hooks/useObservations.ts
+++ b/hooks/useObservations.ts
@@ -410,3 +410,5 @@ export const useObservationsQuery = <TData = ObservationsQuery, TError = unknown
     useFetch<ObservationsQuery, ObservationsQueryVariables>(ObservationsDocument).bind(null, variables),
     options,
   );
+
+export const DEFAULT_OBSERVATIONS_WINDOW: Duration = {weeks: -2};

--- a/network/prefetchAllActiveForecasts.ts
+++ b/network/prefetchAllActiveForecasts.ts
@@ -5,7 +5,7 @@ import {preloadAvalancheCenterLogo} from 'components/AvalancheCenterLogo';
 import {preloadAvalancheDangerIcons} from 'components/AvalancheDangerIcon';
 import {preloadAvalancheProblemIcons} from 'components/AvalancheProblemIcon';
 import {images} from 'components/content/carousel';
-import {sub} from 'date-fns';
+import {add} from 'date-fns';
 import AvalancheCenterCapabilitiesQuery from 'hooks/useAvalancheCenterCapabilities';
 import AvalancheCenterMetadataQuery from 'hooks/useAvalancheCenterMetadata';
 import AvalancheForecastQuery from 'hooks/useAvalancheForecast';
@@ -15,6 +15,7 @@ import AvalancheCenterMapLayerQuery from 'hooks/useMapLayer';
 import NACObservationsQuery from 'hooks/useNACObservations';
 import NWACObservationsQuery from 'hooks/useNWACObservations';
 import NWACWeatherForecastQuery from 'hooks/useNWACWeatherForecast';
+import {DEFAULT_OBSERVATIONS_WINDOW} from 'hooks/useObservations';
 import SynopsisQuery from 'hooks/useSynopsis';
 import WeatherForecastQuery from 'hooks/useWeatherForecast';
 import WeatherStationsQuery from 'hooks/useWeatherStationsMetadata';
@@ -56,7 +57,7 @@ export const prefetchAllActiveForecasts = async (
   }
 
   const endDate: Date = currentDateTime;
-  const startDate = sub(endDate, {weeks: 2});
+  const startDate = add(endDate, DEFAULT_OBSERVATIONS_WINDOW);
   if (center_id === 'NWAC') {
     void NWACObservationsQuery.prefetch(queryClient, nwacHost, center_id, startDate, endDate, logger);
   }

--- a/theme/colors.ts
+++ b/theme/colors.ts
@@ -29,6 +29,7 @@ export const COLORS: Record<string, ColorValue> = {
   // UI
   blue1: rgbaToHexString('rgba(24, 144, 255, 1)'),
   blue2: rgbaToHexString('rgba(0, 80, 179, 1)'),
+  blue2Background: rgbaToHexString('rgba(0, 80, 179, 0.2)'),
   blue3: rgbaToHexString('rgba(0, 58, 140, 1)'),
   'NWAC-dark': rgbaToHexString('rgba(20, 45, 86, 1)'),
   'NWAC-light': rgbaToHexString('rgba(160, 204, 216, 1)'),


### PR DESCRIPTION
Big change: infinite scroll working with the observations list. This works with both NAC and NWAC. There is an unfortunate interaction with the date filtering option that I haven't completely figured out how to handle. @stevekuznetsov I'll tag you in a comment next to the thing to figure out.

Two additional small changes: 
- add a background tint to the pressed state of normal buttons, so you can tell when you've pressed them
- make "Reset the query cache" more selective, fixing #325 

Obligatory movie:

https://github.com/stevekuznetsov/avalanche-forecast/assets/101196/9c6753f9-2e2e-4eb9-b97a-41f2a1c3cb4c

