### PR TITLE
Fix layout problems at startup

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useState} from 'react';
+import React, {useCallback, useEffect} from 'react';
 
 import {
   Lato_100Thin,
@@ -54,7 +54,6 @@ require('date-time-format-timezone');
 
 import axios, {AxiosRequestConfig} from 'axios';
 import {createLogger, stdSerializers} from 'browser-bunyan';
-import {AvalancheCenterSelectionModal} from 'components/modals/AvalancheCenterSelectionModal';
 import {QUERY_CACHE_ASYNC_STORAGE_KEY} from 'data/asyncStorageKeys';
 import * as FileSystem from 'expo-file-system';
 import {ConsoleFormattedStream} from 'logging/consoleFormattedStream';
@@ -290,17 +289,13 @@ const BaseApp: React.FunctionComponent<{
     logger.error({error: error}, 'error loading fonts');
   }
 
-  const [splashScreenVisible, setSplashScreenVisible] = useState(true);
   const navigationRef = useNavigationContainerRef();
 
   const onLayoutRootView = useCallback(async () => {
     // This callback won't execute until fontsLoaded is true, because
     // otherwise we won't render the view that triggers this callback
     await SplashScreen.hideAsync();
-    setSplashScreenVisible(false);
-  }, [setSplashScreenVisible]);
-
-  const showAvalancheCenterSelectionModal = !splashScreenVisible && !preferences.hasSeenCenterPicker;
+  }, []);
 
   if (!fontsLoaded) {
     // The splash screen keeps rendering while fonts are loading
@@ -321,19 +316,6 @@ const BaseApp: React.FunctionComponent<{
                       void onLayoutRootView();
                     }}
                     style={StyleSheet.absoluteFill}>
-                    <AvalancheCenterSelectionModal
-                      visible={showAvalancheCenterSelectionModal}
-                      initialSelection={preferences.center}
-                      onClose={center => {
-                        setPreferences({center: center, hasSeenCenterPicker: true});
-                        // We need to clear navigation state to force all screens from the
-                        // previous avalanche center selection to unmount
-                        navigationRef.reset({
-                          index: 0,
-                          routes: [{name: 'Home'}],
-                        });
-                      }}
-                    />
                     <TabNavigator.Navigator
                       initialRouteName="Home"
                       screenOptions={({route}) => ({

--- a/components/modals/AvalancheCenterSelectionModal.tsx
+++ b/components/modals/AvalancheCenterSelectionModal.tsx
@@ -27,10 +27,7 @@ export const AvalancheCenterSelectionModal: React.FC<AvalancheCenterSelectionMod
   const capabilitiesResult = useAvalancheCenterCapabilities();
   const capabilities = capabilitiesResult.data;
   const metadataResults = useAllAvalancheCenterMetadata(capabilities);
-  if (incompleteQueryState(capabilitiesResult, ...metadataResults) || !capabilities) {
-    return <QueryState results={[capabilitiesResult, ...metadataResults]} />;
-  }
-
+  const loading = incompleteQueryState(capabilitiesResult, ...metadataResults) || !capabilities;
   const metadata: AvalancheCenter[] = [];
   for (const result of metadataResults) {
     if (result.data) {
@@ -41,22 +38,30 @@ export const AvalancheCenterSelectionModal: React.FC<AvalancheCenterSelectionMod
   return (
     <Modal transparent visible={visible} animationType="slide" onRequestClose={closeHandler}>
       <SafeAreaProvider>
-        <SafeAreaView style={{backgroundColor: 'rgba(0, 0, 0, 0.2)'}}>
+        <SafeAreaView style={{backgroundColor: loading ? undefined : 'rgba(0, 0, 0, 0.2)'}}>
           <Center width="100%" height="100%" px={48}>
-            <VStack alignItems="stretch" bg="white" borderRadius={16} px={12} py={24} space={8} width="100%" position="relative" overflow="hidden">
-              <Center mb={4}>
-                <Title3Semibold>Welcome! Let’s Get Started</Title3Semibold>
-              </Center>
-              <Body>Select your local avalanche center to start using the app. You can change this anytime in settings.</Body>
-              <AvalancheCenterList selectedCenter={selectedCenter} setSelectedCenter={setSelectedCenter} data={avalancheCenterList(AvalancheCenters.SupportedCenters, metadata)} />
-              <Button onPress={closeHandler} alignSelf="stretch" buttonStyle="primary" mt={16}>
-                <BodyBlack>Continue</BodyBlack>
-              </Button>
-              {/* placeholder view to create space for the topo illustration */}
-              <View height={200} />
-              {/* these magic numbers are yanked out of Figma */}
-              <Topo width={887.0152587890625} height={456.3430480957031} style={{position: 'absolute', left: -364, top: 382}} />
-            </VStack>
+            {loading ? (
+              <QueryState results={[capabilitiesResult, ...metadataResults]} />
+            ) : (
+              <VStack alignItems="stretch" bg="white" borderRadius={16} px={12} py={24} space={8} width="100%" position="relative" overflow="hidden">
+                <Center mb={4}>
+                  <Title3Semibold>Welcome! Let’s Get Started</Title3Semibold>
+                </Center>
+                <Body>Select your local avalanche center to start using the app. You can change this anytime in settings.</Body>
+                <AvalancheCenterList
+                  selectedCenter={selectedCenter}
+                  setSelectedCenter={setSelectedCenter}
+                  data={avalancheCenterList(AvalancheCenters.SupportedCenters, metadata)}
+                />
+                <Button onPress={closeHandler} alignSelf="stretch" buttonStyle="primary" mt={16}>
+                  <BodyBlack>Continue</BodyBlack>
+                </Button>
+                {/* placeholder view to create space for the topo illustration */}
+                <View height={200} />
+                {/* these magic numbers are yanked out of Figma */}
+                <Topo width={887.0152587890625} height={456.3430480957031} style={{position: 'absolute', left: -364, top: 382}} />
+              </VStack>
+            )}
           </Center>
         </SafeAreaView>
       </SafeAreaProvider>


### PR DESCRIPTION
before | after
--- | ---
<img src="https://github.com/stevekuznetsov/avalanche-forecast/assets/101196/0492c00f-fbfb-458f-9fc6-9dcd40522f2c" height="800px"> | <img src="https://github.com/stevekuznetsov/avalanche-forecast/assets/101196/be8a5b42-8527-44ea-b9dd-1440ec3d52cd" height="800px">

there were a few things going on here!
- the avalanche center selection dialog was rendering a `QueryState` even when it wasn't supposed to be visible 🙈 
- the dialog had a chance to render before the map view was ready
