### PR TITLE
Set up some useful env variables

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,38 @@
+#
+# Instructions:
+# 1) make a copy of this file in .env
+# 2) fill in required values
+# 3) uncomment the values you want to override
+
+#
+# This is required for builds to be able to upload sourcemaps to Sentry
+#
+SENTRY_AUTH_TOKEN=
+
+#
+# This is embedded in the app via app.config.ts. Must be present at runtime to send Sentry events.
+#
+SENTRY_DSN=
+
+#
+# These are embedded in the app via app.config.ts. Must be present to use maps. Not required for Expo Go.
+#
+ANDROID_GOOGLE_MAPS_API_KEY=
+IOS_GOOGLE_MAPS_API_KEY=
+
+#
+# Set this to a value to enable Sentry in development mode. Off by default.
+#
+# EXPO_PUBLIC_SENTRY_IN_DEV=1
+
+#
+# Set this to prevent warnings and errors from popping up onscreen. Useful when running in
+# the summer and you don't want to see messages about missing forecasts.
+#
+# EXPO_PUBLIC_DISABLE_LOGBOX=1
+
+#
+# Set this to change the startup date for the app. The default is 'latest'. 2/20/2023 is a
+# good date for NWAC.
+#
+# EXPO_PUBLIC_DATE='2023-02-20'

--- a/App.tsx
+++ b/App.tsx
@@ -122,7 +122,7 @@ if (Sentry?.init) {
   } else {
     Sentry.init({
       dsn,
-      enableInExpoDevelopment: false,
+      enableInExpoDevelopment: Boolean(process.env.EXPO_PUBLIC_SENTRY_IN_DEV),
       enableWatchdogTerminationTracking: true,
     });
   }
@@ -223,7 +223,7 @@ const App = () => {
 
 const AppWithClientContext = () => {
   const [staging, setStaging] = React.useState(false);
-  const [requestedTime, setRequestedTime] = React.useState<RequestedTime>('latest');
+  const [requestedTime, setRequestedTime] = React.useState<RequestedTime>(process.env.EXPO_PUBLIC_DATE ? new Date(process.env.EXPO_PUBLIC_DATE) : 'latest');
 
   const contextValue = {
     ...(staging ? stagingHosts : productionHosts),

--- a/App.tsx
+++ b/App.tsx
@@ -119,8 +119,6 @@ if (Sentry?.init) {
   // Only initialize Sentry if we can find the correct env setup
   if (dsn === 'LOADED_FROM_ENVIRONMENT') {
     logger.warn('Sentry integration not configured, check your environment');
-  } else if (!process.env.SENTRY_AUTH_TOKEN) {
-    logger.warn('SENTRY_AUTH_TOKEN is not defined in the environment, Sentry not available');
   } else {
     Sentry.init({
       dsn,

--- a/app.json
+++ b/app.json
@@ -49,7 +49,8 @@
           "file": "sentry-expo/upload-sourcemaps",
           "config": {
             "organization": "nwac",
-            "project": "mobile-app"
+            "project": "mobile-app",
+            "setCommits": true
           }
         }
       ]

--- a/components/screens/MenuScreen.tsx
+++ b/components/screens/MenuScreen.tsx
@@ -241,9 +241,6 @@ export const MenuScreen = (queryCache: QueryCache, avalancheCenterId: AvalancheC
                     <Card borderRadius={0} borderColor="white" header={<BodyBlack>Sentry</BodyBlack>}>
                       <VStack space={4}>
                         <Body>Config</Body>
-                        <BodySm fontFamily={Platform.select({ios: 'Courier New', android: 'monospace'})} color={colorLookup(process.env.SENTRY_AUTH_TOKEN ? 'text' : 'red')}>
-                          SENTRY_AUTH_TOKEN: {process.env.SENTRY_AUTH_TOKEN ? `${process.env.SENTRY_AUTH_TOKEN.slice(0, 15)}...` : 'missing'}
-                        </BodySm>
                         {(() => {
                           const dsn = Constants.expoConfig?.extra?.sentry_dsn as string | undefined;
                           return (

--- a/logger.ts
+++ b/logger.ts
@@ -1,4 +1,5 @@
 import * as FileSystem from 'expo-file-system';
+import {LogBox} from 'react-native';
 
 // react-native-logs always logs to FS.documentDirectory
 const LOG_PATH = 'log.txt';
@@ -9,4 +10,8 @@ if (process.env.NODE_ENV !== 'test') {
   void (async () => {
     await FileSystem.deleteAsync(logFilePath, {idempotent: true});
   })();
+}
+
+if (process.env.EXPO_PUBLIC_DISABLE_LOGBOX) {
+  LogBox.ignoreAllLogs(true);
 }


### PR DESCRIPTION
Take advantage of new Expo behavior to (1) automatically load `.env` files and (2) automatically make environment variables starting with `EXPO_PUBLIC_` available in the app. Added these variables:

variable | what it does
--- | ---
`EXPO_PUBLIC_SENTRY_IN_DEV` | enable Sentry in development mode
`EXPO_PUBLIC_DISABLE_LOGBOX` | prevent warnings and errors from popping up onscreen
`EXPO_PUBLIC_DATE` | pick a date other than 'latest' to start the app with

There's a sample `.env.local` file that shows how this all works.